### PR TITLE
CC-4: Add conversation log parsing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .scala-build/
 .metals/
 .mcp.json
+project-management/issues/CC-4/batch-implement.log

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,10 +116,89 @@ Represents structured content within assistant messages:
 sealed trait ContentBlock
 ├── TextBlock(text: String)
 ├── ToolUseBlock(id, name, input)
-└── ToolResultBlock(toolUseId, content, isError)
+├── ToolResultBlock(toolUseId, content, isError)
+├── ThinkingBlock(thinking, signature)
+└── RedactedThinkingBlock(data)
 ```
 
 **Design Note**: These types are **deliberately simplified** compared to the full TypeScript SDK, hiding session IDs and internal complexity to provide a clean user experience.
+
+## Conversation Log Parsing
+
+The SDK can read and parse Claude Code conversation log files (`.jsonl` files written by the Claude Code CLI). This subsystem follows the same functional core / dual-implementation pattern used by the query API.
+
+### Log File Format
+
+Claude Code writes conversation history as JSONL files, one JSON object per line. Each line is an envelope containing:
+- Common metadata: `uuid`, `parentUuid`, `sessionId`, `timestamp`, `isSidechain`, `cwd`, `version`
+- A `type` field that distinguishes the payload kind
+- Type-specific payload fields
+
+### Domain Model
+
+**Location**: `works.iterative.claude.core.log.model`
+
+```scala
+// Envelope type — one per JSONL line
+case class ConversationLogEntry(
+  uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version,
+  payload: LogEntryPayload
+)
+
+// Payload hierarchy
+sealed trait LogEntryPayload
+├── UserLogEntry(content: List[ContentBlock])
+├── AssistantLogEntry(content, model, usage, requestId)
+├── SystemLogEntry(subtype, data)
+├── ProgressLogEntry(data, parentToolUseId)
+├── QueueOperationLogEntry(operation, content)
+├── FileHistorySnapshotLogEntry(data)
+├── LastPromptLogEntry(data)
+└── RawLogEntry(entryType, json)   // fallback for unknown types
+
+case class TokenUsage(inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens, serviceTier)
+case class LogFileMetadata(path, sessionId, summary, lastModified, fileSize, cwd, gitBranch, createdAt)
+```
+
+### Parsing Layer
+
+**ContentBlockParser** (`works.iterative.claude.core.parsing`): Pure function that decodes a circe `Json` value into a `ContentBlock`. Handles all five variants including `ThinkingBlock` and `RedactedThinkingBlock`.
+
+**ConversationLogParser** (`works.iterative.claude.core.log.parsing`): Pure function that decodes a single JSONL line string into an `Option[ConversationLogEntry]`. Returns `None` for blank lines or unrecognised JSON; unknown entry types are wrapped in `RawLogEntry` rather than discarded.
+
+### Service Layer
+
+Two parameterised traits provide the public contract:
+
+```scala
+trait ConversationLogIndex[F[_]]:
+  def listSessions(projectPath: os.Path): F[Seq[LogFileMetadata]]
+  def forSession(projectPath: os.Path, sessionId: String): F[Option[LogFileMetadata]]
+
+trait ConversationLogReader[F[_]]:
+  type EntryStream
+  def readAll(path: os.Path): F[List[ConversationLogEntry]]
+  def stream(path: os.Path): EntryStream
+```
+
+The `F[_]` parameter is instantiated as the identity functor (`[A] =>> A`) for direct-style callers and as `IO` for effectful callers.
+
+### Implementations
+
+| Implementation | Module | Effect | Stream type |
+|---|---|---|---|
+| `DirectConversationLogIndex` | `direct.log` | identity | — |
+| `DirectConversationLogReader` | `direct.log` | identity | `ox.flow.Flow[ConversationLogEntry]` |
+| `EffectfulConversationLogIndex` | `effectful.log` | `cats.effect.IO` | — |
+| `EffectfulConversationLogReader` | `effectful.log` | `cats.effect.IO` | `fs2.Stream[IO, ConversationLogEntry]` |
+
+### ProjectPathDecoder
+
+**Location**: `works.iterative.claude.core.log.ProjectPathDecoder`
+
+A pure utility that converts Claude's path-encoded project directory names back to filesystem path strings. Claude encodes an absolute path by replacing each `/` separator with `-`, so `/home/user/project` becomes `-home-user-project`. `ProjectPathDecoder.decode` reverses this transformation.
+
+Note: The decoding is ambiguous when original path segments contain `-` characters; callers should validate the result against the filesystem.
 
 ## Internal CLI Management Layer
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,120 @@ val program = for {
 // Resources are automatically cleaned up via fs2's Resource management
 ```
 
+## Conversation Log Parsing
+
+The SDK can read and parse the JSONL conversation logs that Claude Code writes to disk. Log files are stored under `~/.claude/projects/` in directories named after the project path.
+
+### Listing Sessions (Direct API)
+
+```scala
+import works.iterative.claude.direct.*
+
+val logDir = os.Path("/home/user/.claude/projects") / ProjectPathDecoder.decode("-home-user-myproject")
+
+val index = DirectConversationLogIndex()
+val sessions: Seq[LogFileMetadata] = index.listSessions(logDir)
+
+sessions.foreach { meta =>
+  println(s"Session ${meta.sessionId}, last modified ${meta.lastModified}")
+  meta.summary.foreach(s => println(s"  Summary: $s"))
+}
+```
+
+### Reading Log Entries (Direct API)
+
+```scala
+import works.iterative.claude.direct.*
+
+val reader = DirectConversationLogReader()
+val meta = DirectConversationLogIndex().listSessions(logDir).head
+
+// Load all entries at once
+val entries: List[ConversationLogEntry] = reader.readAll(meta.path)
+
+entries.foreach { entry =>
+  entry.payload match
+    case UserLogEntry(content) =>
+      content.collect { case TextBlock(text) => println(s"User: $text") }
+    case AssistantLogEntry(content, model, usage, _) =>
+      content.collect { case TextBlock(text) => println(s"Assistant: $text") }
+      usage.foreach(u => println(s"  Tokens: ${u.inputTokens} in / ${u.outputTokens} out"))
+    case _ =>
+}
+```
+
+### Accessing Thinking Blocks
+
+```scala
+import works.iterative.claude.direct.*
+
+val entries = DirectConversationLogReader().readAll(path)
+entries.foreach { entry =>
+  entry.payload match
+    case AssistantLogEntry(content, _, _, _) =>
+      content.foreach {
+        case ThinkingBlock(thoughts, _) => println(s"Thinking: $thoughts")
+        case RedactedThinkingBlock(_)   => println("(redacted thinking)")
+        case TextBlock(text)            => println(s"Response: $text")
+        case _                          =>
+      }
+    case _ =>
+}
+```
+
+### Streaming Log Entries (Direct API)
+
+```scala
+import works.iterative.claude.direct.*
+import ox.*
+
+supervised {
+  val reader = DirectConversationLogReader()
+  reader.stream(path).runForeach { entry =>
+    println(s"[${entry.timestamp}] ${entry.payload.getClass.getSimpleName}")
+  }
+}
+```
+
+### Listing and Reading Sessions (Effectful API)
+
+```scala
+import works.iterative.claude.effectful.*
+import cats.effect.*
+
+object LogExample extends IOApp.Simple:
+  def run =
+    val logDir = os.Path("/home/user/.claude/projects") /
+      ProjectPathDecoder.decode("-home-user-myproject")
+
+    val index  = EffectfulConversationLogIndex()
+    val reader = EffectfulConversationLogReader()
+
+    for
+      sessions <- index.listSessions(logDir)
+      _        <- IO.println(s"Found ${sessions.size} sessions")
+      entries  <- reader.readAll(sessions.head.path)
+      _        <- IO.println(s"Loaded ${entries.size} entries")
+    yield ()
+```
+
+### Streaming Log Entries (Effectful API)
+
+```scala
+import works.iterative.claude.effectful.*
+import cats.effect.*
+import fs2.Stream
+
+val reader = EffectfulConversationLogReader()
+
+val program: IO[Unit] =
+  reader.stream(path)
+    .collect { case entry if entry.payload.isInstanceOf[AssistantLogEntry] => entry }
+    .evalMap(entry => IO.println(s"Assistant turn: ${entry.uuid}"))
+    .compile
+    .drain
+```
+
 ## Architecture
 
 The SDK is built on:

--- a/project-management/issues/CC-4/analysis.md
+++ b/project-management/issues/CC-4/analysis.md
@@ -143,106 +143,57 @@ Both `direct.package` and `effectful.package` (or equivalent re-export objects) 
 
 ## Technical Risks & Uncertainties
 
-### CLARIFY: Log entry type exhaustiveness
+### RESOLVED: Log entry type exhaustiveness
 
-The issue lists 7 entry types. Real log files show at least these, but the format is undocumented and may contain additional types in newer Claude Code versions.
+**Decision:** Option B — Capture unknown types as `RawLogEntry(entryType: String, json: Json)`.
 
-**Questions to answer:**
-1. Should unknown entry types be silently skipped, or captured as a generic/raw entry?
-2. Do we need to handle forward compatibility (new fields on known types)?
-
-**Options:**
-- **Option A**: Skip unknown types silently (simplest, matches existing JsonParser behavior for unknown message types)
-- **Option B**: Capture unknown types as a generic `RawLogEntry(type: String, json: Json)` (preserves data, allows downstream handling)
-- **Option C**: Fail on unknown types (strictest, least resilient)
-
-**Impact:** Determines whether tools built on this SDK will break or degrade gracefully when Claude Code adds new entry types.
+The format is undocumented and will evolve. Silently dropping data means consumers can't detect they're missing something. A `RawLogEntry` is cheap to implement and gives downstream code a way to handle new types without SDK updates.
 
 ---
 
-### CLARIFY: User message content representation
+### RESOLVED: User message content representation
 
-In the stream-json format, user messages have `content: String`. In log files, user messages have `message.content` which can be either a string OR an array of content blocks (e.g., `tool_result` blocks). The existing `UserMessage(content: String)` cannot represent this.
+**Decision:** Option A — `UserLogEntry` uses `List[ContentBlock]` for content, separate from `UserMessage(String)`.
 
-**Questions to answer:**
-1. Should `UserLogEntry` use a separate content type, or should we modify `UserMessage`?
-2. If separate, how much structure do we expose for user message content blocks?
-
-**Options:**
-- **Option A**: `UserLogEntry` uses `List[ContentBlock]` for content — different from `UserMessage(String)` but accurately represents the log format
-- **Option B**: `UserLogEntry` wraps `UserMessage` and adds metadata — forces string-only content, losing tool_result structure
-- **Option C**: Modify `UserMessage` to support both string and block content — backward incompatible
-
-**Impact:** Affects how accurately we represent user messages and whether tool result content in user messages is accessible.
+Log types are a separate hierarchy (see next decision). User messages in logs genuinely contain content block arrays (including `tool_result` blocks), so `UserLogEntry` should faithfully represent the log format.
 
 ---
 
-### CLARIFY: Relationship between log types and existing Message types
+### RESOLVED: Relationship between log types and existing Message types
 
-Log entries carry much richer data than stream-json messages. The question is whether log-specific message types should extend `Message` or be entirely separate.
+**Decision:** Option A — Entirely separate type hierarchies.
 
-**Questions to answer:**
-1. Should `AssistantLogEntry` extend `AssistantMessage`, or be independent?
-2. Do consumers need to treat log entries and stream messages polymorphically?
+Investigation of the TypeScript Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) confirms this approach. The TS SDK defines `SDKMessage` (a 23+ variant union) for stream output and a separate `SessionMessage` type for JSONL log reading. `SessionMessage` has `message: unknown` — they don't even try to share types between stream and log formats. `getSessionMessages()` returns `SessionMessage[]`, while `query()` yields `SDKMessage`. The two concerns are fully decoupled.
 
-**Options:**
-- **Option A**: Entirely separate type hierarchies — cleanest separation, no coupling, but no polymorphism
-- **Option B**: Log entry payloads extend existing Message types — enables polymorphism, but adds metadata fields to Message trait
-- **Option C**: Log entry payloads contain existing Message types (composition) — `AssistantLogEntry` has-a `AssistantMessage` plus additional metadata
-
-**Impact:** Affects API ergonomics and whether code written for stream messages can work with log data.
+Our Scala SDK can be richer than the TS SDK by actually typing the log message payloads (they leave it as `unknown`), but the type hierarchy separation is the same. Shared parts are at the `ContentBlock` level (reused by both hierarchies), not at the `Message` level.
 
 ---
 
-### CLARIFY: Log file discovery heuristics
+### RESOLVED: Log file discovery heuristics
 
-The `~/.claude/projects/` directory structure uses path-encoded directory names (e.g., `-home-mph-Devel` for `/home/mph/Devel`). Session IDs appear to match JSONL filenames.
+**Decision:** Option B — Full discovery with path decoding.
 
-**Questions to answer:**
-1. Should the index only list files from a given project directory, or support discovering all projects?
-2. Should we decode the directory name back to a filesystem path?
-3. What metadata should we extract without parsing file contents (filename-based sessionId, file size, modification time)?
+The primary use cases require being able to: (1) list all sessions across all projects, (2) list sessions for a specific project directory, (3) get a specific session by ID searching across projects. This matches the TS SDK's `listSessions({ dir? })` and `getSessionInfo(sessionId, { dir? })` API surface.
 
-**Options:**
-- **Option A**: Simple file listing of a given directory — caller provides the project path
-- **Option B**: Full discovery with path decoding — SDK finds all projects and their logs
-- **Option C**: Start with Option A, add Option B later if needed (YAGNI)
-
-**Impact:** Scope of the index service; Option B is significantly more work.
+The `~/.claude/projects/` directory structure uses path-encoded directory names (e.g., `-home-mph-Devel` for `/home/mph/Devel`). The `ConversationLogIndex` needs to decode these back to filesystem paths, enumerate JSONL files within them, and extract metadata (sessionId from filename, file size, modification time). The TS SDK's `SDKSessionInfo` includes: `sessionId`, `summary`, `lastModified`, `fileSize`, `customTitle`, `firstPrompt`, `gitBranch`, `cwd`, `tag`, `createdAt` — we should aim for comparable metadata in `LogFileMetadata`.
 
 ---
 
-### CLARIFY: ThinkingBlock signature optionality
+### RESOLVED: ThinkingBlock signature optionality
 
-Thinking blocks in log files contain a `signature` field. It is unclear whether this field is always present and non-empty. During streaming or in certain model configurations, thinking blocks may appear without signatures.
+**Decision:** Option A — `ThinkingBlock(thinking: String, signature: String)` with both fields required.
 
-**Questions to answer:**
-1. Should `signature` be `String` (required) or `Option[String]` (optional)?
-2. Should we reject thinking blocks without signatures?
+The official Anthropic API SDK (`@anthropic-ai/sdk`) defines `ThinkingBlock` with both `signature: string` and `thinking: string` as required (non-optional) fields. This is the canonical type for completed thinking blocks.
 
-**Options:**
-- **Option A**: `ThinkingBlock(thinking: String, signature: String)` — strict, assumes signature is always present
-- **Option B**: `ThinkingBlock(thinking: String, signature: Option[String])` — permissive, handles missing signatures
-- **Option C**: Examine real log files to determine whether signatures are always present, then decide
-
-**Impact:** Determines parser strictness and whether some thinking blocks could be silently dropped.
+Additionally, the API defines `RedactedThinkingBlock { data: string, type: 'redacted_thinking' }` for cases where thinking content is hidden for safety reasons. We should add this as a separate `ContentBlock` variant as well.
 
 ---
 
-### CLARIFY: Timestamp handling for log entries
+### RESOLVED: Timestamp handling for log entries
 
-The envelope contains ISO-8601 timestamps. The format is undocumented, so timestamps could be missing, malformed, or in unexpected formats.
+**Decision:** Option B — `timestamp: Option[Instant]`, entries always included.
 
-**Questions to answer:**
-1. Should `timestamp` be `Instant` (required) or `Option[Instant]` (optional)?
-2. Should entries with unparseable timestamps be dropped or included with raw string timestamp?
-
-**Options:**
-- **Option A**: `timestamp: Instant` — required, entries without valid timestamps are skipped
-- **Option B**: `timestamp: Option[Instant]` — optional, entries always included
-- **Option C**: `timestamp: String` — keep raw string, let consumers parse (least information loss)
-
-**Impact:** Determines whether entries could be silently dropped due to timestamp parsing issues.
+The TS SDK marks `timestamp` as optional on `SDKUserMessage` (`timestamp?: string`), confirming it can be absent. Parsing to `Instant` gives consumers typed access, and `Option` ensures entries are never silently dropped due to timestamp issues.
 
 ---
 

--- a/project-management/issues/CC-4/analysis.md
+++ b/project-management/issues/CC-4/analysis.md
@@ -1,0 +1,376 @@
+# Technical Analysis: Add conversation log parsing support
+
+**Issue:** CC-4
+**Created:** 2026-03-24
+**Status:** Draft
+
+## Problem Statement
+
+The SDK currently only parses real-time CLI stream output (`--output-format stream-json`). Claude Code also stores full conversation logs as JSONL files in `~/.claude/projects/`, containing richer data than the streaming format: thinking blocks (with signatures), token usage per message, model information, message threading (uuid/parentUuid), sidechain flags, and various metadata entries (progress, queue operations, file history snapshots).
+
+Thinking blocks are not available through the streaming interface at all, making log parsing the only programmatic way to access this data. External tools that want to analyze past sessions, display thinking content, or compute per-message cost breakdowns have no way to do this through the current SDK.
+
+## Proposed Solution
+
+### High-Level Approach
+
+Add a new `core.log` package containing pure parsing logic for JSONL conversation log files, with corresponding `direct` and `effectful` API surfaces. The log format is fundamentally different from the stream-json format: each JSONL line is a self-contained envelope carrying metadata (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version, etc.) plus a type-specific payload. The parser must handle 7+ entry types rather than the 4 message types in stream-json.
+
+The domain model introduces a `ConversationLogEntry` envelope type that wraps type-specific payloads, plus a new `ThinkingBlock` content block. The existing `ContentBlock` hierarchy is extended. Two new service traits are introduced: `ConversationLogIndex` (list/discover log files) and `ConversationLogReader` (parse a single log file into a stream of typed entries).
+
+### Why This Approach
+
+The conversation log format shares some structure with stream-json (content blocks, message roles) but differs significantly in envelope structure, entry types, and metadata richness. Extending the existing `ContentBlock` with `ThinkingBlock` maximizes reuse while keeping log-specific types (envelope, usage, model metadata) in a separate package. The index/reader split separates discovery concerns from parsing concerns, and both services naturally fit the existing dual-API pattern.
+
+### Package Mapping
+
+The codebase uses `core` (model + parsing), `direct`, and `effectful` — not traditional layered architecture packages. The conceptual layers map to actual packages as follows:
+
+| Conceptual Layer | Actual Package(s) |
+|---|---|
+| Domain (types) | `core.log.model` (new log types), `core.model` (extended `ContentBlock`) |
+| Parsing (pure logic) | `core.log.parsing` (new log parser), `core.parsing` (extended content block parsing) |
+| Service traits | `core.log` (trait definitions for `ConversationLogIndex`, `ConversationLogReader`) |
+| Direct API | `direct.log` (Ox-based implementations of service traits) |
+| Effectful API | `effectful.log` (cats-effect/fs2 implementations of service traits) |
+
+## Architecture Design
+
+**Purpose:** Define WHAT components each layer needs, not HOW they're implemented.
+
+### Domain Layer (`core.log.model` + `core.model`)
+
+**Components:**
+- `ThinkingBlock` — new `ContentBlock` variant for extended thinking content (added to `core.model.ContentBlock`)
+- `ConversationLogEntry` — envelope type carrying common metadata (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, gitBranch, version, userType, entrypoint, slug)
+- `LogEntryPayload` — sealed trait for type-specific payloads:
+  - `UserLogEntry` — user messages with content blocks (not just strings, since log format has tool_result content blocks in user messages)
+  - `AssistantLogEntry` — assistant messages with content blocks, model, usage metadata, requestId
+  - `SystemLogEntry` — system events (subtype + data map, similar to existing SystemMessage)
+  - `ProgressLogEntry` — progress updates (data map, parentToolUseID)
+  - `QueueOperationLogEntry` — queue operations (operation type, content)
+  - `FileHistorySnapshotLogEntry` — file state snapshots
+  - `LastPromptLogEntry` — last prompt markers
+- `TokenUsage` — structured token usage (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, service_tier)
+- `LogFileMetadata` — basic metadata about a log file (path, sessionId, timestamps, size) for the index service
+
+**Responsibilities:**
+- Model the full conversation log structure as immutable types
+- `TokenUsage` provides typed access to token counts rather than `Map[String, Any]`
+
+**Estimated Effort:** 1-3 hours
+**Complexity:** Low — many types but each is a straightforward case class/enum; fixing exhaustiveness warnings is the only non-trivial part
+
+---
+
+### Parsing Layer (`core.log.parsing` + `core.parsing`)
+
+**Components:**
+- `ConversationLogParser` (in `core.log.parsing`) — pure parsing logic for log JSONL lines
+  - `parseLogLine(line: String): Option[ConversationLogEntry]`
+  - `parseLogEntry(json: Json): Option[ConversationLogEntry]`
+  - Content block parsing for thinking blocks
+- Extension of `core.parsing.JsonParser` — add `thinking` case to content block parsing
+
+**Note:** `JsonParser.parseContentBlock` is currently `private`. Two options:
+1. Make it package-private or public so `ConversationLogParser` can reuse it
+2. Extract shared content block parsing into a common utility (e.g., `core.parsing.ContentBlockParser`)
+
+Option 2 is cleaner — it avoids coupling the log parser to the stream-json parser and creates a reusable content block parsing utility that both parsers consume.
+
+**Responsibilities:**
+- Pure JSON-to-type conversion for all log entry types
+- Content block parsing (text, thinking, tool_use, tool_result) shared between stream and log parsers
+- Graceful handling of malformed/unknown entries
+
+**Estimated Effort:** 3-5 hours
+**Complexity:** Moderate — many entry types to handle; the bulk of implementation and testing work
+
+---
+
+### Service Layer (`core.log` traits + `direct.log` + `effectful.log`)
+
+**Components:**
+- `ConversationLogIndex` trait (in `core.log`) — lists available log files with metadata
+  - `list(projectPath: Path): Seq[LogFileMetadata]` — scan a project directory for JSONL files
+  - `forSession(projectPath: Path, sessionId: String): Option[LogFileMetadata]` — find a specific session
+- `ConversationLogReader` trait (in `core.log`) — reads and parses a single log file
+  - `read(path: Path): Stream[ConversationLogEntry]` — returns a stream of parsed entries
+  - `readAll(path: Path): List[ConversationLogEntry]` — convenience for loading entire file
+- Direct implementations (in `direct.log`) — uses os-lib for file I/O, Ox Flow for streaming
+- Effectful implementations (in `effectful.log`) — uses fs2.io.file for file I/O, fs2.Stream for streaming
+
+**Responsibilities:**
+- File I/O for listing and reading JSONL files
+- Line-by-line reading delegating to pure `ConversationLogParser`
+- Extracting basic metadata (sessionId from filename, file size, modification time)
+
+**Estimated Effort:** 3-4 hours
+**Complexity:** Moderate — dual API implementations follow existing patterns but still require writing and testing both
+
+---
+
+### Re-exports
+
+Both `direct.package` and `effectful.package` (or equivalent re-export objects) need to expose the new types: `ThinkingBlock`, log entry types, `ConversationLogIndex`, `ConversationLogReader`.
+
+---
+
+## Technical Decisions
+
+### Patterns
+
+- Extend existing `ContentBlock` sealed trait with `ThinkingBlock` — keeps one content block hierarchy
+- New `ConversationLogEntry` envelope is separate from `Message` — the log format is structurally different (envelope + payload vs. flat message)
+- Extract shared content block parsing into `core.parsing.ContentBlockParser` — avoids coupling between log and stream parsers
+- `ConversationLogIndex` and `ConversationLogReader` as traits in `core.log` with implementations in `direct.log` and `effectful.log`
+
+### Technology Choices
+
+- **Parsing**: circe (already used) for JSON parsing of log lines
+- **File I/O (direct)**: `os-lib` (already a dependency) for file listing and reading
+- **File I/O (effectful)**: `fs2.io.file` (already a dependency) for streaming file reads
+- **Data Storage**: Read-only access to existing JSONL files on disk; no writes
+- **Time parsing**: `java.time.Instant` for ISO-8601 timestamps
+
+### Integration Points
+
+- `core.model.ContentBlock` — extended with `ThinkingBlock`
+- `core.parsing.JsonParser.parseContentBlock` — refactored: shared logic extracted to `ContentBlockParser`, `parseContentBlock` made non-private or replaced
+- `direct.package` and `effectful.package` — re-export new types
+- New `core.log.model` package depends on `core.model` (for `ContentBlock`)
+- New `core.log.parsing` package depends on `core.parsing.ContentBlockParser` (for shared content block parsing)
+
+## Technical Risks & Uncertainties
+
+### CLARIFY: Log entry type exhaustiveness
+
+The issue lists 7 entry types. Real log files show at least these, but the format is undocumented and may contain additional types in newer Claude Code versions.
+
+**Questions to answer:**
+1. Should unknown entry types be silently skipped, or captured as a generic/raw entry?
+2. Do we need to handle forward compatibility (new fields on known types)?
+
+**Options:**
+- **Option A**: Skip unknown types silently (simplest, matches existing JsonParser behavior for unknown message types)
+- **Option B**: Capture unknown types as a generic `RawLogEntry(type: String, json: Json)` (preserves data, allows downstream handling)
+- **Option C**: Fail on unknown types (strictest, least resilient)
+
+**Impact:** Determines whether tools built on this SDK will break or degrade gracefully when Claude Code adds new entry types.
+
+---
+
+### CLARIFY: User message content representation
+
+In the stream-json format, user messages have `content: String`. In log files, user messages have `message.content` which can be either a string OR an array of content blocks (e.g., `tool_result` blocks). The existing `UserMessage(content: String)` cannot represent this.
+
+**Questions to answer:**
+1. Should `UserLogEntry` use a separate content type, or should we modify `UserMessage`?
+2. If separate, how much structure do we expose for user message content blocks?
+
+**Options:**
+- **Option A**: `UserLogEntry` uses `List[ContentBlock]` for content — different from `UserMessage(String)` but accurately represents the log format
+- **Option B**: `UserLogEntry` wraps `UserMessage` and adds metadata — forces string-only content, losing tool_result structure
+- **Option C**: Modify `UserMessage` to support both string and block content — backward incompatible
+
+**Impact:** Affects how accurately we represent user messages and whether tool result content in user messages is accessible.
+
+---
+
+### CLARIFY: Relationship between log types and existing Message types
+
+Log entries carry much richer data than stream-json messages. The question is whether log-specific message types should extend `Message` or be entirely separate.
+
+**Questions to answer:**
+1. Should `AssistantLogEntry` extend `AssistantMessage`, or be independent?
+2. Do consumers need to treat log entries and stream messages polymorphically?
+
+**Options:**
+- **Option A**: Entirely separate type hierarchies — cleanest separation, no coupling, but no polymorphism
+- **Option B**: Log entry payloads extend existing Message types — enables polymorphism, but adds metadata fields to Message trait
+- **Option C**: Log entry payloads contain existing Message types (composition) — `AssistantLogEntry` has-a `AssistantMessage` plus additional metadata
+
+**Impact:** Affects API ergonomics and whether code written for stream messages can work with log data.
+
+---
+
+### CLARIFY: Log file discovery heuristics
+
+The `~/.claude/projects/` directory structure uses path-encoded directory names (e.g., `-home-mph-Devel` for `/home/mph/Devel`). Session IDs appear to match JSONL filenames.
+
+**Questions to answer:**
+1. Should the index only list files from a given project directory, or support discovering all projects?
+2. Should we decode the directory name back to a filesystem path?
+3. What metadata should we extract without parsing file contents (filename-based sessionId, file size, modification time)?
+
+**Options:**
+- **Option A**: Simple file listing of a given directory — caller provides the project path
+- **Option B**: Full discovery with path decoding — SDK finds all projects and their logs
+- **Option C**: Start with Option A, add Option B later if needed (YAGNI)
+
+**Impact:** Scope of the index service; Option B is significantly more work.
+
+---
+
+### CLARIFY: ThinkingBlock signature optionality
+
+Thinking blocks in log files contain a `signature` field. It is unclear whether this field is always present and non-empty. During streaming or in certain model configurations, thinking blocks may appear without signatures.
+
+**Questions to answer:**
+1. Should `signature` be `String` (required) or `Option[String]` (optional)?
+2. Should we reject thinking blocks without signatures?
+
+**Options:**
+- **Option A**: `ThinkingBlock(thinking: String, signature: String)` — strict, assumes signature is always present
+- **Option B**: `ThinkingBlock(thinking: String, signature: Option[String])` — permissive, handles missing signatures
+- **Option C**: Examine real log files to determine whether signatures are always present, then decide
+
+**Impact:** Determines parser strictness and whether some thinking blocks could be silently dropped.
+
+---
+
+### CLARIFY: Timestamp handling for log entries
+
+The envelope contains ISO-8601 timestamps. The format is undocumented, so timestamps could be missing, malformed, or in unexpected formats.
+
+**Questions to answer:**
+1. Should `timestamp` be `Instant` (required) or `Option[Instant]` (optional)?
+2. Should entries with unparseable timestamps be dropped or included with raw string timestamp?
+
+**Options:**
+- **Option A**: `timestamp: Instant` — required, entries without valid timestamps are skipped
+- **Option B**: `timestamp: Option[Instant]` — optional, entries always included
+- **Option C**: `timestamp: String` — keep raw string, let consumers parse (least information loss)
+
+**Impact:** Determines whether entries could be silently dropped due to timestamp parsing issues.
+
+---
+
+## Total Estimates
+
+**Per-Layer Breakdown:**
+- Domain Layer: 1-3 hours
+- Parsing Layer: 3-5 hours
+- Service Layer: 3-4 hours
+
+**Total Range:** 7-12 hours
+
+**Confidence:** Medium
+
+**Reasoning:**
+- The log format is observable from real files but undocumented; surprises are possible
+- The dual-API pattern is well-established, reducing uncertainty for the service layer
+- Many new types to define but each is mechanically straightforward
+- The CLARIFY items around type relationships could shift the design significantly
+
+## Testing Strategy
+
+### Per-Layer Testing
+
+**Domain Layer:**
+- Unit: Verify type construction and field access for all new types
+- Unit: Verify `TokenUsage` correctly represents token count structures
+
+**Parsing Layer:**
+- Unit: `ConversationLogParser.parseLogLine` with representative JSON strings for each entry type
+- Unit: `ConversationLogParser` handling of malformed/unknown entries
+- Unit: `ContentBlockParser` with thinking blocks (and existing block types for regression)
+- Integration: Full parse of real log file samples (complete JSONL files as test resources)
+
+**Service Layer:**
+- Integration: `ConversationLogIndex` listing real JSONL files in temp directories
+- Integration: `ConversationLogReader` reading and parsing real sample JSONL files end-to-end
+- Integration: Both direct and effectful implementations tested with real file I/O
+
+**Test Data Strategy:**
+- Embed sample JSONL snippets as string constants in test files (one per entry type)
+- Include a small but complete sample JSONL file as a test resource for integration tests
+- Sample data derived from real log files (with sensitive content redacted)
+
+**Regression Coverage:**
+- Existing `JsonParser` tests must still pass after extracting shared content block parsing
+- Existing `ContentBlock` pattern matches in the codebase must be checked for exhaustiveness warnings after adding `ThinkingBlock`
+
+## Deployment Considerations
+
+### Database Changes
+None. Read-only access to existing files.
+
+### Configuration Changes
+None required. Log file paths are passed by the caller.
+
+### Rollout Strategy
+Library release — consumers opt in by calling the new API.
+
+### Rollback Plan
+Revert to previous SDK version. No persistent state changes.
+
+## Dependencies
+
+### Prerequisites
+- Resolve CLARIFY markers (especially type relationship decisions) before implementation
+- Sample JSONL test fixtures prepared from real log files
+
+### Layer Dependencies
+- Domain types must be defined first (types used by all other layers)
+- Content block parsing extraction/extension can happen in parallel with domain types
+- Log parser depends on domain types and shared content block parsing
+- Service trait definitions depend on domain types
+- Service implementations (direct + effectful) depend on service traits and log parser
+- Direct and effectful implementations can be developed in parallel
+
+### External Blockers
+- None. Log format is already stable in current Claude Code versions.
+
+## Risks & Mitigations
+
+### Risk 1: Log format changes in future Claude Code versions
+**Likelihood:** Medium
+**Impact:** Medium
+**Mitigation:** Design parser to skip unknown entry types gracefully; use Option types for fields that may not be present in all versions. Include Claude Code version from log metadata in parsed entries.
+
+### Risk 2: Exhaustiveness warnings from adding ThinkingBlock to ContentBlock
+**Likelihood:** High
+**Impact:** Low
+**Mitigation:** Adding a new case to `ContentBlock` will cause match exhaustiveness warnings wherever it is pattern-matched. These are compile-time warnings and must be fixed as part of this work. The existing code uses `case _ => None` or `.collectFirst` patterns that should handle this gracefully.
+
+### Risk 3: Large log files causing memory pressure
+**Likelihood:** Low
+**Impact:** Medium
+**Mitigation:** The streaming reader design (fs2.Stream / ox.flow.Flow) processes entries lazily. The `readAll` convenience method should document that it loads everything into memory.
+
+---
+
+## Implementation Sequence
+
+**Recommended Order:**
+
+1. **Domain types** (`core.log.model` + `ThinkingBlock` in `core.model`) — Define all new types. Add `ThinkingBlock` to existing `ContentBlock` sealed trait. Fix any exhaustiveness warnings.
+2. **Shared content block parsing** — Extract `ContentBlockParser` from `JsonParser.parseContentBlock`. Add thinking block support. Verify existing stream-json tests still pass.
+3. **Log parser** (`core.log.parsing`) — Build `ConversationLogParser` using `ContentBlockParser` for content blocks. Pure parsing for all entry types.
+4. **Service traits** (`core.log`) — Define `ConversationLogIndex` and `ConversationLogReader` trait interfaces.
+5. **Service implementations** (`direct.log` + `effectful.log`) — File I/O and wiring. Direct and effectful variants can be parallelized.
+6. **Re-exports and integration** — Update package objects, update ARCHITECTURE.md.
+
+**Ordering Rationale:**
+- Domain types are the foundation; everything depends on them
+- Content block parsing extraction is a prerequisite for the log parser
+- Core parser is pure and testable in isolation; it should be solid before wiring up I/O
+- Service traits define the contract before implementations fill it in
+- Direct and effectful variants within each layer can be parallelized
+
+## Documentation Requirements
+
+- [ ] Code documentation (inline comments for complex parsing logic, PURPOSE headers on all new files)
+- [ ] API documentation (scaladoc on public traits and methods)
+- [ ] Architecture decision record (update ARCHITECTURE.md with log parsing section)
+- [ ] Update README.md with log parsing usage examples
+
+---
+
+**Analysis Status:** Ready for Review
+
+**Next Steps:**
+1. Resolve CLARIFY markers with stakeholders
+2. Run **wf-create-tasks** with the issue ID
+3. Run **wf-implement** for layer-by-layer implementation

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -132,3 +132,46 @@ A  test/works/iterative/claude/core/log/ServiceTraitTest.scala
 ```
 
 ---
+
+## Phase 5: Service implementations (2026-03-25)
+
+**Layer:** Service (direct + effectful)
+
+**What was built:**
+- `works/iterative/claude/core/log/ProjectPathDecoder.scala` — pure utility to decode Claude project directory names (dash-encoded) to filesystem path strings
+- `works/iterative/claude/core/log/LogFileMetadataBuilder.scala` — shared pure logic for building LogFileMetadata from filesystem stat, used by both direct and effectful implementations
+- `works/iterative/claude/direct/log/DirectConversationLogIndex.scala` — synchronous ConversationLogIndex using os-lib for file discovery
+- `works/iterative/claude/direct/log/DirectConversationLogReader.scala` — synchronous ConversationLogReader using os-lib for readAll, lazy scala.io.Source for streaming via Ox Flow
+- `works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala` — IO-based ConversationLogIndex using fs2.io.file for directory listing
+- `works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala` — IO-based ConversationLogReader using fs2.Stream text pipeline
+
+**Dependencies on other layers:**
+- Domain (Phase 1): `ConversationLogEntry`, `LogFileMetadata`, all payload types
+- Parsing (Phase 3): `ConversationLogParser.parseLogLine` for pure JSONL parsing
+- Service (Phase 4): `ConversationLogIndex[F[_]]`, `ConversationLogReader[F[_]]` trait contracts
+
+**Testing:**
+- Unit tests: 7 tests added (ProjectPathDecoder)
+- Integration tests: 40 tests added (10 DirectIndex, 10 DirectReader, 9 EffectfulIndex, 9 EffectfulReader — all using real temp directories and files)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-05-20260325-125229.md
+- No critical issues; warnings addressed: PURPOSE comments cleaned, metadataFor extracted to shared builder, stream made lazy, effectful index non-existent directory guard added
+
+**Files changed:**
+```
+A  works/iterative/claude/core/log/ProjectPathDecoder.scala
+A  works/iterative/claude/core/log/LogFileMetadataBuilder.scala
+A  works/iterative/claude/direct/log/DirectConversationLogIndex.scala
+A  works/iterative/claude/direct/log/DirectConversationLogReader.scala
+A  works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala
+A  works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala
+A  test/works/iterative/claude/core/log/ProjectPathDecoderTest.scala
+A  test/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+A  test/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+A  test/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
+A  test/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
+```
+
+---

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -175,3 +175,39 @@ A  test/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.
 ```
 
 ---
+
+## Phase 6: Re-exports and documentation (2026-03-25)
+
+**Layer:** Public API surface + Documentation
+
+**What was built:**
+- `works/iterative/claude/direct/package.scala` — added re-exports for ThinkingBlock, RedactedThinkingBlock, all log model types, service traits, direct implementations, and ProjectPathDecoder
+- `works/iterative/claude/effectful/package.scala` — created new package object mirroring direct pattern with all core and log types, plus effectful implementations
+- `ARCHITECTURE.md` — added Conversation Log Parsing section covering domain model, parsing layer, service layer, dual implementations, and ProjectPathDecoder
+- `README.md` — added Conversation Log Parsing section with usage examples for both direct and effectful APIs
+
+**Dependencies on other layers:**
+- Domain (Phase 1): All content block and log model types
+- Service (Phase 4): ConversationLogIndex, ConversationLogReader traits
+- Implementations (Phase 5): All direct and effectful implementations
+
+**Testing:**
+- Unit tests: 2 test suites added (DirectPackageReexportTest, EffectfulPackageReexportTest) — compilation verification tests
+- Integration tests: 0 (re-exports only, no new logic)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-06-20260325-132224.md
+- No critical issues; warnings addressed: ordering consistency, ProjectPathDecoder type alias, test improvements (temp dirs, effectful reader exercise)
+
+**Files changed:**
+```
+M  works/iterative/claude/direct/package.scala
+A  works/iterative/claude/effectful/package.scala
+A  test/works/iterative/claude/direct/DirectPackageReexportTest.scala
+A  test/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+M  ARCHITECTURE.md
+M  README.md
+```
+
+---

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -72,3 +72,34 @@ M  works/iterative/claude/core/parsing/JsonParser.scala
 ```
 
 ---
+
+## Phase 3: Log entry parser (2026-03-25)
+
+**Layer:** Parsing
+
+**What was built:**
+- `works/iterative/claude/core/log/parsing/ConversationLogParser.scala` — pure JSONL log line parser with envelope extraction, type-based payload dispatch, and TokenUsage parsing
+- Handles all 8 payload types: human (string + array content), assistant (with model/usage/requestId), system, progress, queue_operation, file_history_snapshot, last_prompt, and unknown types via RawLogEntry
+- Reuses `ContentBlockParser` for content block parsing within log entries
+
+**Dependencies on other layers:**
+- Domain (Phase 1): Uses `ConversationLogEntry`, `LogEntryPayload` variants, `TokenUsage`, `ContentBlock` variants
+- Parsing (Phase 2): Uses `ContentBlockParser.parseContentBlock` for content blocks within log entries
+
+**Testing:**
+- Unit tests: 28 tests added (6 entry point/error path, 4 envelope metadata, 10 payload types, 2 TokenUsage, 6 error path tests from review)
+- Integration tests: 0 (pure parsing, no I/O)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-03-20260325-104938.md
+- No critical issues in Phase 3 code; design-level suggestions about Phase 1 model types (enum, Map[String, Json]) noted for future work
+- Fixed: extracted EnvelopeKeys constant, narrowed exception handling, removed unused parameter, extracted parseContentBlocks helper, inlined extractEnvelope, added 6 error path tests, strengthened data assertions
+
+**Files changed:**
+```
+A  works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+A  test/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -43,3 +43,32 @@ M  works/iterative/claude/core/model/ContentBlock.scala
 ```
 
 ---
+
+## Phase 2: Content block parsing extraction (2026-03-25)
+
+**Layer:** Parsing
+
+**What was built:**
+- `works/iterative/claude/core/parsing/ContentBlockParser.scala` — standalone content block parser extracted from `JsonParser`, handles text, tool_use, tool_result, thinking, and redacted_thinking blocks
+- `works/iterative/claude/core/parsing/JsonParser.scala` — updated to delegate content block parsing to `ContentBlockParser`
+
+**Dependencies on other layers:**
+- Domain (Phase 1): Uses `ThinkingBlock`, `RedactedThinkingBlock`, and other `ContentBlock` variants
+
+**Testing:**
+- Unit tests: 8 tests added (ContentBlockParserTest — all 5 block types, optional fields, unknown type, missing type field)
+- Integration tests: 0 (all existing JsonParser tests pass unchanged, including property-based round-trip tests)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-02-20260325-113323.md
+- No critical issues; warnings are design-level suggestions (enum conversion, method decomposition, error path tests)
+
+**Files changed:**
+```
+A  works/iterative/claude/core/parsing/ContentBlockParser.scala
+A  test/works/iterative/claude/core/parsing/ContentBlockParserTest.scala
+M  works/iterative/claude/core/parsing/JsonParser.scala
+```
+
+---

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -1,0 +1,45 @@
+# Implementation Log: Add conversation log parsing support
+
+Issue: CC-4
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: Domain types (2026-03-25)
+
+**Layer:** Domain
+
+**What was built:**
+- `works/iterative/claude/core/model/ContentBlock.scala` — added `ThinkingBlock` and `RedactedThinkingBlock` variants to existing `ContentBlock` sealed trait
+- `works/iterative/claude/core/log/model/TokenUsage.scala` — structured token usage counts with optional cache fields
+- `works/iterative/claude/core/log/model/LogEntryPayload.scala` — sealed trait with 8 payload variants (User, Assistant, System, Progress, QueueOperation, FileHistorySnapshot, LastPrompt, Raw)
+- `works/iterative/claude/core/log/model/ConversationLogEntry.scala` — envelope type with uuid, timestamp, sessionId, and payload
+- `works/iterative/claude/core/log/model/LogFileMetadata.scala` — file metadata for log index service
+
+**Dependencies on other layers:**
+- None — this is the foundation layer
+
+**Testing:**
+- Unit tests: 22 tests added (5 ContentBlock, 17 LogModel)
+- Integration tests: 0 (not needed for domain types)
+- Exhaustiveness fix: updated `serializeContentBlock` in `JsonParserTest` for new variants
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-01-20260325.md
+- No critical issues; warnings are design-level suggestions consistent with existing patterns
+
+**Files changed:**
+```
+A  test/works/iterative/claude/core/log/model/LogModelTest.scala
+A  test/works/iterative/claude/core/model/ContentBlockTest.scala
+M  test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
+A  works/iterative/claude/core/log/model/ConversationLogEntry.scala
+A  works/iterative/claude/core/log/model/LogEntryPayload.scala
+A  works/iterative/claude/core/log/model/LogFileMetadata.scala
+A  works/iterative/claude/core/log/model/TokenUsage.scala
+M  works/iterative/claude/core/model/ContentBlock.scala
+```
+
+---

--- a/project-management/issues/CC-4/implementation-log.md
+++ b/project-management/issues/CC-4/implementation-log.md
@@ -103,3 +103,32 @@ A  test/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
 ```
 
 ---
+
+## Phase 4: Service traits (2026-03-25)
+
+**Layer:** Service
+
+**What was built:**
+- `works/iterative/claude/core/log/ConversationLogIndex.scala` — abstract trait parameterised by `F[_]` for session discovery (`listSessions`, `forSession`)
+- `works/iterative/claude/core/log/ConversationLogReader.scala` — abstract trait parameterised by `F[_]` with `EntryStream` type member for log reading (`readAll`, `stream`)
+
+**Dependencies on other layers:**
+- Domain (Phase 1): Uses `ConversationLogEntry`, `LogFileMetadata`
+
+**Testing:**
+- Unit tests: 4 compilation tests (identity F and IO for both traits)
+- Integration tests: 0 (abstract traits with no implementation logic)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-04-20260325-120953.md
+- No critical issues; warnings about unconstrained `EntryStream` type member (design decision — no common stream supertype between ox.flow.Flow and fs2.Stream), redundant comments and vacuous asserts (fixed)
+
+**Files changed:**
+```
+A  works/iterative/claude/core/log/ConversationLogIndex.scala
+A  works/iterative/claude/core/log/ConversationLogReader.scala
+A  test/works/iterative/claude/core/log/ServiceTraitTest.scala
+```
+
+---

--- a/project-management/issues/CC-4/phase-01-context.md
+++ b/project-management/issues/CC-4/phase-01-context.md
@@ -1,0 +1,129 @@
+# Phase 1: Domain types
+
+## Goals
+
+Define all new domain types needed for conversation log parsing support. This phase establishes the type foundation that all subsequent phases depend on.
+
+## Scope
+
+### In Scope
+
+1. **Extend `ContentBlock` sealed trait** (`core.model.ContentBlock`):
+   - Add `ThinkingBlock(thinking: String, signature: String)` — extended thinking content from API
+   - Add `RedactedThinkingBlock(data: String)` — redacted thinking for safety-filtered content
+
+2. **Fix exhaustiveness warnings** in existing codebase:
+   - Any pattern matches on `ContentBlock` must handle the new variants
+   - Check `core.parsing.JsonParser.parseContentBlock` (already has `case _ => None`)
+   - Check direct and effectful wrappers
+
+3. **New log model types** in `core.log.model` package:
+   - `ConversationLogEntry` — envelope type with common metadata:
+     - `uuid: String`
+     - `parentUuid: Option[String]`
+     - `timestamp: Option[java.time.Instant]`
+     - `sessionId: String`
+     - `isSidechain: Boolean`
+     - `cwd: Option[String]`
+     - `version: Option[String]`
+     - `payload: LogEntryPayload`
+   - `LogEntryPayload` — sealed trait with variants:
+     - `UserLogEntry(content: List[ContentBlock])` — user messages (content block arrays in logs)
+     - `AssistantLogEntry(content: List[ContentBlock], model: Option[String], usage: Option[TokenUsage], requestId: Option[String])` — assistant messages with metadata
+     - `SystemLogEntry(subtype: String, data: Map[String, Any])` — system events
+     - `ProgressLogEntry(data: Map[String, Any], parentToolUseId: Option[String])` — progress updates
+     - `QueueOperationLogEntry(operation: String, content: Option[String])` — queue operations
+     - `FileHistorySnapshotLogEntry(data: Map[String, Any])` — file state snapshots
+     - `LastPromptLogEntry(data: Map[String, Any])` — last prompt markers
+     - `RawLogEntry(entryType: String, json: io.circe.Json)` — unknown/future entry types
+   - `TokenUsage` — structured token usage:
+     - `inputTokens: Int`
+     - `outputTokens: Int`
+     - `cacheCreationInputTokens: Option[Int]`
+     - `cacheReadInputTokens: Option[Int]`
+     - `serviceTier: Option[String]`
+   - `LogFileMetadata` — metadata about a log file for the index service:
+     - `path: os.Path`
+     - `sessionId: String`
+     - `summary: Option[String]`
+     - `lastModified: java.time.Instant`
+     - `fileSize: Long`
+     - `cwd: Option[String]`
+     - `gitBranch: Option[String]`
+     - `createdAt: Option[java.time.Instant]`
+
+### Out of Scope
+
+- Parsing logic (Phase 2 and 3)
+- Service traits (Phase 4)
+- Service implementations (Phase 5)
+- Re-exports to direct/effectful packages (Phase 6)
+
+## Dependencies
+
+### Prior Phases
+None — this is the first phase.
+
+### External Dependencies
+- `io.circe.Json` — used in `RawLogEntry` for preserving raw JSON of unknown entry types
+- `os.Path` — used in `LogFileMetadata` (already a project dependency)
+- `java.time.Instant` — for timestamp fields
+
+## Approach
+
+### Implementation Strategy
+
+1. Add `ThinkingBlock` and `RedactedThinkingBlock` to existing `ContentBlock.scala`
+2. Verify no exhaustiveness warnings are introduced (check existing pattern matches)
+3. Create new `core/log/model/` package directory
+4. Define `TokenUsage` case class (no dependencies on other new types)
+5. Define `LogEntryPayload` sealed trait and all variants
+6. Define `ConversationLogEntry` envelope
+7. Define `LogFileMetadata` case class
+8. All files must have PURPOSE headers per project conventions
+
+### Key Design Decisions
+
+- **Separate type hierarchies**: Log types (`LogEntryPayload`) are completely separate from stream types (`Message`). Shared parts are at the `ContentBlock` level only.
+- **`RawLogEntry` for forward compatibility**: Unknown entry types are captured with their raw JSON rather than silently dropped.
+- **`Option[Instant]` for timestamps**: The TS SDK marks timestamp as optional; we follow suit.
+- **`List[ContentBlock]` for user content**: Log user messages contain content block arrays (including `tool_result` blocks), unlike stream `UserMessage(String)`.
+
+## Files to Create/Modify
+
+### New Files
+- `works/iterative/claude/core/log/model/ConversationLogEntry.scala` — envelope type
+- `works/iterative/claude/core/log/model/LogEntryPayload.scala` — sealed trait + all payload variants
+- `works/iterative/claude/core/log/model/TokenUsage.scala` — token usage case class
+- `works/iterative/claude/core/log/model/LogFileMetadata.scala` — file metadata case class
+
+### Modified Files
+- `works/iterative/claude/core/model/ContentBlock.scala` — add ThinkingBlock and RedactedThinkingBlock
+
+### Files to Check for Exhaustiveness
+- `works/iterative/claude/core/parsing/JsonParser.scala` — `parseContentBlock` already has `case _ => None`
+- `works/iterative/claude/direct/internal/parsing/JsonParser.scala` — wraps core parser
+- `works/iterative/claude/effectful/internal/parsing/JsonParser.scala` — wraps core parser
+- Any tests matching on ContentBlock
+
+## Testing Strategy
+
+### Unit Tests
+- Verify all new types can be constructed with required fields
+- Verify `ConversationLogEntry` correctly holds each `LogEntryPayload` variant
+- Verify `TokenUsage` field access and defaults
+- Verify `LogFileMetadata` construction
+- Verify `ThinkingBlock` and `RedactedThinkingBlock` are valid `ContentBlock` instances
+
+### Compilation Checks
+- Ensure no new exhaustiveness warnings after adding ContentBlock variants
+- Ensure all existing tests still compile and pass
+
+## Acceptance Criteria
+
+1. `ThinkingBlock` and `RedactedThinkingBlock` exist as `ContentBlock` variants
+2. All log domain types compile with correct field types
+3. No exhaustiveness warnings introduced in existing code
+4. All existing tests pass unchanged
+5. All new files have PURPOSE headers
+6. New types are in `works.iterative.claude.core.log.model` package

--- a/project-management/issues/CC-4/phase-01-tasks.md
+++ b/project-management/issues/CC-4/phase-01-tasks.md
@@ -2,27 +2,28 @@
 
 ## Setup
 
-- [ ] [setup] Create `works/iterative/claude/core/log/model/` directory structure
+- [x] [setup] Create `works/iterative/claude/core/log/model/` directory structure
 
 ## Tests
 
-- [ ] [test] Write tests for `ThinkingBlock` and `RedactedThinkingBlock` as ContentBlock variants
-- [ ] [test] Write tests for `TokenUsage` construction and field access
-- [ ] [test] Write tests for `LogEntryPayload` sealed trait — construct each variant and verify fields
-- [ ] [test] Write tests for `ConversationLogEntry` envelope holding each payload variant
-- [ ] [test] Write tests for `LogFileMetadata` construction
+- [x] [test] Write tests for `ThinkingBlock` and `RedactedThinkingBlock` as ContentBlock variants
+- [x] [test] Write tests for `TokenUsage` construction and field access
+- [x] [test] Write tests for `LogEntryPayload` sealed trait — construct each variant and verify fields
+- [x] [test] Write tests for `ConversationLogEntry` envelope holding each payload variant
+- [x] [test] Write tests for `LogFileMetadata` construction
 
 ## Implementation
 
-- [ ] [impl] Add `ThinkingBlock(thinking: String, signature: String)` to `ContentBlock` sealed trait
-- [ ] [impl] Add `RedactedThinkingBlock(data: String)` to `ContentBlock` sealed trait
-- [ ] [impl] Verify no exhaustiveness warnings in existing code (compile check)
-- [ ] [impl] Create `TokenUsage` case class in `core.log.model`
-- [ ] [impl] Create `LogEntryPayload` sealed trait with all 8 payload variants in `core.log.model`
-- [ ] [impl] Create `ConversationLogEntry` envelope case class in `core.log.model`
-- [ ] [impl] Create `LogFileMetadata` case class in `core.log.model`
+- [x] [impl] Add `ThinkingBlock(thinking: String, signature: String)` to `ContentBlock` sealed trait
+- [x] [impl] Add `RedactedThinkingBlock(data: String)` to `ContentBlock` sealed trait
+- [x] [impl] Verify no exhaustiveness warnings in existing code (compile check)
+- [x] [impl] Create `TokenUsage` case class in `core.log.model`
+- [x] [impl] Create `LogEntryPayload` sealed trait with all 8 payload variants in `core.log.model`
+- [x] [impl] Create `ConversationLogEntry` envelope case class in `core.log.model`
+- [x] [impl] Create `LogFileMetadata` case class in `core.log.model`
 
 ## Integration
 
-- [ ] [integration] Run full test suite to verify no regressions from ContentBlock changes
-- [ ] [integration] Verify all existing tests pass
+- [x] [integration] Run full test suite to verify no regressions from ContentBlock changes
+- [x] [integration] Verify all existing tests pass
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-01-tasks.md
+++ b/project-management/issues/CC-4/phase-01-tasks.md
@@ -1,0 +1,28 @@
+# Phase 1 Tasks: Domain types
+
+## Setup
+
+- [ ] [setup] Create `works/iterative/claude/core/log/model/` directory structure
+
+## Tests
+
+- [ ] [test] Write tests for `ThinkingBlock` and `RedactedThinkingBlock` as ContentBlock variants
+- [ ] [test] Write tests for `TokenUsage` construction and field access
+- [ ] [test] Write tests for `LogEntryPayload` sealed trait — construct each variant and verify fields
+- [ ] [test] Write tests for `ConversationLogEntry` envelope holding each payload variant
+- [ ] [test] Write tests for `LogFileMetadata` construction
+
+## Implementation
+
+- [ ] [impl] Add `ThinkingBlock(thinking: String, signature: String)` to `ContentBlock` sealed trait
+- [ ] [impl] Add `RedactedThinkingBlock(data: String)` to `ContentBlock` sealed trait
+- [ ] [impl] Verify no exhaustiveness warnings in existing code (compile check)
+- [ ] [impl] Create `TokenUsage` case class in `core.log.model`
+- [ ] [impl] Create `LogEntryPayload` sealed trait with all 8 payload variants in `core.log.model`
+- [ ] [impl] Create `ConversationLogEntry` envelope case class in `core.log.model`
+- [ ] [impl] Create `LogFileMetadata` case class in `core.log.model`
+
+## Integration
+
+- [ ] [integration] Run full test suite to verify no regressions from ContentBlock changes
+- [ ] [integration] Verify all existing tests pass

--- a/project-management/issues/CC-4/phase-02-context.md
+++ b/project-management/issues/CC-4/phase-02-context.md
@@ -1,0 +1,95 @@
+# Phase 2: Content block parsing extraction
+
+## Goals
+
+Extract shared content block parsing logic from `JsonParser.parseContentBlock` into a standalone `ContentBlockParser` object, add parsing for `thinking` and `redacted_thinking` block types, and update `JsonParser` to delegate to the new parser. All existing tests must continue to pass.
+
+## Scope
+
+### In Scope
+
+1. **Create `ContentBlockParser` object** in `core.parsing` package:
+   - Extract the content block parsing logic currently in `JsonParser.parseContentBlock` (lines 47-67)
+   - Public method `parseContentBlock(json: Json): Option[ContentBlock]`
+   - Handles: `text`, `tool_use`, `tool_result`, `thinking`, `redacted_thinking`
+   - Unknown types return `None` (same behavior as current code)
+
+2. **Add thinking block parsing**:
+   - `"thinking"` type → `ThinkingBlock(thinking, signature)` — both fields required
+   - `"redacted_thinking"` type → `RedactedThinkingBlock(data)`
+
+3. **Update `JsonParser`** to delegate to `ContentBlockParser`:
+   - Remove `private def parseContentBlock` from `JsonParser`
+   - Call `ContentBlockParser.parseContentBlock` instead
+
+4. **Regression verification**:
+   - All existing `JsonParserTest` tests (core and direct) must pass unchanged
+   - Property-based round-trip tests must still work (the direct test already serializes `ThinkingBlock` and `RedactedThinkingBlock`)
+
+### Out of Scope
+
+- Log entry parsing (Phase 3)
+- Any changes to `Message` types
+- Changes to direct/effectful `JsonParser` wrappers (they delegate to core `JsonParser` which delegates to `ContentBlockParser`)
+
+## Dependencies
+
+### Prior Phases
+- **Phase 1**: `ThinkingBlock` and `RedactedThinkingBlock` already exist in `ContentBlock.scala`
+
+### External Dependencies
+- `io.circe.Json` — for JSON parsing (already used)
+
+## Approach
+
+### Implementation Strategy
+
+1. Create `ContentBlockParser.scala` in `works/iterative/claude/core/parsing/`
+2. Move the content block parsing logic from `JsonParser.parseContentBlock` into `ContentBlockParser.parseContentBlock`
+3. Add `thinking` and `redacted_thinking` cases
+4. Update `JsonParser.parseAssistantMessage` to call `ContentBlockParser.parseContentBlock` instead of the private method
+5. Remove the private `parseContentBlock` from `JsonParser`
+6. Write unit tests for `ContentBlockParser` covering all 5 block types plus unknown types
+7. Verify all existing tests pass
+
+### Key Design Decisions
+
+- **Standalone object, not trait**: `ContentBlockParser` is a pure parsing utility with no state, so an `object` is appropriate (matches `JsonParser` pattern)
+- **Same signature**: `parseContentBlock(json: Json): Option[ContentBlock]` — identical to the current private method for seamless delegation
+- **Reusable by Phase 3**: `ConversationLogParser` (Phase 3) will call `ContentBlockParser.parseContentBlock` for content blocks within log entries
+
+## Files to Create/Modify
+
+### New Files
+- `works/iterative/claude/core/parsing/ContentBlockParser.scala` — extracted content block parsing with thinking support
+- `test/works/iterative/claude/core/parsing/ContentBlockParserTest.scala` — unit tests for all block types
+
+### Modified Files
+- `works/iterative/claude/core/parsing/JsonParser.scala` — remove private `parseContentBlock`, delegate to `ContentBlockParser`
+
+## Testing Strategy
+
+### Unit Tests (ContentBlockParserTest)
+- Parse `text` block → `TextBlock`
+- Parse `tool_use` block → `ToolUseBlock`
+- Parse `tool_result` block → `ToolResultBlock`
+- Parse `thinking` block → `ThinkingBlock`
+- Parse `redacted_thinking` block → `RedactedThinkingBlock`
+- Parse unknown type → `None`
+- Parse JSON without `type` field → `None`
+- Parse `tool_result` with optional fields (content, isError)
+
+### Regression Tests
+- All 7 tests in `core/parsing/JsonParserTest.scala` pass
+- All tests in `direct/internal/parsing/JsonParserTest.scala` pass (including property-based round-trip tests that already serialize ThinkingBlock and RedactedThinkingBlock)
+
+## Acceptance Criteria
+
+1. `ContentBlockParser` object exists in `works.iterative.claude.core.parsing`
+2. `ContentBlockParser.parseContentBlock` handles all 5 content block types
+3. `JsonParser` no longer has a private `parseContentBlock` method
+4. `JsonParser` delegates to `ContentBlockParser` for content block parsing
+5. All existing tests pass without modification
+6. New `ContentBlockParserTest` covers all block types
+7. New file has PURPOSE headers
+8. No compilation warnings

--- a/project-management/issues/CC-4/phase-02-tasks.md
+++ b/project-management/issues/CC-4/phase-02-tasks.md
@@ -1,0 +1,25 @@
+# Phase 2 Tasks: Content block parsing extraction
+
+## Setup
+
+- [ ] [setup] Verify all existing tests pass before making changes
+
+## Tests
+
+- [ ] [test] Write ContentBlockParserTest: parse text block returns TextBlock
+- [ ] [test] Write ContentBlockParserTest: parse tool_use block returns ToolUseBlock
+- [ ] [test] Write ContentBlockParserTest: parse tool_result block returns ToolResultBlock
+- [ ] [test] Write ContentBlockParserTest: parse thinking block returns ThinkingBlock
+- [ ] [test] Write ContentBlockParserTest: parse redacted_thinking block returns RedactedThinkingBlock
+- [ ] [test] Write ContentBlockParserTest: parse unknown type returns None
+- [ ] [test] Write ContentBlockParserTest: parse JSON without type field returns None
+
+## Implementation
+
+- [ ] [impl] Create ContentBlockParser object with parseContentBlock method (all 5 block types)
+- [ ] [impl] Update JsonParser to delegate to ContentBlockParser, remove private parseContentBlock
+
+## Integration
+
+- [ ] [integration] Verify all existing JsonParser tests pass (core + direct)
+- [ ] [integration] Verify no compilation warnings

--- a/project-management/issues/CC-4/phase-02-tasks.md
+++ b/project-management/issues/CC-4/phase-02-tasks.md
@@ -2,24 +2,25 @@
 
 ## Setup
 
-- [ ] [setup] Verify all existing tests pass before making changes
+- [x] [setup] Verify all existing tests pass before making changes
 
 ## Tests
 
-- [ ] [test] Write ContentBlockParserTest: parse text block returns TextBlock
-- [ ] [test] Write ContentBlockParserTest: parse tool_use block returns ToolUseBlock
-- [ ] [test] Write ContentBlockParserTest: parse tool_result block returns ToolResultBlock
-- [ ] [test] Write ContentBlockParserTest: parse thinking block returns ThinkingBlock
-- [ ] [test] Write ContentBlockParserTest: parse redacted_thinking block returns RedactedThinkingBlock
-- [ ] [test] Write ContentBlockParserTest: parse unknown type returns None
-- [ ] [test] Write ContentBlockParserTest: parse JSON without type field returns None
+- [x] [test] Write ContentBlockParserTest: parse text block returns TextBlock
+- [x] [test] Write ContentBlockParserTest: parse tool_use block returns ToolUseBlock
+- [x] [test] Write ContentBlockParserTest: parse tool_result block returns ToolResultBlock
+- [x] [test] Write ContentBlockParserTest: parse thinking block returns ThinkingBlock
+- [x] [test] Write ContentBlockParserTest: parse redacted_thinking block returns RedactedThinkingBlock
+- [x] [test] Write ContentBlockParserTest: parse unknown type returns None
+- [x] [test] Write ContentBlockParserTest: parse JSON without type field returns None
 
 ## Implementation
 
-- [ ] [impl] Create ContentBlockParser object with parseContentBlock method (all 5 block types)
-- [ ] [impl] Update JsonParser to delegate to ContentBlockParser, remove private parseContentBlock
+- [x] [impl] Create ContentBlockParser object with parseContentBlock method (all 5 block types)
+- [x] [impl] Update JsonParser to delegate to ContentBlockParser, remove private parseContentBlock
 
 ## Integration
 
-- [ ] [integration] Verify all existing JsonParser tests pass (core + direct)
-- [ ] [integration] Verify no compilation warnings
+- [x] [integration] Verify all existing JsonParser tests pass (core + direct)
+- [x] [integration] Verify no compilation warnings
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-03-context.md
+++ b/project-management/issues/CC-4/phase-03-context.md
@@ -1,0 +1,138 @@
+# Phase 3: Log entry parser
+
+## Goals
+
+Build `ConversationLogParser` — a pure parsing object for JSONL conversation log lines. Each line in a log file is a self-contained JSON object (envelope) carrying metadata plus a type-specific payload. The parser converts raw JSON lines into typed `ConversationLogEntry` instances, reusing `ContentBlockParser` for content blocks within messages.
+
+## Scope
+
+### In Scope
+
+1. **Create `ConversationLogParser` object** in `core.log.parsing` package:
+   - `parseLogLine(line: String): Option[ConversationLogEntry]` — parse a single JSONL line
+   - `parseLogEntry(json: Json): Option[ConversationLogEntry]` — parse a pre-parsed JSON value
+   - Internal helpers for envelope metadata and each payload type
+
+2. **Parse envelope metadata** common to all entry types:
+   - `uuid: String` (required)
+   - `parentUuid: Option[String]`
+   - `timestamp: Option[Instant]` — ISO-8601 string parsed to `java.time.Instant`
+   - `sessionId: String` (required)
+   - `isSidechain: Boolean` (default false)
+   - `cwd: Option[String]`
+   - `version: Option[String]`
+
+3. **Parse each entry type payload** based on the `type` field:
+   - `"human"` → `UserLogEntry(content: List[ContentBlock])` — user message content as array of content blocks; handle both string and array content formats
+   - `"assistant"` → `AssistantLogEntry(content, model, usage, requestId)` — assistant messages with content blocks, model name, token usage, and request ID
+   - `"system"` → `SystemLogEntry(subtype, data)` — system events with subtype and data map
+   - `"progress"` → `ProgressLogEntry(data, parentToolUseId)` — progress updates
+   - `"queue_operation"` → `QueueOperationLogEntry(operation, content)` — queue operations
+   - `"file_history_snapshot"` → `FileHistorySnapshotLogEntry(data)` — file state snapshots
+   - `"last_prompt"` → `LastPromptLogEntry(data)` — last prompt markers
+   - Unknown types → `RawLogEntry(entryType, json)` — preserve raw JSON for forward compatibility
+
+4. **Parse `TokenUsage`** from assistant message `message.usage` field:
+   - `input_tokens`, `output_tokens` (required)
+   - `cache_creation_input_tokens`, `cache_read_input_tokens` (optional)
+   - `service_tier` (optional)
+
+5. **Handle user message content formats**:
+   - String content → wrap in `List(TextBlock(content))`
+   - Array content → parse each element via `ContentBlockParser`
+
+6. **Reuse `ContentBlockParser`** for all content block parsing within log entries
+
+### Out of Scope
+
+- File I/O (Phase 5 — service implementations handle reading JSONL files)
+- Service traits (Phase 4)
+- Streaming/batched parsing (Phase 5 — readers handle line-by-line streaming)
+
+## Dependencies
+
+### Prior Phases
+- **Phase 1**: All domain types (`ConversationLogEntry`, `LogEntryPayload` variants, `TokenUsage`, `ContentBlock` variants)
+- **Phase 2**: `ContentBlockParser.parseContentBlock` for content block parsing within log entries
+
+### External Dependencies
+- `io.circe.{Json, parser}` — JSON parsing (already used throughout)
+- `java.time.Instant` — ISO-8601 timestamp parsing
+
+## Approach
+
+### Implementation Strategy
+
+1. Create `works/iterative/claude/core/log/parsing/ConversationLogParser.scala`
+2. Implement `parseLogLine` as entry point (string → parse JSON → delegate to `parseLogEntry`)
+3. Implement `parseLogEntry` — extract envelope metadata, then dispatch on `type` field to payload parsers
+4. Implement private payload parsers for each entry type
+5. Implement `parseTokenUsage` helper for assistant message usage data
+6. Implement content parsing helper that handles both string and array content formats
+7. Write comprehensive tests covering all entry types, edge cases, and error handling
+
+### Key Design Decisions
+
+- **Same patterns as `JsonParser`**: Use `object` with public entry points and private helpers, `Option`-based error handling, circe `HCursor` for field extraction
+- **Forward compatibility via `RawLogEntry`**: Unknown entry types are captured with their raw JSON rather than silently dropped
+- **Graceful degradation**: Malformed lines return `None`; individual optional fields use `Option` to avoid dropping entries with partial data
+- **Content format normalization**: User messages in logs can be either a string or an array of content blocks; the parser normalizes both to `List[ContentBlock]`
+- **Reuse over duplication**: Delegate to `ContentBlockParser` for content blocks; use similar `extractJsonValue` pattern from `JsonParser` for untyped data maps
+
+## Files to Create/Modify
+
+### New Files
+- `works/iterative/claude/core/log/parsing/ConversationLogParser.scala` — pure log entry parser
+- `test/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala` — comprehensive unit tests
+
+### Modified Files
+- None expected
+
+## Testing Strategy
+
+### Unit Tests (ConversationLogParserTest)
+
+**Entry point tests:**
+- Parse valid JSONL line → `Some(ConversationLogEntry)`
+- Parse empty/whitespace line → `None`
+- Parse invalid JSON → `None`
+- Parse JSON missing required envelope fields (uuid, sessionId) → `None`
+
+**Envelope metadata tests:**
+- Parse all envelope fields present
+- Parse with optional fields missing (parentUuid, timestamp, cwd, version)
+- Parse ISO-8601 timestamp to `Instant`
+- Parse `isSidechain` defaulting to `false` when absent
+
+**Payload type tests (one per entry type):**
+- `"human"` with string content → `UserLogEntry` with `List(TextBlock(...))`
+- `"human"` with array content → `UserLogEntry` with parsed content blocks
+- `"assistant"` with content blocks, model, usage, requestId → `AssistantLogEntry`
+- `"assistant"` with minimal fields (no usage, no model) → `AssistantLogEntry`
+- `"system"` with subtype and data → `SystemLogEntry`
+- `"progress"` with data and parentToolUseId → `ProgressLogEntry`
+- `"queue_operation"` with operation and content → `QueueOperationLogEntry`
+- `"file_history_snapshot"` with data → `FileHistorySnapshotLogEntry`
+- `"last_prompt"` with data → `LastPromptLogEntry`
+- Unknown type → `RawLogEntry` with preserved JSON
+
+**TokenUsage tests:**
+- Parse full usage data (all fields)
+- Parse minimal usage data (only required fields)
+
+**Regression:**
+- Existing `ContentBlockParser` and `JsonParser` tests still pass
+
+## Acceptance Criteria
+
+1. `ConversationLogParser` object exists in `works.iterative.claude.core.log.parsing`
+2. `parseLogLine` and `parseLogEntry` are public entry points
+3. All 8 payload types are parsed correctly (7 known + RawLogEntry for unknown)
+4. User message content handles both string and array formats
+5. `TokenUsage` is parsed from assistant message usage data
+6. Envelope metadata (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version) is correctly extracted
+7. Unknown entry types produce `RawLogEntry` with preserved JSON
+8. Malformed/empty lines return `None`
+9. All new and existing tests pass
+10. New files have PURPOSE headers
+11. No compilation warnings

--- a/project-management/issues/CC-4/phase-03-tasks.md
+++ b/project-management/issues/CC-4/phase-03-tasks.md
@@ -1,0 +1,65 @@
+# Phase 3 Tasks: Log entry parser
+
+## Setup
+
+- [ ] [setup] Verify all existing tests pass before starting
+- [ ] [setup] Create `works/iterative/claude/core/log/parsing/` directory structure
+
+## Tests — Entry Points
+
+- [ ] [test] Write ConversationLogParserTest: parseLogLine with valid JSONL line returns Some(ConversationLogEntry)
+- [ ] [test] Write ConversationLogParserTest: parseLogLine with empty/whitespace line returns None
+- [ ] [test] Write ConversationLogParserTest: parseLogLine with invalid JSON returns None
+- [ ] [test] Write ConversationLogParserTest: parseLogEntry with missing required uuid field returns None
+- [ ] [test] Write ConversationLogParserTest: parseLogEntry with missing required sessionId field returns None
+
+## Tests — Envelope Metadata
+
+- [ ] [test] Write ConversationLogParserTest: parses all envelope metadata fields (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
+- [ ] [test] Write ConversationLogParserTest: parses with optional fields absent (parentUuid, timestamp, cwd, version)
+- [ ] [test] Write ConversationLogParserTest: parses ISO-8601 timestamp string to Instant
+- [ ] [test] Write ConversationLogParserTest: isSidechain defaults to false when absent
+
+## Tests — Payload Types
+
+- [ ] [test] Write ConversationLogParserTest: "human" type with string content produces UserLogEntry with List(TextBlock)
+- [ ] [test] Write ConversationLogParserTest: "human" type with array content produces UserLogEntry with parsed content blocks
+- [ ] [test] Write ConversationLogParserTest: "assistant" type with content, model, usage, requestId produces AssistantLogEntry
+- [ ] [test] Write ConversationLogParserTest: "assistant" type with minimal fields (no usage, no model) produces AssistantLogEntry
+- [ ] [test] Write ConversationLogParserTest: "system" type with subtype and data produces SystemLogEntry
+- [ ] [test] Write ConversationLogParserTest: "progress" type with data and parentToolUseId produces ProgressLogEntry
+- [ ] [test] Write ConversationLogParserTest: "queue_operation" type with operation and content produces QueueOperationLogEntry
+- [ ] [test] Write ConversationLogParserTest: "file_history_snapshot" type with data produces FileHistorySnapshotLogEntry
+- [ ] [test] Write ConversationLogParserTest: "last_prompt" type with data produces LastPromptLogEntry
+- [ ] [test] Write ConversationLogParserTest: unknown type produces RawLogEntry with preserved JSON
+
+## Tests — TokenUsage
+
+- [ ] [test] Write ConversationLogParserTest: parses full token usage (all fields including cache and service_tier)
+- [ ] [test] Write ConversationLogParserTest: parses minimal token usage (only input_tokens and output_tokens)
+
+## Implementation — Core Parser
+
+- [ ] [impl] Create ConversationLogParser object with parseLogLine method (string to JSON delegation)
+- [ ] [impl] Implement parseLogEntry method (JSON to ConversationLogEntry with envelope extraction and type dispatch)
+- [ ] [impl] Implement envelope metadata extraction (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
+- [ ] [impl] Implement ISO-8601 timestamp parsing to Instant
+
+## Implementation — Payload Parsers
+
+- [ ] [impl] Implement "human" payload parser with string-to-TextBlock and array content handling
+- [ ] [impl] Implement "assistant" payload parser with content blocks, model, usage, requestId
+- [ ] [impl] Implement parseTokenUsage helper for assistant message usage data
+- [ ] [impl] Implement "system" payload parser with subtype and data map extraction
+- [ ] [impl] Implement "progress" payload parser with data map and parentToolUseId
+- [ ] [impl] Implement "queue_operation" payload parser with operation and content
+- [ ] [impl] Implement "file_history_snapshot" payload parser with data map
+- [ ] [impl] Implement "last_prompt" payload parser with data map
+- [ ] [impl] Implement unknown type fallback to RawLogEntry
+
+## Integration
+
+- [ ] [verify] All new ConversationLogParserTest tests pass
+- [ ] [verify] All existing tests pass (JsonParser, ContentBlockParser, LogModel, ContentBlock)
+- [ ] [verify] No compilation warnings
+- [ ] [verify] PURPOSE headers present on new files

--- a/project-management/issues/CC-4/phase-03-tasks.md
+++ b/project-management/issues/CC-4/phase-03-tasks.md
@@ -2,64 +2,65 @@
 
 ## Setup
 
-- [ ] [setup] Verify all existing tests pass before starting
-- [ ] [setup] Create `works/iterative/claude/core/log/parsing/` directory structure
+- [x] [setup] Verify all existing tests pass before starting
+- [x] [setup] Create `works/iterative/claude/core/log/parsing/` directory structure
 
 ## Tests — Entry Points
 
-- [ ] [test] Write ConversationLogParserTest: parseLogLine with valid JSONL line returns Some(ConversationLogEntry)
-- [ ] [test] Write ConversationLogParserTest: parseLogLine with empty/whitespace line returns None
-- [ ] [test] Write ConversationLogParserTest: parseLogLine with invalid JSON returns None
-- [ ] [test] Write ConversationLogParserTest: parseLogEntry with missing required uuid field returns None
-- [ ] [test] Write ConversationLogParserTest: parseLogEntry with missing required sessionId field returns None
+- [x] [test] Write ConversationLogParserTest: parseLogLine with valid JSONL line returns Some(ConversationLogEntry)
+- [x] [test] Write ConversationLogParserTest: parseLogLine with empty/whitespace line returns None
+- [x] [test] Write ConversationLogParserTest: parseLogLine with invalid JSON returns None
+- [x] [test] Write ConversationLogParserTest: parseLogEntry with missing required uuid field returns None
+- [x] [test] Write ConversationLogParserTest: parseLogEntry with missing required sessionId field returns None
 
 ## Tests — Envelope Metadata
 
-- [ ] [test] Write ConversationLogParserTest: parses all envelope metadata fields (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
-- [ ] [test] Write ConversationLogParserTest: parses with optional fields absent (parentUuid, timestamp, cwd, version)
-- [ ] [test] Write ConversationLogParserTest: parses ISO-8601 timestamp string to Instant
-- [ ] [test] Write ConversationLogParserTest: isSidechain defaults to false when absent
+- [x] [test] Write ConversationLogParserTest: parses all envelope metadata fields (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
+- [x] [test] Write ConversationLogParserTest: parses with optional fields absent (parentUuid, timestamp, cwd, version)
+- [x] [test] Write ConversationLogParserTest: parses ISO-8601 timestamp string to Instant
+- [x] [test] Write ConversationLogParserTest: isSidechain defaults to false when absent
 
 ## Tests — Payload Types
 
-- [ ] [test] Write ConversationLogParserTest: "human" type with string content produces UserLogEntry with List(TextBlock)
-- [ ] [test] Write ConversationLogParserTest: "human" type with array content produces UserLogEntry with parsed content blocks
-- [ ] [test] Write ConversationLogParserTest: "assistant" type with content, model, usage, requestId produces AssistantLogEntry
-- [ ] [test] Write ConversationLogParserTest: "assistant" type with minimal fields (no usage, no model) produces AssistantLogEntry
-- [ ] [test] Write ConversationLogParserTest: "system" type with subtype and data produces SystemLogEntry
-- [ ] [test] Write ConversationLogParserTest: "progress" type with data and parentToolUseId produces ProgressLogEntry
-- [ ] [test] Write ConversationLogParserTest: "queue_operation" type with operation and content produces QueueOperationLogEntry
-- [ ] [test] Write ConversationLogParserTest: "file_history_snapshot" type with data produces FileHistorySnapshotLogEntry
-- [ ] [test] Write ConversationLogParserTest: "last_prompt" type with data produces LastPromptLogEntry
-- [ ] [test] Write ConversationLogParserTest: unknown type produces RawLogEntry with preserved JSON
+- [x] [test] Write ConversationLogParserTest: "human" type with string content produces UserLogEntry with List(TextBlock)
+- [x] [test] Write ConversationLogParserTest: "human" type with array content produces UserLogEntry with parsed content blocks
+- [x] [test] Write ConversationLogParserTest: "assistant" type with content, model, usage, requestId produces AssistantLogEntry
+- [x] [test] Write ConversationLogParserTest: "assistant" type with minimal fields (no usage, no model) produces AssistantLogEntry
+- [x] [test] Write ConversationLogParserTest: "system" type with subtype and data produces SystemLogEntry
+- [x] [test] Write ConversationLogParserTest: "progress" type with data and parentToolUseId produces ProgressLogEntry
+- [x] [test] Write ConversationLogParserTest: "queue_operation" type with operation and content produces QueueOperationLogEntry
+- [x] [test] Write ConversationLogParserTest: "file_history_snapshot" type with data produces FileHistorySnapshotLogEntry
+- [x] [test] Write ConversationLogParserTest: "last_prompt" type with data produces LastPromptLogEntry
+- [x] [test] Write ConversationLogParserTest: unknown type produces RawLogEntry with preserved JSON
 
 ## Tests — TokenUsage
 
-- [ ] [test] Write ConversationLogParserTest: parses full token usage (all fields including cache and service_tier)
-- [ ] [test] Write ConversationLogParserTest: parses minimal token usage (only input_tokens and output_tokens)
+- [x] [test] Write ConversationLogParserTest: parses full token usage (all fields including cache and service_tier)
+- [x] [test] Write ConversationLogParserTest: parses minimal token usage (only input_tokens and output_tokens)
 
 ## Implementation — Core Parser
 
-- [ ] [impl] Create ConversationLogParser object with parseLogLine method (string to JSON delegation)
-- [ ] [impl] Implement parseLogEntry method (JSON to ConversationLogEntry with envelope extraction and type dispatch)
-- [ ] [impl] Implement envelope metadata extraction (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
-- [ ] [impl] Implement ISO-8601 timestamp parsing to Instant
+- [x] [impl] Create ConversationLogParser object with parseLogLine method (string to JSON delegation)
+- [x] [impl] Implement parseLogEntry method (JSON to ConversationLogEntry with envelope extraction and type dispatch)
+- [x] [impl] Implement envelope metadata extraction (uuid, parentUuid, timestamp, sessionId, isSidechain, cwd, version)
+- [x] [impl] Implement ISO-8601 timestamp parsing to Instant
 
 ## Implementation — Payload Parsers
 
-- [ ] [impl] Implement "human" payload parser with string-to-TextBlock and array content handling
-- [ ] [impl] Implement "assistant" payload parser with content blocks, model, usage, requestId
-- [ ] [impl] Implement parseTokenUsage helper for assistant message usage data
-- [ ] [impl] Implement "system" payload parser with subtype and data map extraction
-- [ ] [impl] Implement "progress" payload parser with data map and parentToolUseId
-- [ ] [impl] Implement "queue_operation" payload parser with operation and content
-- [ ] [impl] Implement "file_history_snapshot" payload parser with data map
-- [ ] [impl] Implement "last_prompt" payload parser with data map
-- [ ] [impl] Implement unknown type fallback to RawLogEntry
+- [x] [impl] Implement "human" payload parser with string-to-TextBlock and array content handling
+- [x] [impl] Implement "assistant" payload parser with content blocks, model, usage, requestId
+- [x] [impl] Implement parseTokenUsage helper for assistant message usage data
+- [x] [impl] Implement "system" payload parser with subtype and data map extraction
+- [x] [impl] Implement "progress" payload parser with data map and parentToolUseId
+- [x] [impl] Implement "queue_operation" payload parser with operation and content
+- [x] [impl] Implement "file_history_snapshot" payload parser with data map
+- [x] [impl] Implement "last_prompt" payload parser with data map
+- [x] [impl] Implement unknown type fallback to RawLogEntry
 
 ## Integration
 
-- [ ] [verify] All new ConversationLogParserTest tests pass
-- [ ] [verify] All existing tests pass (JsonParser, ContentBlockParser, LogModel, ContentBlock)
-- [ ] [verify] No compilation warnings
-- [ ] [verify] PURPOSE headers present on new files
+- [x] [verify] All new ConversationLogParserTest tests pass
+- [x] [verify] All existing tests pass (JsonParser, ContentBlockParser, LogModel, ContentBlock)
+- [x] [verify] No compilation warnings
+- [x] [verify] PURPOSE headers present on new files
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-04-context.md
+++ b/project-management/issues/CC-4/phase-04-context.md
@@ -1,0 +1,82 @@
+# Phase 4: Service traits
+
+## Goals
+
+Define `ConversationLogIndex` and `ConversationLogReader` as abstract trait contracts in `core.log`, establishing the interface that Phase 5 implementations (direct and effectful) will satisfy.
+
+## Scope
+
+### In Scope
+
+1. `ConversationLogIndex` trait in `works.iterative.claude.core.log` — session discovery:
+   - `listSessions(projectPath: os.Path): F[Seq[LogFileMetadata]]` — all sessions for a project directory
+   - `forSession(projectPath: os.Path, sessionId: String): F[Option[LogFileMetadata]]` — find a specific session
+
+2. `ConversationLogReader` trait in `works.iterative.claude.core.log` — log file reading:
+   - `readAll(path: os.Path): F[List[ConversationLogEntry]]` — load all entries from a log file
+   - `stream(path: os.Path): S` — streaming read, where `S` is a type member (each implementation provides its own stream type)
+
+3. Both traits use `os.Path` throughout since `LogFileMetadata.path` is already `os.Path`; the effectful implementation can adapt internally.
+
+### Out of Scope
+
+- Implementations (Phase 5)
+- File I/O
+- Filesystem discovery logic
+
+## Dependencies
+
+- **Phase 1**: `ConversationLogEntry`, `LogFileMetadata`
+- No external library dependencies beyond what is already imported
+
+## Approach
+
+Follow the existing codebase pattern: `direct.ClaudeCode` and `effectful.ClaudeCode` are independent implementations with no shared abstract base. Apply the same pattern here — define the traits with a higher-kinded effect type parameter `F[_]` so both styles can implement them cleanly:
+
+```scala
+trait ConversationLogIndex[F[_]]:
+  def listSessions(projectPath: os.Path): F[Seq[LogFileMetadata]]
+  def forSession(projectPath: os.Path, sessionId: String): F[Option[LogFileMetadata]]
+```
+
+For `ConversationLogReader`, the streaming return type differs fundamentally between direct (`ox.flow.Flow`) and effectful (`fs2.Stream[IO, _]`), so use a type member for the stream type alongside `F[_]`:
+
+```scala
+trait ConversationLogReader[F[_]]:
+  type EntryStream
+  def readAll(path: os.Path): F[List[ConversationLogEntry]]
+  def stream(path: os.Path): EntryStream
+```
+
+This keeps the traits in `core` free of direct/effectful dependencies while giving implementations full control over their stream type.
+
+## Files to Create/Modify
+
+### New Files
+
+- `works/iterative/claude/core/log/ConversationLogIndex.scala` — index/discovery trait
+- `works/iterative/claude/core/log/ConversationLogReader.scala` — reader trait
+
+### Modified Files
+
+- None
+
+## Testing Strategy
+
+Traits are abstract contracts with no logic to test directly. Tests for this phase verify:
+
+- The traits compile with the expected method signatures
+- A minimal anonymous implementation compiles for both `F = [A] =>> A` (identity/direct) and `F = cats.effect.IO` (effectful)
+
+These are compilation-only tests, placed in a single test file:
+- `test/works/iterative/claude/core/log/ServiceTraitTest.scala`
+
+## Acceptance Criteria
+
+1. `ConversationLogIndex[F[_]]` exists in `works.iterative.claude.core.log` with `listSessions` and `forSession`
+2. `ConversationLogReader[F[_]]` exists in `works.iterative.claude.core.log` with `readAll` and `stream` (using an `EntryStream` type member)
+3. Both traits use `os.Path` and reference `LogFileMetadata` / `ConversationLogEntry` from `core.log.model`
+4. Compilation test confirms both traits can be implemented with identity `F` (direct style) and `IO` (effectful style)
+5. All existing tests still pass
+6. Both files have PURPOSE headers
+7. No compilation warnings

--- a/project-management/issues/CC-4/phase-04-tasks.md
+++ b/project-management/issues/CC-4/phase-04-tasks.md
@@ -2,21 +2,23 @@
 
 ## Setup
 
-- [ ] [setup] Create source files with package declarations and PURPOSE headers
+- [x] [setup] Create source files with package declarations and PURPOSE headers
 
 ## Tests
 
-- [ ] [test] Write compilation test for `ConversationLogIndex` with identity `F` (direct style)
-- [ ] [test] Write compilation test for `ConversationLogIndex` with `IO` (effectful style)
-- [ ] [test] Write compilation test for `ConversationLogReader` with identity `F` and `List` stream type
-- [ ] [test] Write compilation test for `ConversationLogReader` with `IO` and `fs2.Stream` stream type
+- [x] [test] Write compilation test for `ConversationLogIndex` with identity `F` (direct style)
+- [x] [test] Write compilation test for `ConversationLogIndex` with `IO` (effectful style)
+- [x] [test] Write compilation test for `ConversationLogReader` with identity `F` and `List` stream type
+- [x] [test] Write compilation test for `ConversationLogReader` with `IO` and `fs2.Stream` stream type
 
 ## Implementation
 
-- [ ] [impl] Define `ConversationLogIndex[F[_]]` trait with `listSessions` and `forSession`
-- [ ] [impl] Define `ConversationLogReader[F[_]]` trait with `readAll` and `stream` (EntryStream type member)
+- [x] [impl] Define `ConversationLogIndex[F[_]]` trait with `listSessions` and `forSession`
+- [x] [impl] Define `ConversationLogReader[F[_]]` trait with `readAll` and `stream` (EntryStream type member)
 
 ## Verification
 
-- [ ] [verify] Run all existing tests to confirm no regressions
-- [ ] [verify] Confirm no compilation warnings
+- [x] [verify] Run all existing tests to confirm no regressions
+- [x] [verify] Confirm no compilation warnings
+
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-04-tasks.md
+++ b/project-management/issues/CC-4/phase-04-tasks.md
@@ -1,0 +1,22 @@
+# Phase 4 Tasks: Service traits
+
+## Setup
+
+- [ ] [setup] Create source files with package declarations and PURPOSE headers
+
+## Tests
+
+- [ ] [test] Write compilation test for `ConversationLogIndex` with identity `F` (direct style)
+- [ ] [test] Write compilation test for `ConversationLogIndex` with `IO` (effectful style)
+- [ ] [test] Write compilation test for `ConversationLogReader` with identity `F` and `List` stream type
+- [ ] [test] Write compilation test for `ConversationLogReader` with `IO` and `fs2.Stream` stream type
+
+## Implementation
+
+- [ ] [impl] Define `ConversationLogIndex[F[_]]` trait with `listSessions` and `forSession`
+- [ ] [impl] Define `ConversationLogReader[F[_]]` trait with `readAll` and `stream` (EntryStream type member)
+
+## Verification
+
+- [ ] [verify] Run all existing tests to confirm no regressions
+- [ ] [verify] Confirm no compilation warnings

--- a/project-management/issues/CC-4/phase-05-context.md
+++ b/project-management/issues/CC-4/phase-05-context.md
@@ -1,0 +1,141 @@
+# Phase 5: Service implementations
+
+## Goals
+
+Implement `ConversationLogIndex` and `ConversationLogReader` in both `direct.log` and `effectful.log` packages. The direct implementations use os-lib for file I/O and Ox `Flow` for streaming. The effectful implementations use fs2.io.file for discovery and fs2.Stream for streaming. Both delegate to the pure `ConversationLogParser` for actual line parsing.
+
+A key part of this phase is path decoding: the `~/.claude/projects/` directory structure uses path-encoded directory names (e.g., `-home-mph-Devel` for `/home/mph/Devel`). Both implementations must decode these paths to populate `LogFileMetadata.cwd`.
+
+## Scope
+
+### In Scope
+
+1. **Direct `ConversationLogIndex`** (`works.iterative.claude.direct.log.DirectConversationLogIndex`):
+   - Implements `ConversationLogIndex[[A] =>> A]` (identity effect)
+   - Uses `os.list` / `os.walk` to find `.jsonl` files under a project path
+   - Extracts `sessionId` from filename (filename minus `.jsonl` extension)
+   - Populates `LogFileMetadata` with file stats (`os.stat`) and decoded `cwd` from path
+   - `listSessions`: lists all `.jsonl` files in the project path
+   - `forSession`: finds a specific session file by `sessionId`
+
+2. **Direct `ConversationLogReader`** (`works.iterative.claude.direct.log.DirectConversationLogReader`):
+   - Implements `ConversationLogReader[[A] =>> A]` with `EntryStream = ox.flow.Flow[ConversationLogEntry]`
+   - `readAll`: reads all lines with `os.read.lines`, parses each with `ConversationLogParser.parseLogLine`, collects results
+   - `stream`: returns an `ox.flow.Flow[ConversationLogEntry]` that reads lines lazily
+
+3. **Effectful `ConversationLogIndex`** (`works.iterative.claude.effectful.log.EffectfulConversationLogIndex`):
+   - Implements `ConversationLogIndex[IO]`
+   - Uses `fs2.io.file.Files[IO]` for directory listing
+   - Same discovery logic as direct but wrapped in `IO`
+
+4. **Effectful `ConversationLogReader`** (`works.iterative.claude.effectful.log.EffectfulConversationLogReader`):
+   - Implements `ConversationLogReader[IO]` with `EntryStream = fs2.Stream[IO, ConversationLogEntry]`
+   - `readAll`: reads file, parses lines, collects to `List` in `IO`
+   - `stream`: returns `fs2.Stream[IO, ConversationLogEntry]` using fs2 text pipeline
+
+5. **Path decoding utility** — shared pure function to decode project directory names back to filesystem paths (e.g., `-home-mph-Devel` → `/home/mph/Devel`). This should live in `core.log` since both implementations need it.
+
+### Out of Scope
+
+- Re-exports (Phase 6)
+- Documentation updates (Phase 6)
+- Reading metadata from inside log files (summary, gitBranch, etc. — only file-level metadata from stat and path for now)
+- Cross-project discovery (scanning all subdirectories of `~/.claude/projects/` to list sessions across all projects) — the current trait API requires a `projectPath` argument; cross-project enumeration can be added later as a higher-level utility
+
+## Dependencies
+
+- **Phase 1**: `ConversationLogEntry`, `LogFileMetadata`, all payload types
+- **Phase 3**: `ConversationLogParser.parseLogLine` for pure parsing
+- **Phase 4**: `ConversationLogIndex[F[_]]`, `ConversationLogReader[F[_]]` trait contracts
+- **Libraries**: os-lib (file I/O), ox (Flow for direct streaming), cats-effect IO, fs2 (Stream + io.file for effectful)
+
+## Approach
+
+### Path Decoding
+
+The `~/.claude/projects/` directory contains subdirectories with encoded paths. The encoding replaces `/` with `-` in the absolute path. For example:
+- Directory name `-home-mph-Devel-projects-foo` → `/home/mph/Devel/projects/foo`
+
+The encoding is ambiguous because path segments themselves can contain `-` (e.g., `-home-mph-my-project` could be `/home/mph/my-project` or `/home/mph/my/project`).
+
+**Decision:** `ProjectPathDecoder` in `core.log` is a pure utility that stores the raw encoded directory name as-is in `LogFileMetadata.cwd`. It also provides a best-effort `decode(dirName: String): String` method that replaces leading `-` with `/` and subsequent `-` with `/` — this gives a plausible path that callers can verify against the filesystem if they need accuracy. The `cwd` field in `LogFileMetadata` stores this best-effort decoded string. No filesystem validation is done inside the decoder — it's a pure function.
+
+### Direct Implementation Pattern
+
+Follow the pattern from `direct.ClaudeCode`:
+- Plain classes/objects, no effect wrappers
+- Direct os-lib calls for file I/O
+- Ox `Flow` for streaming (lazy line-by-line processing)
+- `given Ox` context for Flow operations if needed
+
+### Effectful Implementation Pattern
+
+Follow the pattern from `effectful.ClaudeCode`:
+- Wrap file operations in `IO`
+- Use `fs2.io.file.Files[IO]` for directory listing and file reading
+- Convert `os.Path` to `java.nio.file.Path` via `.toNIO` for fs2 compatibility
+- Use `fs2.Stream` text processing pipeline for line-by-line parsing
+- Return `IO[...]` for non-streaming operations
+
+### LogFileMetadata Population
+
+From file-level information only (no file content parsing):
+- `path`: the `.jsonl` file path
+- `sessionId`: filename without `.jsonl` extension
+- `lastModified`: from file stat
+- `fileSize`: from file stat
+- `cwd`: decoded from parent directory name (best-effort)
+- `summary`, `gitBranch`, `createdAt`: `None` (would require reading file contents)
+
+## Files to Create/Modify
+
+### New Files
+
+- `works/iterative/claude/core/log/ProjectPathDecoder.scala` — pure path decoding utility
+- `works/iterative/claude/direct/log/DirectConversationLogIndex.scala` — direct index implementation
+- `works/iterative/claude/direct/log/DirectConversationLogReader.scala` — direct reader implementation
+- `works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala` — effectful index implementation
+- `works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala` — effectful reader implementation
+
+### Test Files
+
+- `test/works/iterative/claude/core/log/ProjectPathDecoderTest.scala` — path decoding tests
+- `test/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala` — direct index integration tests
+- `test/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala` — direct reader integration tests
+- `test/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala` — effectful index integration tests
+- `test/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala` — effectful reader integration tests
+
+### Modified Files
+
+- None expected
+
+## Testing Strategy
+
+### Unit Tests
+
+- `ProjectPathDecoder`: test various directory name patterns, edge cases (root path, single segment, empty)
+
+### Integration Tests
+
+All service tests use real file I/O with temporary directories:
+
+- **Index tests**: Create temp directory structure mimicking `~/.claude/projects/`, populate with `.jsonl` files, verify `listSessions` finds them and `forSession` returns the right one
+- **Reader tests**: Create temp `.jsonl` files with known content (representative log entries), verify `readAll` returns correctly parsed entries and `stream` produces the same results lazily
+- Both direct and effectful implementations tested against the same scenarios
+
+### Test Data
+
+- Small `.jsonl` test files with representative entries (user, assistant, system, progress)
+- Reuse entry JSON patterns from Phase 3 `ConversationLogParserTest`
+
+## Acceptance Criteria
+
+1. `DirectConversationLogIndex` lists and finds session files using os-lib
+2. `DirectConversationLogReader` reads and streams log entries using os-lib + Ox Flow
+3. `EffectfulConversationLogIndex` lists and finds session files using fs2.io.file
+4. `EffectfulConversationLogReader` reads and streams log entries using fs2.Stream
+5. `ProjectPathDecoder` correctly decodes project directory names to paths
+6. All implementations pass integration tests with real temporary files
+7. All existing tests still pass
+8. All files have PURPOSE headers
+9. No compilation warnings

--- a/project-management/issues/CC-4/phase-05-tasks.md
+++ b/project-management/issues/CC-4/phase-05-tasks.md
@@ -1,0 +1,27 @@
+# Phase 5 Tasks: Service implementations
+
+## Setup
+
+- [ ] [setup] Create directory structure for `direct/log/` and `effectful/log/` packages
+- [ ] [setup] Create directory structure for test files under `test/works/iterative/claude/direct/log/` and `test/works/iterative/claude/effectful/log/`
+
+## Tests First
+
+- [ ] [test] Write `ProjectPathDecoderTest` — test decoding of encoded project directory names to filesystem paths (various patterns, edge cases, empty/root)
+- [ ] [test] Write `DirectConversationLogIndexTest` — integration tests with temp directory structure containing `.jsonl` files; test `listSessions` and `forSession`
+- [ ] [test] Write `DirectConversationLogReaderTest` — integration tests with temp `.jsonl` files containing representative log entries; test `readAll` and `stream`
+- [ ] [test] Write `EffectfulConversationLogIndexTest` — same scenarios as direct index but using `munit-cats-effect` for IO-based assertions
+- [ ] [test] Write `EffectfulConversationLogReaderTest` — same scenarios as direct reader but using `munit-cats-effect` for IO-based and stream-based assertions
+
+## Implementation
+
+- [ ] [impl] Implement `ProjectPathDecoder` in `core.log` — pure function to decode project directory names to best-effort filesystem path strings
+- [ ] [impl] Implement `DirectConversationLogIndex` in `direct.log` — os-lib file discovery implementing `ConversationLogIndex[[A] =>> A]`
+- [ ] [impl] Implement `DirectConversationLogReader` in `direct.log` — os-lib + Ox Flow implementing `ConversationLogReader[[A] =>> A]` with `EntryStream = ox.flow.Flow[ConversationLogEntry]`
+- [ ] [impl] Implement `EffectfulConversationLogIndex` in `effectful.log` — fs2.io.file implementing `ConversationLogIndex[IO]`
+- [ ] [impl] Implement `EffectfulConversationLogReader` in `effectful.log` — fs2.Stream implementing `ConversationLogReader[IO]` with `EntryStream = fs2.Stream[IO, ConversationLogEntry]`
+
+## Integration
+
+- [ ] [integration] Verify all existing tests still pass after adding new implementations
+- [ ] [integration] Verify no compilation warnings

--- a/project-management/issues/CC-4/phase-05-tasks.md
+++ b/project-management/issues/CC-4/phase-05-tasks.md
@@ -2,26 +2,27 @@
 
 ## Setup
 
-- [ ] [setup] Create directory structure for `direct/log/` and `effectful/log/` packages
-- [ ] [setup] Create directory structure for test files under `test/works/iterative/claude/direct/log/` and `test/works/iterative/claude/effectful/log/`
+- [x] [setup] Create directory structure for `direct/log/` and `effectful/log/` packages
+- [x] [setup] Create directory structure for test files under `test/works/iterative/claude/direct/log/` and `test/works/iterative/claude/effectful/log/`
 
 ## Tests First
 
-- [ ] [test] Write `ProjectPathDecoderTest` — test decoding of encoded project directory names to filesystem paths (various patterns, edge cases, empty/root)
-- [ ] [test] Write `DirectConversationLogIndexTest` — integration tests with temp directory structure containing `.jsonl` files; test `listSessions` and `forSession`
-- [ ] [test] Write `DirectConversationLogReaderTest` — integration tests with temp `.jsonl` files containing representative log entries; test `readAll` and `stream`
-- [ ] [test] Write `EffectfulConversationLogIndexTest` — same scenarios as direct index but using `munit-cats-effect` for IO-based assertions
-- [ ] [test] Write `EffectfulConversationLogReaderTest` — same scenarios as direct reader but using `munit-cats-effect` for IO-based and stream-based assertions
+- [x] [test] Write `ProjectPathDecoderTest` — test decoding of encoded project directory names to filesystem paths (various patterns, edge cases, empty/root)
+- [x] [test] Write `DirectConversationLogIndexTest` — integration tests with temp directory structure containing `.jsonl` files; test `listSessions` and `forSession`
+- [x] [test] Write `DirectConversationLogReaderTest` — integration tests with temp `.jsonl` files containing representative log entries; test `readAll` and `stream`
+- [x] [test] Write `EffectfulConversationLogIndexTest` — same scenarios as direct index but using `munit-cats-effect` for IO-based assertions
+- [x] [test] Write `EffectfulConversationLogReaderTest` — same scenarios as direct reader but using `munit-cats-effect` for IO-based and stream-based assertions
 
 ## Implementation
 
-- [ ] [impl] Implement `ProjectPathDecoder` in `core.log` — pure function to decode project directory names to best-effort filesystem path strings
-- [ ] [impl] Implement `DirectConversationLogIndex` in `direct.log` — os-lib file discovery implementing `ConversationLogIndex[[A] =>> A]`
-- [ ] [impl] Implement `DirectConversationLogReader` in `direct.log` — os-lib + Ox Flow implementing `ConversationLogReader[[A] =>> A]` with `EntryStream = ox.flow.Flow[ConversationLogEntry]`
-- [ ] [impl] Implement `EffectfulConversationLogIndex` in `effectful.log` — fs2.io.file implementing `ConversationLogIndex[IO]`
-- [ ] [impl] Implement `EffectfulConversationLogReader` in `effectful.log` — fs2.Stream implementing `ConversationLogReader[IO]` with `EntryStream = fs2.Stream[IO, ConversationLogEntry]`
+- [x] [impl] Implement `ProjectPathDecoder` in `core.log` — pure function to decode project directory names to best-effort filesystem path strings
+- [x] [impl] Implement `DirectConversationLogIndex` in `direct.log` — os-lib file discovery implementing `ConversationLogIndex[[A] =>> A]`
+- [x] [impl] Implement `DirectConversationLogReader` in `direct.log` — os-lib + Ox Flow implementing `ConversationLogReader[[A] =>> A]` with `EntryStream = ox.flow.Flow[ConversationLogEntry]`
+- [x] [impl] Implement `EffectfulConversationLogIndex` in `effectful.log` — fs2.io.file implementing `ConversationLogIndex[IO]`
+- [x] [impl] Implement `EffectfulConversationLogReader` in `effectful.log` — fs2.Stream implementing `ConversationLogReader[IO]` with `EntryStream = fs2.Stream[IO, ConversationLogEntry]`
 
 ## Integration
 
-- [ ] [integration] Verify all existing tests still pass after adding new implementations
-- [ ] [integration] Verify no compilation warnings
+- [x] [integration] Verify all existing tests still pass after adding new implementations
+- [x] [integration] Verify no compilation warnings
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-06-context.md
+++ b/project-management/issues/CC-4/phase-06-context.md
@@ -1,0 +1,89 @@
+# Phase 6: Re-exports and documentation
+
+## Goals
+
+Complete the public API surface for conversation log parsing by:
+1. Adding re-exports for new log-related types to the `direct` package object
+2. Creating a new `effectful` package object with re-exports for both existing and new types
+3. Updating ARCHITECTURE.md with the conversation log parsing architecture
+4. Updating README.md with log parsing usage examples
+
+## Scope
+
+### In Scope
+- Add `ThinkingBlock`, `RedactedThinkingBlock` re-exports to `direct/package.scala`
+- Add log model type re-exports (`ConversationLogEntry`, `LogEntryPayload` variants, `TokenUsage`, `LogFileMetadata`) to `direct/package.scala`
+- Add log service re-exports (`ConversationLogIndex`, `ConversationLogReader`) and direct implementations to `direct/package.scala`
+- Create `effectful/package.scala` mirroring direct's pattern, including both existing types and new log types, plus effectful implementations
+- Update ARCHITECTURE.md with a new section covering log parsing architecture (domain types, parsing, service traits, implementations)
+- Update README.md with log file reading examples for both direct and effectful APIs
+
+### Out of Scope
+- No new functionality — only re-exporting and documenting what was built in Phases 1-5
+- No changes to implementation code
+
+## Dependencies on Prior Phases
+
+- **Phase 1** (Domain types): `ThinkingBlock`, `RedactedThinkingBlock`, `ConversationLogEntry`, `LogEntryPayload` variants, `TokenUsage`, `LogFileMetadata`
+- **Phase 2** (Content block parsing): `ContentBlockParser` (internal, not re-exported)
+- **Phase 3** (Log parser): `ConversationLogParser` (internal, not re-exported)
+- **Phase 4** (Service traits): `ConversationLogIndex`, `ConversationLogReader`
+- **Phase 5** (Implementations): `DirectConversationLogIndex`, `DirectConversationLogReader`, `EffectfulConversationLogIndex`, `EffectfulConversationLogReader`, `ProjectPathDecoder`
+
+## Approach
+
+### Re-exports Strategy
+
+Follow the existing pattern in `direct/package.scala`: type alias + val re-export for case classes/objects, type alias only for traits/sealed traits.
+
+**Types to add to `direct/package.scala`:**
+- ContentBlock variants: `ThinkingBlock`, `RedactedThinkingBlock`
+- Log model: `ConversationLogEntry`, `LogEntryPayload`, `UserLogEntry`, `AssistantLogEntry`, `SystemLogEntry`, `ProgressLogEntry`, `QueueOperationLogEntry`, `FileHistorySnapshotLogEntry`, `LastPromptLogEntry`, `RawLogEntry`, `TokenUsage`, `LogFileMetadata`
+- Service traits: `ConversationLogIndex`, `ConversationLogReader`
+- Direct implementations: `DirectConversationLogIndex`, `DirectConversationLogReader`
+- Utility: `ProjectPathDecoder`
+
+**Create `effectful/package.scala`:**
+- Mirror all existing direct re-exports (QueryOptions, Message types, ContentBlock types, PermissionMode)
+- Add all log-related re-exports (same as direct)
+- Add effectful implementations: `EffectfulConversationLogIndex`, `EffectfulConversationLogReader`
+
+### Documentation Strategy
+
+**ARCHITECTURE.md additions:**
+- New "Conversation Log Parsing" section covering:
+  - Log file format overview (JSONL envelope + typed payloads)
+  - Domain model (`ConversationLogEntry`, `LogEntryPayload` hierarchy)
+  - Parsing layer (`ContentBlockParser`, `ConversationLogParser`)
+  - Service layer (traits + dual implementations)
+  - `ProjectPathDecoder` for path-encoded directory names
+- Update ContentBlock hierarchy diagram to include `ThinkingBlock` and `RedactedThinkingBlock`
+
+**README.md additions:**
+- New section "Conversation Log Parsing" with usage examples:
+  - Listing available sessions
+  - Reading log entries from a session
+  - Accessing thinking blocks
+  - Both direct and effectful examples
+
+## Files to Modify
+
+1. `works/iterative/claude/direct/package.scala` — add re-exports
+2. `works/iterative/claude/effectful/package.scala` — create with full re-exports (NEW)
+3. `ARCHITECTURE.md` — add log parsing architecture section
+4. `README.md` — add log parsing usage examples
+
+## Testing Strategy
+
+- **Compilation test**: Verify that importing `works.iterative.claude.direct.*` and `works.iterative.claude.effectful.*` provides access to all new types
+- **Existing tests**: All existing tests must continue to pass
+- No new runtime tests needed — this phase is purely re-exports and documentation
+
+## Acceptance Criteria
+
+- [ ] `import works.iterative.claude.direct.*` gives access to all log-related types and direct implementations
+- [ ] `import works.iterative.claude.effectful.*` gives access to all types and effectful implementations
+- [ ] ARCHITECTURE.md documents the conversation log parsing architecture
+- [ ] README.md includes usage examples for log parsing
+- [ ] All existing tests pass
+- [ ] Compilation succeeds with no new warnings

--- a/project-management/issues/CC-4/phase-06-tasks.md
+++ b/project-management/issues/CC-4/phase-06-tasks.md
@@ -2,30 +2,31 @@
 
 ## Setup
 
-- [ ] [setup] Read current `direct/package.scala` and verify existing re-export pattern
-- [ ] [setup] Inventory all public types from Phases 1-5 that need re-exporting
+- [x] [setup] Read current `direct/package.scala` and verify existing re-export pattern
+- [x] [setup] Inventory all public types from Phases 1-5 that need re-exporting
 
 ## Tests
 
-- [ ] [test] Write compilation test verifying `import works.iterative.claude.direct.*` provides access to all new types (ThinkingBlock, RedactedThinkingBlock, ConversationLogEntry, LogEntryPayload variants, TokenUsage, LogFileMetadata, service traits, direct implementations)
-- [ ] [test] Write compilation test verifying `import works.iterative.claude.effectful.*` provides access to all types and effectful implementations
-- [ ] [test] Verify all existing tests still pass after re-export changes
+- [x] [test] Write compilation test verifying `import works.iterative.claude.direct.*` provides access to all new types (ThinkingBlock, RedactedThinkingBlock, ConversationLogEntry, LogEntryPayload variants, TokenUsage, LogFileMetadata, service traits, direct implementations)
+- [x] [test] Write compilation test verifying `import works.iterative.claude.effectful.*` provides access to all types and effectful implementations
+- [x] [test] Verify all existing tests still pass after re-export changes
 
 ## Implementation
 
-- [ ] [impl] Add ContentBlock variant re-exports to `direct/package.scala` (ThinkingBlock, RedactedThinkingBlock)
-- [ ] [impl] Add log model type re-exports to `direct/package.scala` (ConversationLogEntry, LogEntryPayload, all payload variants, TokenUsage, LogFileMetadata)
-- [ ] [impl] Add service trait and direct implementation re-exports to `direct/package.scala` (ConversationLogIndex, ConversationLogReader, DirectConversationLogIndex, DirectConversationLogReader, ProjectPathDecoder)
-- [ ] [impl] Create `effectful/package.scala` with existing type re-exports (QueryOptions, Message types, ContentBlock types, PermissionMode) mirroring direct pattern
-- [ ] [impl] Add all log-related re-exports to `effectful/package.scala` (same types as direct plus EffectfulConversationLogIndex, EffectfulConversationLogReader)
+- [x] [impl] Add ContentBlock variant re-exports to `direct/package.scala` (ThinkingBlock, RedactedThinkingBlock)
+- [x] [impl] Add log model type re-exports to `direct/package.scala` (ConversationLogEntry, LogEntryPayload, all payload variants, TokenUsage, LogFileMetadata)
+- [x] [impl] Add service trait and direct implementation re-exports to `direct/package.scala` (ConversationLogIndex, ConversationLogReader, DirectConversationLogIndex, DirectConversationLogReader, ProjectPathDecoder)
+- [x] [impl] Create `effectful/package.scala` with existing type re-exports (QueryOptions, Message types, ContentBlock types, PermissionMode) mirroring direct pattern
+- [x] [impl] Add all log-related re-exports to `effectful/package.scala` (same types as direct plus EffectfulConversationLogIndex, EffectfulConversationLogReader)
 
 ## Documentation
 
-- [ ] [docs] Update ARCHITECTURE.md with conversation log parsing section (domain model, parsing layer, service layer, dual implementations)
-- [ ] [docs] Update ContentBlock hierarchy diagram in ARCHITECTURE.md to include ThinkingBlock and RedactedThinkingBlock
-- [ ] [docs] Update README.md with conversation log parsing usage examples (listing sessions, reading entries, direct and effectful examples)
+- [x] [docs] Update ARCHITECTURE.md with conversation log parsing section (domain model, parsing layer, service layer, dual implementations)
+- [x] [docs] Update ContentBlock hierarchy diagram in ARCHITECTURE.md to include ThinkingBlock and RedactedThinkingBlock
+- [x] [docs] Update README.md with conversation log parsing usage examples (listing sessions, reading entries, direct and effectful examples)
 
 ## Integration
 
-- [ ] [integration] Run full test suite to verify no regressions
-- [ ] [integration] Verify compilation succeeds with no new warnings
+- [x] [integration] Run full test suite to verify no regressions
+- [x] [integration] Verify compilation succeeds with no new warnings
+**Phase Status:** Complete

--- a/project-management/issues/CC-4/phase-06-tasks.md
+++ b/project-management/issues/CC-4/phase-06-tasks.md
@@ -1,0 +1,31 @@
+# Phase 6 Tasks: Re-exports and documentation
+
+## Setup
+
+- [ ] [setup] Read current `direct/package.scala` and verify existing re-export pattern
+- [ ] [setup] Inventory all public types from Phases 1-5 that need re-exporting
+
+## Tests
+
+- [ ] [test] Write compilation test verifying `import works.iterative.claude.direct.*` provides access to all new types (ThinkingBlock, RedactedThinkingBlock, ConversationLogEntry, LogEntryPayload variants, TokenUsage, LogFileMetadata, service traits, direct implementations)
+- [ ] [test] Write compilation test verifying `import works.iterative.claude.effectful.*` provides access to all types and effectful implementations
+- [ ] [test] Verify all existing tests still pass after re-export changes
+
+## Implementation
+
+- [ ] [impl] Add ContentBlock variant re-exports to `direct/package.scala` (ThinkingBlock, RedactedThinkingBlock)
+- [ ] [impl] Add log model type re-exports to `direct/package.scala` (ConversationLogEntry, LogEntryPayload, all payload variants, TokenUsage, LogFileMetadata)
+- [ ] [impl] Add service trait and direct implementation re-exports to `direct/package.scala` (ConversationLogIndex, ConversationLogReader, DirectConversationLogIndex, DirectConversationLogReader, ProjectPathDecoder)
+- [ ] [impl] Create `effectful/package.scala` with existing type re-exports (QueryOptions, Message types, ContentBlock types, PermissionMode) mirroring direct pattern
+- [ ] [impl] Add all log-related re-exports to `effectful/package.scala` (same types as direct plus EffectfulConversationLogIndex, EffectfulConversationLogReader)
+
+## Documentation
+
+- [ ] [docs] Update ARCHITECTURE.md with conversation log parsing section (domain model, parsing layer, service layer, dual implementations)
+- [ ] [docs] Update ContentBlock hierarchy diagram in ARCHITECTURE.md to include ThinkingBlock and RedactedThinkingBlock
+- [ ] [docs] Update README.md with conversation log parsing usage examples (listing sessions, reading entries, direct and effectful examples)
+
+## Integration
+
+- [ ] [integration] Run full test suite to verify no regressions
+- [ ] [integration] Verify compilation succeeds with no new warnings

--- a/project-management/issues/CC-4/release-notes.md
+++ b/project-management/issues/CC-4/release-notes.md
@@ -1,0 +1,10 @@
+# Podpora čtení konverzačních logů Claude Code
+
+**Issue:** CC-4
+**Datum:** 2026-03-25
+
+SDK nyní umožňuje číst a analyzovat kompletní konverzační logy, které Claude Code ukládá ve formátu JSONL v adresáři `~/.claude/projects/`. Díky tomu mohou externí nástroje přistupovat k datům, která nejsou dostupná přes streamovací rozhraní — zejména k obsahu rozšířeného myšlení (thinking blocks), detailním informacím o spotřebě tokenů a kompletní struktuře konverzací včetně větvení.
+
+Nové rozhraní poskytuje dva hlavní způsoby práce s logy. Služba pro indexování logů umožňuje procházet dostupné konverzační soubory, filtrovat je podle projektu a vyhledávat konkrétní relace podle jejich identifikátoru. Služba pro čtení logů pak zpracovává jednotlivé soubory a vrací proud typovaných záznamů — uživatelské zprávy, odpovědi asistenta s informacemi o použitém modelu a spotřebě, systémové události, záznamy o průběhu a další typy.
+
+Obě služby jsou k dispozici ve dvou variantách podle stávajícího vzoru SDK: synchronní varianta využívající Ox a přímé I/O operace, a efektová varianta postavená na cats-effect a fs2 pro funkcionální reaktivní zpracování. Uživatelé si tak mohou zvolit přístup, který odpovídá architektuře jejich aplikace.

--- a/project-management/issues/CC-4/review-packet.md
+++ b/project-management/issues/CC-4/review-packet.md
@@ -1,0 +1,319 @@
+---
+generated_from: e30fdfc3dc582b4fdf59c81077f21071f80ecc3e
+generated_at: 2026-03-25T12:26:14Z
+branch: CC-4
+issue_id: CC-4
+phase: "6 (complete)"
+files_analyzed:
+  - works/iterative/claude/core/model/ContentBlock.scala
+  - works/iterative/claude/core/log/model/ConversationLogEntry.scala
+  - works/iterative/claude/core/log/model/LogEntryPayload.scala
+  - works/iterative/claude/core/log/model/TokenUsage.scala
+  - works/iterative/claude/core/log/model/LogFileMetadata.scala
+  - works/iterative/claude/core/parsing/ContentBlockParser.scala
+  - works/iterative/claude/core/parsing/JsonParser.scala
+  - works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+  - works/iterative/claude/core/log/ConversationLogIndex.scala
+  - works/iterative/claude/core/log/ConversationLogReader.scala
+  - works/iterative/claude/core/log/LogFileMetadataBuilder.scala
+  - works/iterative/claude/core/log/ProjectPathDecoder.scala
+  - works/iterative/claude/direct/log/DirectConversationLogIndex.scala
+  - works/iterative/claude/direct/log/DirectConversationLogReader.scala
+  - works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala
+  - works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala
+  - works/iterative/claude/direct/package.scala
+  - works/iterative/claude/effectful/package.scala
+  - ARCHITECTURE.md
+  - README.md
+---
+
+# Review Packet: CC-4 — Conversation Log Parsing
+
+## Goals
+
+This feature adds conversation log parsing support to the Scala Claude Code SDK, enabling programmatic access to the full content of `.jsonl` session files stored in `~/.claude/projects/`.
+
+The existing SDK only parses real-time CLI stream output (`--output-format stream-json`). That format lacks thinking blocks entirely, and omits per-message token usage, message threading metadata, and sidechain information. Log files are the only source of this data.
+
+Key objectives:
+
+- Provide typed domain types for every known log entry kind, with a `RawLogEntry` fallback for unknown/future types so callers can detect forward-incompatibility rather than silently losing data.
+- Extend `ContentBlock` with `ThinkingBlock` and `RedactedThinkingBlock` (shared between stream and log parsing).
+- Extract shared content block parsing into `ContentBlockParser` so neither the stream parser nor the log parser depends on the other.
+- Expose two parameterised service traits — `ConversationLogIndex` (discover sessions) and `ConversationLogReader` (parse entries) — with both direct-style (Ox / identity functor) and effectful (cats-effect IO / fs2) implementations.
+- Make the full API available via a single import from either `works.iterative.claude.direct.*` or `works.iterative.claude.effectful.*`.
+
+
+## Scenarios
+
+- [ ] A caller using the direct API can list all `.jsonl` session files in a given project directory
+- [ ] A caller using the effectful API can list sessions within an `IO` program
+- [ ] `forSession` returns `Some(metadata)` when the session file exists and `None` otherwise
+- [ ] A directory name like `-home-mph-Devel-myproject` is decoded to `/home/mph/Devel/myproject` and surfaced as `cwd` in `LogFileMetadata`
+- [ ] Non-`.jsonl` files in a project directory are ignored by the index
+- [ ] `readAll` parses a `.jsonl` file and returns a typed `List[ConversationLogEntry]`
+- [ ] `stream` (direct: `Flow`, effectful: `fs2.Stream`) yields entries lazily without loading the whole file
+- [ ] Empty and whitespace-only lines in a log file are silently skipped
+- [ ] Malformed JSON lines are silently skipped
+- [ ] A `human` log line is parsed into `UserLogEntry` with `List[ContentBlock]` content (supports both string and array `content` fields)
+- [ ] An `assistant` log line is parsed into `AssistantLogEntry` with model, token usage, and requestId
+- [ ] `TokenUsage` includes optional cache token counts and service tier
+- [ ] A `system` line is parsed into `SystemLogEntry(subtype, data)`
+- [ ] A `progress` line is parsed into `ProgressLogEntry` with optional `parentToolUseId`
+- [ ] A `queue_operation` line becomes `QueueOperationLogEntry`
+- [ ] `file_history_snapshot` and `last_prompt` entries are parsed into their respective types
+- [ ] An unknown entry type is wrapped in `RawLogEntry(entryType, json)` rather than dropped
+- [ ] `ThinkingBlock(thinking, signature)` and `RedactedThinkingBlock(data)` are valid `ContentBlock` values
+- [ ] `import works.iterative.claude.direct.*` exposes all new log types and direct implementations
+- [ ] `import works.iterative.claude.effectful.*` exposes all new log types and effectful implementations
+
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `works/iterative/claude/core/log/parsing/ConversationLogParser.scala` | `parseLogLine`, `parseLogEntry` | Core pure parsing logic; all other components delegate here |
+| `works/iterative/claude/core/log/ConversationLogReader.scala` | `ConversationLogReader[F[_]]` | Service trait defining the read contract; entry point to understanding the API shape |
+| `works/iterative/claude/core/log/ConversationLogIndex.scala` | `ConversationLogIndex[F[_]]` | Service trait for session discovery |
+| `works/iterative/claude/core/parsing/ContentBlockParser.scala` | `parseContentBlock` | Shared content block parsing; used by both stream and log parsers |
+| `works/iterative/claude/direct/log/DirectConversationLogIndex.scala` | `DirectConversationLogIndex` | Reference implementation for the synchronous API |
+| `works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala` | `EffectfulConversationLogReader` | Shows how fs2 streaming is wired up for the effectful API |
+| `works/iterative/claude/core/log/LogFileMetadataBuilder.scala` | `fromStat` | Shared metadata construction used by both index implementations |
+| `works/iterative/claude/core/log/ProjectPathDecoder.scala` | `decode` | Path decoding utility — worth reviewing the ambiguity note |
+| `works/iterative/claude/direct/package.scala` | package object | Confirms what the single-import surface looks like for direct users |
+
+
+## Diagrams
+
+### Package Dependency Graph
+
+```
+works.iterative.claude
+│
+├── core.model
+│   └── ContentBlock (sealed: TextBlock, ToolUseBlock, ToolResultBlock,
+│                              ThinkingBlock, RedactedThinkingBlock)   [CC-4: +ThinkingBlock, +RedactedThinkingBlock]
+│
+├── core.parsing
+│   └── ContentBlockParser   [CC-4: extracted from JsonParser; handles 5 block types]
+│       └── depends on: core.model
+│
+├── core.log.model           [CC-4: all new]
+│   ├── ConversationLogEntry (envelope)
+│   ├── LogEntryPayload (sealed: 8 variants)
+│   ├── TokenUsage
+│   └── LogFileMetadata
+│       └── depends on: core.model (ContentBlock)
+│
+├── core.log.parsing         [CC-4: all new]
+│   └── ConversationLogParser
+│       └── depends on: core.log.model, core.parsing.ContentBlockParser
+│
+├── core.log                 [CC-4: all new]
+│   ├── ConversationLogIndex[F[_]]   (trait)
+│   ├── ConversationLogReader[F[_]]  (trait)
+│   ├── LogFileMetadataBuilder       (shared util)
+│   └── ProjectPathDecoder           (pure util)
+│       └── depends on: core.log.model
+│
+├── direct.log               [CC-4: all new]
+│   ├── DirectConversationLogIndex   implements ConversationLogIndex[[A]=>>A]
+│   └── DirectConversationLogReader  implements ConversationLogReader[[A]=>>A]
+│       └── EntryStream = ox.flow.Flow[ConversationLogEntry]
+│
+├── effectful.log            [CC-4: all new]
+│   ├── EffectfulConversationLogIndex   implements ConversationLogIndex[IO]
+│   └── EffectfulConversationLogReader  implements ConversationLogReader[IO]
+│       └── EntryStream = fs2.Stream[IO, ConversationLogEntry]
+│
+├── direct (package object)  [CC-4: extended with log re-exports]
+└── effectful (package object) [CC-4: created; mirrors direct + effectful impls]
+```
+
+### Log Entry Parsing Flow
+
+```
+File on disk  (~/.claude/projects/<encoded-path>/<sessionId>.jsonl)
+      │
+      │  ConversationLogIndex.listSessions / forSession
+      ▼
+LogFileMetadata  (sessionId, path, cwd decoded via ProjectPathDecoder, size, mtime)
+      │
+      │  ConversationLogReader.readAll / stream
+      ▼
+Line-by-line read (os.read.lines / fs2.text.lines)
+      │
+      ▼
+ConversationLogParser.parseLogLine(line: String): Option[ConversationLogEntry]
+      │
+      ├── parse JSON (circe)
+      ├── extract envelope fields (uuid, sessionId, timestamp, isSidechain, ...)
+      └── dispatch on "type" field
+            ├── "human"                  → parseUserPayload    → UserLogEntry
+            ├── "assistant"              → parseAssistantPayload → AssistantLogEntry
+            │     └── usage             → TokenUsage
+            │     └── content blocks    → ContentBlockParser.parseContentBlock
+            ├── "system"                 → SystemLogEntry
+            ├── "progress"               → ProgressLogEntry
+            ├── "queue_operation"        → QueueOperationLogEntry
+            ├── "file_history_snapshot"  → FileHistorySnapshotLogEntry
+            ├── "last_prompt"            → LastPromptLogEntry
+            └── _                        → RawLogEntry (type preserved, raw JSON kept)
+```
+
+### LogEntryPayload Hierarchy
+
+```
+sealed trait LogEntryPayload
+├── UserLogEntry(content: List[ContentBlock])
+├── AssistantLogEntry(content, model, usage: Option[TokenUsage], requestId)
+├── SystemLogEntry(subtype: String, data: Map[String, Any])
+├── ProgressLogEntry(data: Map[String, Any], parentToolUseId: Option[String])
+├── QueueOperationLogEntry(operation: String, content: Option[String])
+├── FileHistorySnapshotLogEntry(data: Map[String, Any])
+├── LastPromptLogEntry(data: Map[String, Any])
+└── RawLogEntry(entryType: String, json: io.circe.Json)
+```
+
+### ContentBlock Hierarchy (updated by this feature)
+
+```
+sealed trait ContentBlock
+├── TextBlock(text: String)
+├── ToolUseBlock(id, name, input)
+├── ToolResultBlock(toolUseId, content, isError)
+├── ThinkingBlock(thinking: String, signature: String)   [CC-4: new]
+└── RedactedThinkingBlock(data: String)                  [CC-4: new]
+```
+
+
+## Test Summary
+
+All tests are unit or integration; no E2E tests (the log parsing subsystem operates purely on files and has no CLI invocation path).
+
+### Phase 1 — Domain types
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../core/model/ContentBlockTest.scala` | Unit | `ThinkingBlock` and `RedactedThinkingBlock` are valid `ContentBlock` instances |
+| `test/.../core/log/model/LogModelTest.scala` | Unit | All 8 `LogEntryPayload` variants; `ConversationLogEntry` envelope; `TokenUsage`; `LogFileMetadata` — construction, field access, optional fields |
+
+### Phase 2 — Content block parsing extraction
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../core/parsing/ContentBlockParserTest.scala` | Unit | All 5 content block types including `thinking` and `redacted_thinking`; unknown type returns `None` |
+| `test/.../direct/internal/parsing/JsonParserTest.scala` | Unit | Regression: existing stream-json parsing unchanged after `ContentBlockParser` extraction |
+
+### Phase 3 — Log entry parser
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../core/log/parsing/ConversationLogParserTest.scala` | Unit | Empty/whitespace/malformed lines; missing required fields; all entry type payloads; envelope metadata; `ThinkingBlock` in content; `RawLogEntry` for unknown types; `TokenUsage` parsing; string vs. array `content` field handling |
+
+### Phase 4 — Service traits
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../core/log/ServiceTraitTest.scala` | Unit | `ConversationLogIndex` and `ConversationLogReader` can be satisfied by a minimal in-memory stub; `EntryStream` type member is accessible |
+| `test/.../core/log/ProjectPathDecoderTest.scala` | Unit | Encoding round-trips, empty string, single slash, paths with hyphens in segment names |
+
+### Phase 5 — Service implementations
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../direct/log/DirectConversationLogIndexTest.scala` | Integration | `listSessions`: empty dir, multiple sessions, path population, sessionId derivation, `cwd` decoding, fileSize, optional fields, non-`.jsonl` exclusion. `forSession`: found/not-found, correct path |
+| `test/.../direct/log/DirectConversationLogReaderTest.scala` | Integration | `readAll` with multi-line JSONL; `stream` yields same entries; empty file; malformed lines skipped; real file I/O via temp dirs |
+| `test/.../effectful/log/EffectfulConversationLogIndexTest.scala` | Integration | Same coverage as direct index test, wrapped in `IO` |
+| `test/.../effectful/log/EffectfulConversationLogReaderTest.scala` | Integration | Same coverage as direct reader test, using `fs2.Stream` |
+
+### Phase 6 — Re-exports
+
+| File | Type | What it covers |
+|------|------|----------------|
+| `test/.../direct/DirectPackageReexportTest.scala` | Unit | `import works.iterative.claude.direct.*` exposes all log types and direct implementations |
+| `test/.../effectful/EffectfulPackageReexportTest.scala` | Unit | `import works.iterative.claude.effectful.*` exposes all log types and effectful implementations |
+
+
+## Files Changed
+
+<details>
+<summary>Project management (14 files)</summary>
+
+- `project-management/issues/CC-4/analysis.md` — technical analysis with all design decisions
+- `project-management/issues/CC-4/tasks.md` — phase index and task breakdown
+- `project-management/issues/CC-4/phase-0{1..6}-context.md` — per-phase acceptance criteria
+- `project-management/issues/CC-4/phase-0{1..6}-tasks.md` — per-phase task checklists
+- `project-management/issues/CC-4/implementation-log.md` — notes from implementation
+- `project-management/issues/CC-4/review-state.json` — review workflow state
+
+</details>
+
+<details>
+<summary>Core domain types (5 files)</summary>
+
+- `works/iterative/claude/core/model/ContentBlock.scala` — added `ThinkingBlock`, `RedactedThinkingBlock`
+- `works/iterative/claude/core/log/model/ConversationLogEntry.scala` — new envelope type
+- `works/iterative/claude/core/log/model/LogEntryPayload.scala` — sealed trait + 8 variants
+- `works/iterative/claude/core/log/model/TokenUsage.scala` — structured token counts
+- `works/iterative/claude/core/log/model/LogFileMetadata.scala` — session file metadata
+
+</details>
+
+<details>
+<summary>Parsing layer (3 files)</summary>
+
+- `works/iterative/claude/core/parsing/ContentBlockParser.scala` — extracted from `JsonParser`; handles all 5 block types
+- `works/iterative/claude/core/parsing/JsonParser.scala` — now delegates to `ContentBlockParser`
+- `works/iterative/claude/core/log/parsing/ConversationLogParser.scala` — pure JSONL line parser
+
+</details>
+
+<details>
+<summary>Service layer (4 files)</summary>
+
+- `works/iterative/claude/core/log/ConversationLogIndex.scala` — trait, parameterised on `F[_]`
+- `works/iterative/claude/core/log/ConversationLogReader.scala` — trait with `EntryStream` type member
+- `works/iterative/claude/core/log/LogFileMetadataBuilder.scala` — shared stat-to-metadata logic
+- `works/iterative/claude/core/log/ProjectPathDecoder.scala` — dash-encoded path decoder
+
+</details>
+
+<details>
+<summary>Implementations (4 files)</summary>
+
+- `works/iterative/claude/direct/log/DirectConversationLogIndex.scala` — os-lib, identity functor
+- `works/iterative/claude/direct/log/DirectConversationLogReader.scala` — os-lib + Ox `Flow`
+- `works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala` — fs2.io + `IO`
+- `works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala` — fs2.Stream + `IO`
+
+</details>
+
+<details>
+<summary>Public API surface and documentation (4 files)</summary>
+
+- `works/iterative/claude/direct/package.scala` — extended with all log re-exports
+- `works/iterative/claude/effectful/package.scala` — new file; mirrors direct + effectful impls
+- `ARCHITECTURE.md` — new "Conversation Log Parsing" section
+- `README.md` — log parsing usage examples
+
+</details>
+
+<details>
+<summary>Tests (13 new test files)</summary>
+
+- `test/.../core/model/ContentBlockTest.scala`
+- `test/.../core/log/model/LogModelTest.scala`
+- `test/.../core/parsing/ContentBlockParserTest.scala`
+- `test/.../core/log/parsing/ConversationLogParserTest.scala`
+- `test/.../core/log/ServiceTraitTest.scala`
+- `test/.../core/log/ProjectPathDecoderTest.scala`
+- `test/.../direct/log/DirectConversationLogIndexTest.scala`
+- `test/.../direct/log/DirectConversationLogReaderTest.scala`
+- `test/.../effectful/log/EffectfulConversationLogIndexTest.scala`
+- `test/.../effectful/log/EffectfulConversationLogReaderTest.scala`
+- `test/.../direct/DirectPackageReexportTest.scala`
+- `test/.../effectful/EffectfulPackageReexportTest.scala`
+- `test/.../direct/internal/parsing/JsonParserTest.scala` (regression)
+
+</details>

--- a/project-management/issues/CC-4/review-phase-01-20260325.md
+++ b/project-management/issues/CC-4/review-phase-01-20260325.md
@@ -1,0 +1,76 @@
+# Code Review Results
+
+**Review Context:** Phase 1: Domain types for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 8
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-03-25
+**Git Context:** git diff fdd4f00
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `Map[String, Any]` used in domain model fields — consider `io.circe.Json` for consistency with `RawLogEntry`
+
+### Suggestions
+- Unused imports in test files (`ToolUseBlock`, `ToolResultBlock`)
+- "All variants are subtypes" test names could be more explicit about compile-time intent
+
+---
+
+## Testing Review
+
+### Critical Issues
+None (tests for pure data types with no invariants are inherently limited).
+
+### Warnings
+- Tests verify construction, not behavior — acceptable for pure value types with no invariants
+- `contentBlockGen` does not include `ThinkingBlock`/`RedactedThinkingBlock` — deferred to Phase 2 when parser support is added
+- munit used (matches existing project convention, not ZIO Test)
+
+### Suggestions
+- Add round-trip parsing tests for new ContentBlock variants in Phase 2
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `LogEntryPayload` could be an enum (valid, but sealed trait matches existing `ContentBlock` pattern)
+- `Map[String, Any]` vs `Json` (consistent with existing `SystemMessage.data` pattern)
+
+### Suggestions
+- Consider opaque types for `uuid`/`sessionId` (future improvement)
+- Redundant `LogEntry` suffix on variants (design choice, matches analysis spec)
+
+---
+
+## Composition Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `Map[String, Any]` repeated across 4 payload variants
+- `ConversationLogEntry` flat structure could benefit from `EntryMetadata` extraction (future)
+
+### Suggestions
+- `os.Path` in core model couples to os-lib (acceptable for this project)
+- `serviceTier: Option[String]` could be an enum if values are known
+
+---
+
+## Summary
+
+**Critical Issues:** 0
+**Warnings:** 7 (mostly design suggestions, none blocking)
+**Suggestions:** 8
+
+**Verdict:** Pass — no critical issues. Warnings are design-level suggestions that are either consistent with existing codebase patterns or deferred to appropriate future phases.

--- a/project-management/issues/CC-4/review-phase-02-20260325-113323.md
+++ b/project-management/issues/CC-4/review-phase-02-20260325-113323.md
@@ -1,0 +1,102 @@
+# Code Review Results
+
+**Review Context:** Phase 2: Content block parsing extraction for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 3
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-03-25T11:33:23Z
+**Git Context:** git diff a109ecb
+
+---
+
+<review skill="code-review-style">
+
+## Code Style Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Missing Scaladoc on public API** (`ContentBlockParser.scala:11`): `parseContentBlock` is a public method with no Scaladoc comment.
+- **Redundant section comments in JsonParser** (`JsonParser.scala:10,18,31,56`): Section-divider comments restate what method names already convey.
+
+### Suggestions
+
+- PURPOSE comments are positioned after `package` declaration; convention says they should be first.
+- `extractJsonValue` returns `Any` without documenting why.
+
+</review>
+
+---
+
+<review skill="code-review-testing">
+
+## Testing Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Missing error path tests for malformed typed blocks**: No tests for blocks where `type` is recognized but required fields are missing (e.g., `text` block without `"text"`, `thinking` block without `"signature"`).
+- **Test framework mismatch**: Uses `munit.FunSuite` while project may use ZIO Test elsewhere. Consistent with existing parser tests in the project.
+
+### Suggestions
+
+- Test names repeat class context already implied by suite name.
+- No test for empty JSON object `{}`.
+
+</review>
+
+---
+
+<review skill="code-review-scala3">
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Sealed trait could be enum**: `ContentBlock` sealed trait with 5 case classes is a canonical Scala 3 enum candidate. This is a broader refactor beyond this phase's scope.
+
+### Suggestions
+
+- `parseJson` helper in test has no return type annotation.
+- Could use a type alias or import for `HCursor`.
+
+</review>
+
+---
+
+<review skill="code-review-composition">
+
+## Composition Patterns Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Monolithic match function**: `parseContentBlock` handles all 5 types inline. Could decompose into private `parseXxxBlock` methods matching `JsonParser`'s pattern.
+
+### Suggestions
+
+- Inconsistent module-level call style: `ContentBlockParser.parseContentBlock` is fully qualified within same package.
+
+</review>
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** 4
+- **Suggestions:** 5
+
+All warnings are design-level recommendations. No critical issues blocking merge. The enum conversion and method decomposition are valid improvements but beyond this extraction phase's scope. The missing error path tests are worth addressing.

--- a/project-management/issues/CC-4/review-phase-03-20260325-104938.md
+++ b/project-management/issues/CC-4/review-phase-03-20260325-104938.md
@@ -1,0 +1,85 @@
+# Code Review Results
+
+**Review Context:** Phase 3: Log entry parser for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 2
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-03-25T10:49:38Z
+**Git Context:** git diff a5923a7
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- PURPOSE comments appear after package declaration (matches existing pattern)
+- Long line for Set literals in parseSystemPayload/parseProgressPayload
+- Repeated envelope key sets across three methods
+
+### Suggestions
+- Extract named constant for envelope keys
+- Comment on line 68 describes "how" not "what"
+
+---
+
+## Testing Review
+
+### Critical Issues
+None.
+
+### Warnings
+- Missing error path: "system" type without "subtype" returns None
+- Missing error path: "queue_operation" without "operation" returns None
+- Missing error path: "human" type without "message" returns None
+- Missing error path: "assistant" type without "message" returns None
+- Missing error path: missing "type" field returns None
+
+### Suggestions
+- Strengthen data assertions for file_history_snapshot and progress
+- Add test for empty content array
+- Add test for invalid timestamp format
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+- LogEntryPayload should be enum (Phase 1 model type — not in scope for Phase 3)
+- Map[String, Any] breaks type safety (Phase 1 model decision — deferred)
+
+### Warnings
+- Repeated envelope key sets (DRY violation)
+- parseInstant catches broad Exception
+- Comment describes implementation detail
+
+### Suggestions
+- Extract parseContentBlocks helper
+- Inline extractEnvelope into parseLogEntry
+
+---
+
+## Composition Review
+
+### Critical Issues
+- Duplicated envelope key set (same as above)
+- Map[String, Any] breaks type system (same as above)
+
+### Warnings
+- Content extraction duplicated between user/assistant parsers
+- Unused cursor parameter in parseDataOnlyPayload
+
+### Suggestions
+- Inline extractEnvelope
+- parseDataOnlyPayload is thin wrapper
+
+---
+
+## Summary
+
+- **Critical Issues:** 2 (both are Phase 1 model decisions, not actionable in Phase 3)
+- **Warnings:** 7 actionable
+- **Suggestions:** 8
+
+**Decision:** No critical issues in Phase 3 code. Fix actionable warnings and proceed.

--- a/project-management/issues/CC-4/review-phase-04-20260325-120953.md
+++ b/project-management/issues/CC-4/review-phase-04-20260325-120953.md
@@ -1,0 +1,74 @@
+# Code Review Results
+
+**Review Context:** Phase 4: Service traits for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 3
+**Skills Applied:** code-review-style, code-review-architecture, code-review-testing, code-review-scala3
+**Timestamp:** 2026-03-25T12:09:53
+**Git Context:** git diff 1db7be9
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- Inline comments in tests restate test names — redundant
+- `assert(x != null)` is vacuously true for compilation tests
+
+### Suggestions
+- Add Scaladoc on trait methods (listSessions, forSession, readAll, stream)
+
+---
+
+## Architecture Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `EntryStream` type member is unconstrained — callers can't use it polymorphically
+- Traits live in `core/log` rather than a `ports` sub-package
+
+### Suggestions
+- `LogFileMetadata` uses `os.Path` (infrastructure leak into model)
+- Consider splitting `readAll` and `stream` into separate ports (ISP)
+
+---
+
+## Testing Review
+
+### Critical Issues
+- Tests use munit (NOTE: this is correct for this project — munit is the test framework, not ZIO Test)
+
+### Warnings
+- No edge-case or non-empty return value tests
+- IO-returning methods never evaluated
+
+### Suggestions
+- Test names describe structure rather than behaviour (acceptable for compilation tests)
+
+---
+
+## Scala 3 Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `EntryStream` type member unconstrained (same as architecture finding)
+
+### Suggestions
+- `assert(x != null)` could be dropped for compilation tests
+- `sessionId: String` could be opaque type (future consideration)
+
+---
+
+## Summary
+
+**Critical Issues:** 0 (1 false positive about ZIO Test)
+**Warnings:** 5 (2 about unconstrained EntryStream — design decision, 1 redundant comments, 1 vacuous assert, 1 no edge-case tests)
+**Suggestions:** 5
+
+No critical issues. Warnings about `EntryStream` constraint are design decisions documented in the analysis. Minor cleanup of test assertions and comments recommended.

--- a/project-management/issues/CC-4/review-phase-05-20260325-125229.md
+++ b/project-management/issues/CC-4/review-phase-05-20260325-125229.md
@@ -1,0 +1,101 @@
+# Code Review Results
+
+**Review Context:** Phase 5: Service implementations for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 10
+**Skills Applied:** code-review-style, code-review-scala3, code-review-testing, code-review-architecture, code-review-composition
+**Timestamp:** 2026-03-25T12:52:29Z
+**Git Context:** git diff 9e87145
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- PURPOSE comments mentioned implementation library names (os-lib, Ox Flow, cats-effect, fs2) → **Fixed**
+- ProjectPathDecoder PURPOSE line 2 was implementation detail → **Fixed**
+
+### Suggestions
+- `EntryStream` type alias declared but not used in public method signatures
+- Test helper `withProjectDir` duplicated across index test files
+- Inconsistent use of named constants vs inline literals between direct/effectful reader tests
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `[A] =>> A` type lambda could use a named type alias (e.g., `Id[A]` or `cats.Id`)
+- `apply()` factories on stateless classes could additionally expose `given` instances
+
+### Suggestions
+- `.map(f).collect { case Some(x) => x }` could use `.mapFilter` where available
+- `EffectfulConversationLogIndex.listSessions` doesn't filter by regular file (only `.jsonl` extension)
+- `isInstanceOf` in tests instead of pattern matching
+
+---
+
+## Testing Review
+
+### Critical Issues
+None.
+
+### Warnings
+- Shared instance per test suite (single `val index`/`val reader`) — fragile if implementations gain state
+- `listSessions ignores non-.jsonl files` test bypasses `withProjectDir` helper in both suites
+- Missing test for `listSessions` on non-existent directory
+- `readAll skips malformed JSON lines silently` doesn't assert which entries survived
+
+### Suggestions
+- `ProjectPathDecoderTest` has redundant tests for same decode logic
+- `fileSize` tested with `> 0` rather than exact value
+- `lastModified` field never tested
+
+---
+
+## Architecture Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `os.Path` in core port traits leaks infrastructure into the contract (pre-existing from Phase 4, not introduced in Phase 5)
+- `LogFileMetadata` in `core/log/model` embeds `os.Path` (pre-existing from Phase 1)
+
+### Suggestions
+- `EffectfulConversationLogIndex` mixes fs2 file listing with synchronous os-lib stat calls
+- `DirectConversationLogReader.stream` loaded all lines eagerly before streaming → **Fixed** (now uses `scala.io.Source` for lazy reading)
+
+---
+
+## Composition Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `metadataFor` logic duplicated across direct and effectful implementations → **Fixed** (extracted to `LogFileMetadataBuilder`)
+- `DirectConversationLogReader.stream` read whole file eagerly → **Fixed**
+
+### Suggestions
+- `EffectfulConversationLogIndex.listSessions` didn't guard against non-existent directory → **Fixed**
+- `ProjectPathDecoder.decode` empty string guard is redundant
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** ~12 (4 fixed, 4 pre-existing from prior phases, 4 deferred as minor)
+- **Suggestions:** ~10 (mostly minor style/test improvements)
+
+### Fixed in this iteration:
+1. PURPOSE comments cleaned of library names
+2. `DirectConversationLogReader.stream` now reads lazily via `scala.io.Source`
+3. `metadataFor` extracted to shared `LogFileMetadataBuilder` in core
+4. `EffectfulConversationLogIndex.listSessions` guards non-existent directories

--- a/project-management/issues/CC-4/review-phase-06-20260325-132224.md
+++ b/project-management/issues/CC-4/review-phase-06-20260325-132224.md
@@ -1,0 +1,57 @@
+# Code Review Results
+
+**Review Context:** Phase 6: Re-exports and documentation for issue CC-4 (Iteration 1/3)
+**Files Reviewed:** 4 Scala files + 2 documentation files
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3
+**Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+**Git Context:** git diff ec1e5bbfd81c0d8b3b3c769f0bb8ddf7fa1ea290
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- Ordering inconsistency: `PermissionMode` placement differs between package files → **FIXED**
+- Missing `type` alias for `ProjectPathDecoder` → **FIXED**
+
+### Suggestions
+- Missing section comment in effectful package → Already present
+- EffectfulConversationLogReader test coverage gap → **FIXED**
+
+---
+
+## Testing Review
+
+### Critical Issues
+- EffectfulConversationLogReader re-export test does not test the re-export → **FIXED** (now calls readAll)
+- DirectConversationLogIndex tested against real directory → **FIXED** (now uses temp dir)
+
+### Warnings
+- EffectfulConversationLogIndex test uses fragile path → **FIXED**
+- classOf tests have no runtime assertions → Accepted (compile-check tests are intentional)
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues (pre-existing, not Phase 6 regressions)
+- `package object` used instead of Scala 3 top-level definitions → Pre-existing pattern, consistent with existing code
+- `sealed trait LogEntryPayload` should be `enum` → Phase 1 type, out of scope
+- `sealed trait ContentBlock` should be `enum` → Pre-existing type, out of scope
+
+### Warnings
+- Full qualified names verbose → Matches existing pattern
+- `ProjectPathDecoder` missing type alias → **FIXED**
+
+---
+
+## Summary
+
+- Critical issues: 0 (3 flagged were pre-existing patterns, not Phase 6 regressions)
+- Warnings: 6 found, 5 fixed, 1 accepted (compile-check test pattern is intentional)
+- Suggestions: 2 found, 1 already present, 1 noted for future
+
+**Verdict:** Pass — all actionable items addressed.

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -47,16 +47,24 @@
     {
       "label": "Implementation Log",
       "path": "project-management/issues/CC-4/implementation-log.md"
+    },
+    {
+      "label": "Phase 5 Context",
+      "path": "project-management/issues/CC-4/phase-05-context.md"
+    },
+    {
+      "label": "Phase 5 Tasks",
+      "path": "project-management/issues/CC-4/phase-05-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:13:33.420958932Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T11:19:28.467511853Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 04: Merged",
-    "type": "success",
-    "subtext": "Service traits"
+    "text": "Phase 05: Implementing",
+    "type": "progress",
+    "subtext": "Service implementations"
   },
-  "message": "Phase 04 implementation started",
+  "message": "Phase 05 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -94,13 +102,18 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
   "needs_attention": true,
   "phase_checkpoints": {
-    "4": {
-      "context_sha": "context_sha=1cb4c69b020926faf4bec581b877e2d2c8db3bea"
+    "5": {
+      "context_sha": "context_sha=8c45593e5e01febffe402c4cf71aebfffb217ecb"
     }
   },
   "badges": [
@@ -135,6 +148,10 @@
     {
       "label": "Complete",
       "type": "success"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ],
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -65,11 +65,11 @@
       "path": "project-management/issues/CC-4/phase-06-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:59:15.800306565Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T12:23:52.333425558Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 06: Implementing",
-    "type": "progress",
+    "text": "Phase 06: Merged",
+    "type": "success",
     "subtext": "Re-exports and documentation"
   },
   "message": "Phase 06 implementation started",
@@ -173,6 +173,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ],
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -1,0 +1,45 @@
+{
+  "version": 2,
+  "issue_id": "CC-4",
+  "artifacts": [
+    {
+      "label": "Analysis",
+      "path": "project-management/issues/CC-4/analysis.md",
+      "category": "input"
+    },
+    {
+      "label": "Tasks",
+      "path": "project-management/issues/CC-4/tasks.md",
+      "category": "output"
+    }
+  ],
+  "last_updated": "2026-03-25T09:52:04.624066751Z",
+  "status": "tasks_ready",
+  "display": {
+    "text": "Tasks Ready",
+    "type": "success",
+    "subtext": "6 phases identified"
+  },
+  "message": "Task breakdown complete. Ready to begin implementation.",
+  "activity": "waiting",
+  "workflow_type": "waterfall",
+  "available_actions": [
+    {
+      "id": "create-tasks",
+      "label": "Generate Tasks",
+      "skill": "wf-create-tasks"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
+    }
+  ],
+  "git_sha": "ed00850",
+  "needs_attention": true
+}

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -21,11 +21,11 @@
       "path": "project-management/issues/CC-4/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T10:03:54.807177256Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T10:18:47.176883520Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 01: Implementing",
-    "type": "progress",
+    "text": "Phase 01: Merged",
+    "type": "success",
     "subtext": "Domain types"
   },
   "message": "Phase 01 implementation started",
@@ -64,6 +64,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -55,16 +55,24 @@
     {
       "label": "Phase 5 Tasks",
       "path": "project-management/issues/CC-4/phase-05-tasks.md"
+    },
+    {
+      "label": "Phase 6 Context",
+      "path": "project-management/issues/CC-4/phase-06-context.md"
+    },
+    {
+      "label": "Phase 6 Tasks",
+      "path": "project-management/issues/CC-4/phase-06-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:54:15.391145234Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T11:59:15.800306565Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 05: Merged",
-    "type": "success",
-    "subtext": "Service implementations"
+    "text": "Phase 06: Implementing",
+    "type": "progress",
+    "subtext": "Re-exports and documentation"
   },
-  "message": "Phase 05 implementation started",
+  "message": "Phase 06 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -107,13 +115,18 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
   "needs_attention": true,
   "phase_checkpoints": {
-    "5": {
-      "context_sha": "context_sha=8c45593e5e01febffe402c4cf71aebfffb217ecb"
+    "6": {
+      "context_sha": "context_sha=1305980a69cb0e6e9f86fe21ca1d2ca03d18f0fb"
     }
   },
   "badges": [
@@ -156,6 +169,10 @@
     {
       "label": "Complete",
       "type": "success"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ],
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -11,16 +11,24 @@
       "label": "Tasks",
       "path": "project-management/issues/CC-4/tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Context",
+      "path": "project-management/issues/CC-4/phase-01-context.md"
+    },
+    {
+      "label": "Phase 1 Tasks",
+      "path": "project-management/issues/CC-4/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T09:52:04.624066751Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-03-25T10:03:54.807177256Z",
+  "status": "implementing",
   "display": {
-    "text": "Tasks Ready",
-    "type": "success",
-    "subtext": "6 phases identified"
+    "text": "Phase 01: Implementing",
+    "type": "progress",
+    "subtext": "Domain types"
   },
-  "message": "Task breakdown complete. Ready to begin implementation.",
+  "message": "Phase 01 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -38,8 +46,24 @@
       "id": "implement",
       "label": "Start Implementation",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
-  "needs_attention": true
+  "needs_attention": true,
+  "phase_checkpoints": {
+    "1": {
+      "context_sha": "context_sha=17ea46a986b0755f9d1e1722292462c75ee3a6c7"
+    }
+  },
+  "badges": [
+    {
+      "label": "In Progress",
+      "type": "info"
+    }
+  ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -27,16 +27,24 @@
     {
       "label": "Phase 2 Tasks",
       "path": "project-management/issues/CC-4/phase-02-tasks.md"
+    },
+    {
+      "label": "Phase 3 Context",
+      "path": "project-management/issues/CC-4/phase-03-context.md"
+    },
+    {
+      "label": "Phase 3 Tasks",
+      "path": "project-management/issues/CC-4/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T10:35:17.077982595Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T10:41:16.191712220Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 02: Merged",
-    "type": "success",
-    "subtext": "Content block parsing extraction"
+    "text": "Phase 03: Implementing",
+    "type": "progress",
+    "subtext": "Log entry parser"
   },
-  "message": "Phase 02 implementation started",
+  "message": "Phase 03 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -64,13 +72,18 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
   "needs_attention": true,
   "phase_checkpoints": {
-    "2": {
-      "context_sha": "context_sha=f8894164af939c07a608f7e2bb20febd1465fe89"
+    "3": {
+      "context_sha": "context_sha=ede02ab980542fe85b0f530b29086c00270d8582"
     }
   },
   "badges": [
@@ -89,6 +102,10 @@
     {
       "label": "Complete",
       "type": "success"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -29,11 +29,11 @@
       "path": "project-management/issues/CC-4/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T10:23:02.612236381Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T10:35:17.077982595Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 02: Implementing",
-    "type": "progress",
+    "text": "Phase 02: Merged",
+    "type": "success",
     "subtext": "Content block parsing extraction"
   },
   "message": "Phase 02 implementation started",
@@ -85,6 +85,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -43,9 +43,13 @@
     {
       "label": "Phase 4 Tasks",
       "path": "project-management/issues/CC-4/phase-04-tasks.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-4/implementation-log.md"
     }
   ],
-  "last_updated": "2026-03-25T11:13:08.123274638Z",
+  "last_updated": "2026-03-25T11:13:33.420958932Z",
   "status": "phase_merged",
   "display": {
     "text": "Phase 04: Merged",
@@ -132,5 +136,6 @@
       "label": "Complete",
       "type": "success"
     }
-  ]
+  ],
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -57,11 +57,11 @@
       "path": "project-management/issues/CC-4/phase-05-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:19:28.467511853Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T11:54:15.391145234Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 05: Implementing",
-    "type": "progress",
+    "text": "Phase 05: Merged",
+    "type": "success",
     "subtext": "Service implementations"
   },
   "message": "Phase 05 implementation started",
@@ -152,6 +152,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ],
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -37,11 +37,11 @@
       "path": "project-management/issues/CC-4/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T10:41:16.191712220Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T11:00:49.538390339Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 03: Implementing",
-    "type": "progress",
+    "text": "Phase 03: Merged",
+    "type": "success",
     "subtext": "Log entry parser"
   },
   "message": "Phase 03 implementation started",
@@ -106,6 +106,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -35,16 +35,24 @@
     {
       "label": "Phase 3 Tasks",
       "path": "project-management/issues/CC-4/phase-03-tasks.md"
+    },
+    {
+      "label": "Phase 4 Context",
+      "path": "project-management/issues/CC-4/phase-04-context.md"
+    },
+    {
+      "label": "Phase 4 Tasks",
+      "path": "project-management/issues/CC-4/phase-04-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:00:49.538390339Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T11:05:30.206587787Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 03: Merged",
-    "type": "success",
-    "subtext": "Log entry parser"
+    "text": "Phase 04: Implementing",
+    "type": "progress",
+    "subtext": "Service traits"
   },
-  "message": "Phase 03 implementation started",
+  "message": "Phase 04 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -77,13 +85,18 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
   "needs_attention": true,
   "phase_checkpoints": {
-    "3": {
-      "context_sha": "context_sha=ede02ab980542fe85b0f530b29086c00270d8582"
+    "4": {
+      "context_sha": "context_sha=1cb4c69b020926faf4bec581b877e2d2c8db3bea"
     }
   },
   "badges": [
@@ -110,6 +123,10 @@
     {
       "label": "Complete",
       "type": "success"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -45,11 +45,11 @@
       "path": "project-management/issues/CC-4/phase-04-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T11:05:30.206587787Z",
-  "status": "implementing",
+  "last_updated": "2026-03-25T11:13:08.123274638Z",
+  "status": "phase_merged",
   "display": {
-    "text": "Phase 04: Implementing",
-    "type": "progress",
+    "text": "Phase 04: Merged",
+    "type": "success",
     "subtext": "Service traits"
   },
   "message": "Phase 04 implementation started",
@@ -127,6 +127,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Complete",
+      "type": "success"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -19,16 +19,24 @@
     {
       "label": "Phase 1 Tasks",
       "path": "project-management/issues/CC-4/phase-01-tasks.md"
+    },
+    {
+      "label": "Phase 2 Context",
+      "path": "project-management/issues/CC-4/phase-02-context.md"
+    },
+    {
+      "label": "Phase 2 Tasks",
+      "path": "project-management/issues/CC-4/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-03-25T10:18:47.176883520Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T10:23:02.612236381Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 01: Merged",
-    "type": "success",
-    "subtext": "Domain types"
+    "text": "Phase 02: Implementing",
+    "type": "progress",
+    "subtext": "Content block parsing extraction"
   },
-  "message": "Phase 01 implementation started",
+  "message": "Phase 02 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -51,13 +59,18 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
   "git_sha": "ed00850",
   "needs_attention": true,
   "phase_checkpoints": {
-    "1": {
-      "context_sha": "context_sha=17ea46a986b0755f9d1e1722292462c75ee3a6c7"
+    "2": {
+      "context_sha": "context_sha=f8894164af939c07a608f7e2bb20febd1465fe89"
     }
   },
   "badges": [
@@ -68,6 +81,10 @@
     {
       "label": "Complete",
       "type": "success"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ]
 }

--- a/project-management/issues/CC-4/review-state.json
+++ b/project-management/issues/CC-4/review-state.json
@@ -63,16 +63,28 @@
     {
       "label": "Phase 6 Tasks",
       "path": "project-management/issues/CC-4/phase-06-tasks.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-4/implementation-log.md"
+    },
+    {
+      "label": "Release Notes",
+      "path": "project-management/issues/CC-4/release-notes.md"
+    },
+    {
+      "label": "Review Packet",
+      "path": "project-management/issues/CC-4/review-packet.md"
     }
   ],
-  "last_updated": "2026-03-25T12:23:52.333425558Z",
-  "status": "phase_merged",
+  "last_updated": "2026-03-25T12:28:36.534195007Z",
+  "status": "all_complete",
   "display": {
-    "text": "Phase 06: Merged",
+    "text": "Ready for Final Review",
     "type": "success",
     "subtext": "Re-exports and documentation"
   },
-  "message": "Phase 06 implementation started",
+  "message": "All phases complete - final PR created",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -120,6 +132,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "ed00850",
@@ -179,5 +196,5 @@
       "type": "success"
     }
   ],
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/8"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/11"
 }

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -11,7 +11,7 @@
 - [x] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
 - [x] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
 - [x] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
-- [ ] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`
+- [x] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`
 
 ## Phase Details
 

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -9,7 +9,7 @@
 - [x] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
 - [x] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
 - [x] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
-- [ ] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
+- [x] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
 - [ ] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
 - [ ] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`
 

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -1,0 +1,76 @@
+# Implementation Tasks: Add conversation log parsing support
+
+**Issue:** CC-4
+**Created:** 2026-03-25
+**Status:** 0/6 phases complete (0%)
+
+## Phase Index
+
+- [ ] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
+- [ ] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
+- [ ] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
+- [ ] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
+- [ ] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
+- [ ] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`
+
+## Phase Details
+
+### Phase 1: Domain types
+**Package:** `core.log.model` + `core.model`
+- Add `ThinkingBlock(thinking: String, signature: String)` to `ContentBlock` sealed trait
+- Add `RedactedThinkingBlock(data: String)` to `ContentBlock` sealed trait
+- Fix exhaustiveness warnings in existing code
+- Define `ConversationLogEntry` envelope (uuid, parentUuid, timestamp, sessionId, isSidechain, metadata)
+- Define `LogEntryPayload` sealed trait with all payload variants (UserLogEntry, AssistantLogEntry, SystemLogEntry, ProgressLogEntry, QueueOperationLogEntry, FileHistorySnapshotLogEntry, LastPromptLogEntry, RawLogEntry)
+- Define `TokenUsage` case class
+- Define `LogFileMetadata` case class (sessionId, summary, lastModified, fileSize, cwd, gitBranch, createdAt)
+
+### Phase 2: Content block parsing extraction
+**Package:** `core.parsing`
+- Extract shared content block parsing from `JsonParser.parseContentBlock` (currently private) into `ContentBlockParser`
+- Add `thinking` and `redacted_thinking` block parsing
+- Update `JsonParser` to delegate to `ContentBlockParser`
+- Verify all existing JsonParser tests still pass
+
+### Phase 3: Log entry parser
+**Package:** `core.log.parsing`
+- Build `ConversationLogParser` — pure parsing for JSONL log lines
+- Parse envelope metadata (uuid, parentUuid, timestamp, sessionId, etc.)
+- Parse each entry type payload (user, assistant, system, progress, queue-operation, file-history-snapshot, last-prompt)
+- Capture unknown entry types as `RawLogEntry`
+- Reuse `ContentBlockParser` for content blocks within messages
+- Handle user message content as `List[ContentBlock]` (string or array)
+- Parse `TokenUsage` from assistant message usage data
+
+### Phase 4: Service traits
+**Package:** `core.log`
+- Define `ConversationLogIndex` trait (list all sessions, list by project, get by session ID)
+- Define `ConversationLogReader` trait (stream entries, read all entries)
+- Support full discovery: all projects, per-project, by session ID
+
+### Phase 5: Service implementations
+**Packages:** `direct.log` + `effectful.log`
+- Direct `ConversationLogIndex` using os-lib for file discovery and path decoding
+- Direct `ConversationLogReader` using os-lib + Ox Flow for streaming
+- Effectful `ConversationLogIndex` using fs2.io.file
+- Effectful `ConversationLogReader` using fs2.Stream
+- Path decoding for `~/.claude/projects/` directory structure
+
+### Phase 6: Re-exports and documentation
+- Update `direct.package` and `effectful.package` to re-export new types
+- Update ARCHITECTURE.md with log parsing section
+- Update README.md with usage examples
+
+## Progress Tracker
+
+**Completed:** 0/6 phases
+**Estimated Total:** 8-13 hours
+**Time Spent:** 0 hours
+
+## Notes
+
+- Phase context files generated just-in-time during implementation
+- Use wf-implement to start next phase automatically
+- Estimates are rough and will be refined during implementation
+- Phases follow layer dependency order from analysis
+- All CLARIFYs resolved: separate type hierarchies, full discovery, required ThinkingBlock fields, Option[Instant] timestamps

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -8,7 +8,7 @@
 
 - [x] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
 - [x] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
-- [ ] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
+- [x] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
 - [ ] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
 - [ ] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
 - [ ] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -10,7 +10,7 @@
 - [x] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
 - [x] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
 - [x] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
-- [ ] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
+- [x] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`
 - [ ] Phase 6: Re-exports and documentation (Est: 1h) → `phase-06-context.md`
 
 ## Phase Details

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -6,7 +6,7 @@
 
 ## Phase Index
 
-- [ ] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
+- [x] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
 - [ ] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
 - [ ] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
 - [ ] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`

--- a/project-management/issues/CC-4/tasks.md
+++ b/project-management/issues/CC-4/tasks.md
@@ -7,7 +7,7 @@
 ## Phase Index
 
 - [x] Phase 1: Domain types (Est: 1-3h) → `phase-01-context.md`
-- [ ] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
+- [x] Phase 2: Content block parsing extraction (Est: 1-2h) → `phase-02-context.md`
 - [ ] Phase 3: Log entry parser (Est: 2-3h) → `phase-03-context.md`
 - [ ] Phase 4: Service traits (Est: 1h) → `phase-04-context.md`
 - [ ] Phase 5: Service implementations (Est: 2-3h) → `phase-05-context.md`

--- a/test/works/iterative/claude/core/log/ProjectPathDecoderTest.scala
+++ b/test/works/iterative/claude/core/log/ProjectPathDecoderTest.scala
@@ -1,0 +1,54 @@
+// PURPOSE: Unit tests for ProjectPathDecoder path decoding from Claude project directory names
+// PURPOSE: Covers standard paths, edge cases like root, single segment, and empty input
+
+package works.iterative.claude.core.log
+
+import munit.FunSuite
+
+class ProjectPathDecoderTest extends FunSuite:
+
+  test("decodes typical multi-segment encoded path"):
+    assertEquals(
+      ProjectPathDecoder.decode("-home-mph-Devel-projects-foo"),
+      "/home/mph/Devel/projects/foo"
+    )
+
+  test("decodes single-segment path"):
+    assertEquals(
+      ProjectPathDecoder.decode("-home"),
+      "/home"
+    )
+
+  test("decodes two-segment path"):
+    assertEquals(
+      ProjectPathDecoder.decode("-home-mph"),
+      "/home/mph"
+    )
+
+  test("decodes path with deep nesting — all dashes become slashes"):
+    // The encoder replaced every / with -, so decoding reverses that by replacing all - with /
+    // Segments containing - in the original are ambiguous and cannot be recovered
+    assertEquals(
+      ProjectPathDecoder.decode("-home-mph-Devel-projects-myapp"),
+      "/home/mph/Devel/projects/myapp"
+    )
+
+  test("returns empty string for empty input"):
+    assertEquals(
+      ProjectPathDecoder.decode(""),
+      ""
+    )
+
+  test("decodes root path encoded as single dash"):
+    // A leading dash with nothing after is best-effort decoded to just /
+    assertEquals(
+      ProjectPathDecoder.decode("-"),
+      "/"
+    )
+
+  test("best-effort decode replaces every dash with slash"):
+    // -home-my-project decodes to /home/my/project (ambiguous — callers must validate)
+    assertEquals(
+      ProjectPathDecoder.decode("-home-my-project"),
+      "/home/my/project"
+    )

--- a/test/works/iterative/claude/core/log/ServiceTraitTest.scala
+++ b/test/works/iterative/claude/core/log/ServiceTraitTest.scala
@@ -1,0 +1,47 @@
+// PURPOSE: Compilation tests verifying ConversationLogIndex and ConversationLogReader
+// PURPOSE: can be implemented with both identity F (direct style) and IO (effectful style)
+
+package works.iterative.claude.core.log
+
+import munit.FunSuite
+import cats.effect.IO
+import works.iterative.claude.core.log.model.{
+  ConversationLogEntry,
+  LogFileMetadata
+}
+
+class ServiceTraitTest extends FunSuite:
+
+  test("ConversationLogIndex compiles with identity F"):
+    val _: ConversationLogIndex[[A] =>> A] =
+      new ConversationLogIndex[[A] =>> A]:
+        def listSessions(projectPath: os.Path): Seq[LogFileMetadata] = Seq.empty
+        def forSession(
+            projectPath: os.Path,
+            sessionId: String
+        ): Option[LogFileMetadata] = None
+
+  test("ConversationLogIndex compiles with IO"):
+    val _: ConversationLogIndex[IO] = new ConversationLogIndex[IO]:
+      def listSessions(projectPath: os.Path): IO[Seq[LogFileMetadata]] =
+        IO.pure(Seq.empty)
+      def forSession(
+          projectPath: os.Path,
+          sessionId: String
+      ): IO[Option[LogFileMetadata]] =
+        IO.pure(None)
+
+  test("ConversationLogReader compiles with identity F and List stream type"):
+    val _: ConversationLogReader[[A] =>> A] =
+      new ConversationLogReader[[A] =>> A]:
+        type EntryStream = List[ConversationLogEntry]
+        def readAll(path: os.Path): List[ConversationLogEntry] = List.empty
+        def stream(path: os.Path): List[ConversationLogEntry] = List.empty
+
+  test("ConversationLogReader compiles with IO and fs2.Stream stream type"):
+    val _: ConversationLogReader[IO] = new ConversationLogReader[IO]:
+      type EntryStream = fs2.Stream[IO, ConversationLogEntry]
+      def readAll(path: os.Path): IO[List[ConversationLogEntry]] =
+        IO.pure(List.empty)
+      def stream(path: os.Path): fs2.Stream[IO, ConversationLogEntry] =
+        fs2.Stream.empty

--- a/test/works/iterative/claude/core/log/model/LogModelTest.scala
+++ b/test/works/iterative/claude/core/log/model/LogModelTest.scala
@@ -1,0 +1,280 @@
+package works.iterative.claude.core.log.model
+
+// PURPOSE: Unit tests for conversation log domain types
+// PURPOSE: Verifies correct construction and field access for all log model types
+
+import munit.FunSuite
+import java.time.Instant
+import works.iterative.claude.core.model.{ContentBlock, TextBlock}
+import io.circe.Json
+
+class LogModelTest extends FunSuite:
+
+  // TokenUsage tests
+
+  test("TokenUsage should hold required token counts"):
+    val usage = TokenUsage(
+      inputTokens = 100,
+      outputTokens = 50,
+      cacheCreationInputTokens = None,
+      cacheReadInputTokens = None,
+      serviceTier = None
+    )
+    assertEquals(usage.inputTokens, 100)
+    assertEquals(usage.outputTokens, 50)
+
+  test("TokenUsage should hold optional cache token counts"):
+    val usage = TokenUsage(
+      inputTokens = 200,
+      outputTokens = 80,
+      cacheCreationInputTokens = Some(30),
+      cacheReadInputTokens = Some(15),
+      serviceTier = Some("standard")
+    )
+    assertEquals(usage.cacheCreationInputTokens, Some(30))
+    assertEquals(usage.cacheReadInputTokens, Some(15))
+    assertEquals(usage.serviceTier, Some("standard"))
+
+  // LogEntryPayload variant tests
+
+  test("UserLogEntry should hold content blocks"):
+    val content: List[ContentBlock] = List(TextBlock("hello"))
+    val entry = UserLogEntry(content)
+    assertEquals(entry.content, content)
+
+  test("AssistantLogEntry should hold content and optional metadata"):
+    val usage = TokenUsage(100, 50, None, None, None)
+    val entry = AssistantLogEntry(
+      content = List(TextBlock("response")),
+      model = Some("claude-3-5-sonnet"),
+      usage = Some(usage),
+      requestId = Some("req-123")
+    )
+    assertEquals(entry.content, List(TextBlock("response")))
+    assertEquals(entry.model, Some("claude-3-5-sonnet"))
+    assertEquals(entry.usage, Some(usage))
+    assertEquals(entry.requestId, Some("req-123"))
+
+  test("AssistantLogEntry should allow all optional fields to be None"):
+    val entry = AssistantLogEntry(
+      content = List.empty,
+      model = None,
+      usage = None,
+      requestId = None
+    )
+    assertEquals(entry.model, None)
+    assertEquals(entry.usage, None)
+
+  test("SystemLogEntry should hold subtype and data map"):
+    val data = Map[String, Any]("key" -> "value", "count" -> 42)
+    val entry = SystemLogEntry("init", data)
+    assertEquals(entry.subtype, "init")
+    assertEquals(entry.data("key"), "value")
+
+  test("ProgressLogEntry should hold data and optional parentToolUseId"):
+    val data = Map[String, Any]("progress" -> 0.5)
+    val entry = ProgressLogEntry(data, Some("tool-use-id-1"))
+    assertEquals(entry.data, data)
+    assertEquals(entry.parentToolUseId, Some("tool-use-id-1"))
+
+  test("QueueOperationLogEntry should hold operation and optional content"):
+    val entry = QueueOperationLogEntry("enqueue", Some("message content"))
+    assertEquals(entry.operation, "enqueue")
+    assertEquals(entry.content, Some("message content"))
+
+  test("FileHistorySnapshotLogEntry should hold data map"):
+    val data = Map[String, Any]("files" -> List("/a.txt", "/b.txt"))
+    val entry = FileHistorySnapshotLogEntry(data)
+    assertEquals(entry.data, data)
+
+  test("LastPromptLogEntry should hold data map"):
+    val data = Map[String, Any]("prompt" -> "last prompt text")
+    val entry = LastPromptLogEntry(data)
+    assertEquals(entry.data, data)
+
+  test("RawLogEntry should hold entry type and raw JSON"):
+    val json = Json.obj("foo" -> Json.fromString("bar"))
+    val entry = RawLogEntry("unknown_type", json)
+    assertEquals(entry.entryType, "unknown_type")
+    assertEquals(entry.json, json)
+
+  test("All LogEntryPayload variants are subtypes of LogEntryPayload"):
+    val variants: List[LogEntryPayload] = List(
+      UserLogEntry(List.empty),
+      AssistantLogEntry(List.empty, None, None, None),
+      SystemLogEntry("test", Map.empty),
+      ProgressLogEntry(Map.empty, None),
+      QueueOperationLogEntry("op", None),
+      FileHistorySnapshotLogEntry(Map.empty),
+      LastPromptLogEntry(Map.empty),
+      RawLogEntry("raw", Json.Null)
+    )
+    assertEquals(variants.size, 8)
+
+  // ConversationLogEntry tests
+
+  test("ConversationLogEntry should hold envelope metadata and payload"):
+    val payload = UserLogEntry(List(TextBlock("hello")))
+    val now = Instant.now()
+    val entry = ConversationLogEntry(
+      uuid = "uuid-001",
+      parentUuid = Some("parent-uuid-000"),
+      timestamp = Some(now),
+      sessionId = "session-abc",
+      isSidechain = false,
+      cwd = Some("/home/user"),
+      version = Some("1.0"),
+      payload = payload
+    )
+    assertEquals(entry.uuid, "uuid-001")
+    assertEquals(entry.parentUuid, Some("parent-uuid-000"))
+    assertEquals(entry.timestamp, Some(now))
+    assertEquals(entry.sessionId, "session-abc")
+    assertEquals(entry.isSidechain, false)
+    assertEquals(entry.cwd, Some("/home/user"))
+    assertEquals(entry.version, Some("1.0"))
+    assertEquals(entry.payload, payload)
+
+  test("ConversationLogEntry should allow optional fields to be None"):
+    val entry = ConversationLogEntry(
+      uuid = "uuid-002",
+      parentUuid = None,
+      timestamp = None,
+      sessionId = "session-xyz",
+      isSidechain = true,
+      cwd = None,
+      version = None,
+      payload = SystemLogEntry("init", Map.empty)
+    )
+    assertEquals(entry.parentUuid, None)
+    assertEquals(entry.timestamp, None)
+    assertEquals(entry.cwd, None)
+    assertEquals(entry.version, None)
+
+  test("ConversationLogEntry can hold each LogEntryPayload variant"):
+    val sessionId = "session-test"
+    val entries = List(
+      ConversationLogEntry(
+        "u1",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        UserLogEntry(List.empty)
+      ),
+      ConversationLogEntry(
+        "u2",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        AssistantLogEntry(List.empty, None, None, None)
+      ),
+      ConversationLogEntry(
+        "u3",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        SystemLogEntry("init", Map.empty)
+      ),
+      ConversationLogEntry(
+        "u4",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        ProgressLogEntry(Map.empty, None)
+      ),
+      ConversationLogEntry(
+        "u5",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        QueueOperationLogEntry("op", None)
+      ),
+      ConversationLogEntry(
+        "u6",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        FileHistorySnapshotLogEntry(Map.empty)
+      ),
+      ConversationLogEntry(
+        "u7",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        LastPromptLogEntry(Map.empty)
+      ),
+      ConversationLogEntry(
+        "u8",
+        None,
+        None,
+        sessionId,
+        false,
+        None,
+        None,
+        RawLogEntry("unknown", Json.Null)
+      )
+    )
+    assertEquals(entries.size, 8)
+
+  // LogFileMetadata tests
+
+  test("LogFileMetadata should hold file metadata"):
+    val path = os.Path("/home/user/.claude/projects/session.jsonl")
+    val now = Instant.now()
+    val meta = LogFileMetadata(
+      path = path,
+      sessionId = "session-123",
+      summary = Some("a conversation about Scala"),
+      lastModified = now,
+      fileSize = 4096L,
+      cwd = Some("/home/user/project"),
+      gitBranch = Some("main"),
+      createdAt = Some(now)
+    )
+    assertEquals(meta.path, path)
+    assertEquals(meta.sessionId, "session-123")
+    assertEquals(meta.summary, Some("a conversation about Scala"))
+    assertEquals(meta.lastModified, now)
+    assertEquals(meta.fileSize, 4096L)
+    assertEquals(meta.cwd, Some("/home/user/project"))
+    assertEquals(meta.gitBranch, Some("main"))
+    assertEquals(meta.createdAt, Some(now))
+
+  test("LogFileMetadata should allow optional fields to be None"):
+    val path = os.Path("/tmp/session.jsonl")
+    val now = Instant.now()
+    val meta = LogFileMetadata(
+      path = path,
+      sessionId = "session-456",
+      summary = None,
+      lastModified = now,
+      fileSize = 0L,
+      cwd = None,
+      gitBranch = None,
+      createdAt = None
+    )
+    assertEquals(meta.summary, None)
+    assertEquals(meta.cwd, None)
+    assertEquals(meta.gitBranch, None)
+    assertEquals(meta.createdAt, None)

--- a/test/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+++ b/test/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
@@ -1,0 +1,531 @@
+package works.iterative.claude.core.log.parsing
+
+// PURPOSE: Unit tests for ConversationLogParser log entry parsing functionality
+// PURPOSE: Verifies correct parsing of all log entry types, envelope metadata, and error handling
+
+import munit.FunSuite
+import io.circe.{Json, parser}
+import java.time.Instant
+import works.iterative.claude.core.log.model.*
+import works.iterative.claude.core.model.*
+
+class ConversationLogParserTest extends FunSuite:
+
+  // --- Entry point tests ---
+
+  test("parseLogLine with valid JSONL line returns Some(ConversationLogEntry)"):
+    val line =
+      """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assert(
+      result.isDefined,
+      "Expected Some(ConversationLogEntry) for valid JSONL"
+    )
+
+  test("parseLogLine with empty line returns None"):
+    assertEquals(ConversationLogParser.parseLogLine(""), None)
+
+  test("parseLogLine with whitespace-only line returns None"):
+    assertEquals(ConversationLogParser.parseLogLine("   \t  "), None)
+
+  test("parseLogLine with invalid JSON returns None"):
+    assertEquals(
+      ConversationLogParser.parseLogLine("""{"type": "human", malformed}"""),
+      None
+    )
+
+  test("parseLogEntry with missing required uuid field returns None"):
+    val json = parser
+      .parse("""{"type":"human","sessionId":"s1","message":{"content":"hi"}}""")
+      .getOrElse(fail("parse failed"))
+    assertEquals(ConversationLogParser.parseLogEntry(json), None)
+
+  test("parseLogEntry with missing required sessionId field returns None"):
+    val json = parser
+      .parse("""{"type":"human","uuid":"u1","message":{"content":"hi"}}""")
+      .getOrElse(fail("parse failed"))
+    assertEquals(ConversationLogParser.parseLogEntry(json), None)
+
+  // --- Envelope metadata tests ---
+
+  test("parses all envelope metadata fields"):
+    val line =
+      """{
+        "type":"human",
+        "uuid":"uuid-001",
+        "parentUuid":"parent-uuid-000",
+        "timestamp":"2024-01-15T10:30:00Z",
+        "sessionId":"session-abc",
+        "isSidechain":true,
+        "cwd":"/home/user/project",
+        "version":"1.2.3",
+        "message":{"content":"hello"}
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) =>
+        assertEquals(entry.uuid, "uuid-001")
+        assertEquals(entry.parentUuid, Some("parent-uuid-000"))
+        assertEquals(
+          entry.timestamp,
+          Some(Instant.parse("2024-01-15T10:30:00Z"))
+        )
+        assertEquals(entry.sessionId, "session-abc")
+        assertEquals(entry.isSidechain, true)
+        assertEquals(entry.cwd, Some("/home/user/project"))
+        assertEquals(entry.version, Some("1.2.3"))
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test("parses with optional fields absent"):
+    val line =
+      """{"type":"human","uuid":"u2","sessionId":"s2","message":{"content":"hi"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) =>
+        assertEquals(entry.parentUuid, None)
+        assertEquals(entry.timestamp, None)
+        assertEquals(entry.cwd, None)
+        assertEquals(entry.version, None)
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test("parses ISO-8601 timestamp string to Instant"):
+    val line =
+      """{
+        "type":"human",
+        "uuid":"u3",
+        "sessionId":"s3",
+        "timestamp":"2025-06-01T12:00:00.000Z",
+        "message":{"content":"ts test"}
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) =>
+        assertEquals(
+          entry.timestamp,
+          Some(Instant.parse("2025-06-01T12:00:00.000Z"))
+        )
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test("isSidechain defaults to false when absent"):
+    val line =
+      """{"type":"human","uuid":"u4","sessionId":"s4","message":{"content":"x"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.isSidechain, false)
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  // --- Payload type tests ---
+
+  test(
+    """"human" type with string content produces UserLogEntry with List(TextBlock)"""
+  ):
+    val line =
+      """{"type":"human","uuid":"u5","sessionId":"s5","message":{"content":"hello world"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(_, _, _, _, _, _, _, UserLogEntry(content))
+          ) =>
+        assertEquals(content, List(TextBlock("hello world")))
+      case Some(entry) => fail(s"Expected UserLogEntry, got: ${entry.payload}")
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"human" type with array content produces UserLogEntry with parsed content blocks"""
+  ):
+    val line =
+      """{
+        "type":"human",
+        "uuid":"u6",
+        "sessionId":"s6",
+        "message":{
+          "content":[
+            {"type":"text","text":"first block"},
+            {"type":"text","text":"second block"}
+          ]
+        }
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(_, _, _, _, _, _, _, UserLogEntry(content))
+          ) =>
+        assertEquals(
+          content,
+          List(TextBlock("first block"), TextBlock("second block"))
+        )
+      case Some(entry) => fail(s"Expected UserLogEntry, got: ${entry.payload}")
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"assistant" type with content, model, usage, requestId produces AssistantLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"assistant",
+        "uuid":"u7",
+        "sessionId":"s7",
+        "requestId":"req-999",
+        "message":{
+          "model":"claude-3-5-sonnet-20241022",
+          "content":[{"type":"text","text":"response text"}],
+          "usage":{
+            "input_tokens":100,
+            "output_tokens":50,
+            "cache_creation_input_tokens":10,
+            "cache_read_input_tokens":5,
+            "service_tier":"standard"
+          }
+        }
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AssistantLogEntry(content, model, usage, requestId)
+            )
+          ) =>
+        assertEquals(content, List(TextBlock("response text")))
+        assertEquals(model, Some("claude-3-5-sonnet-20241022"))
+        assertEquals(requestId, Some("req-999"))
+        usage match
+          case Some(u) =>
+            assertEquals(u.inputTokens, 100)
+            assertEquals(u.outputTokens, 50)
+            assertEquals(u.cacheCreationInputTokens, Some(10))
+            assertEquals(u.cacheReadInputTokens, Some(5))
+            assertEquals(u.serviceTier, Some("standard"))
+          case None => fail("Expected Some(TokenUsage)")
+      case Some(entry) =>
+        fail(s"Expected AssistantLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(""""assistant" type with minimal fields produces AssistantLogEntry"""):
+    val line =
+      """{
+        "type":"assistant",
+        "uuid":"u8",
+        "sessionId":"s8",
+        "message":{
+          "content":[{"type":"text","text":"minimal"}]
+        }
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AssistantLogEntry(content, model, usage, requestId)
+            )
+          ) =>
+        assertEquals(content, List(TextBlock("minimal")))
+        assertEquals(model, None)
+        assertEquals(usage, None)
+        assertEquals(requestId, None)
+      case Some(entry) =>
+        fail(s"Expected AssistantLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(""""system" type with subtype and data produces SystemLogEntry"""):
+    val line =
+      """{
+        "type":"system",
+        "uuid":"u9",
+        "sessionId":"s9",
+        "subtype":"init",
+        "apiKeySource":"environment",
+        "toolCount":5
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              SystemLogEntry(subtype, data)
+            )
+          ) =>
+        assertEquals(subtype, "init")
+        assertEquals(data("apiKeySource"), "environment")
+      case Some(entry) =>
+        fail(s"Expected SystemLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"progress" type with data and parentToolUseId produces ProgressLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"progress",
+        "uuid":"u10",
+        "sessionId":"s10",
+        "parentToolUseId":"tool-use-123",
+        "progress":0.75
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              ProgressLogEntry(data, parentToolUseId)
+            )
+          ) =>
+        assertEquals(parentToolUseId, Some("tool-use-123"))
+        assertEquals(data("progress"), 0.75)
+      case Some(entry) =>
+        fail(s"Expected ProgressLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"queue_operation" type with operation and content produces QueueOperationLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"queue_operation",
+        "uuid":"u11",
+        "sessionId":"s11",
+        "operation":"enqueue",
+        "content":"some message"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              QueueOperationLogEntry(operation, content)
+            )
+          ) =>
+        assertEquals(operation, "enqueue")
+        assertEquals(content, Some("some message"))
+      case Some(entry) =>
+        fail(s"Expected QueueOperationLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"file_history_snapshot" type with data produces FileHistorySnapshotLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"file_history_snapshot",
+        "uuid":"u12",
+        "sessionId":"s12",
+        "files":["/a.txt","/b.txt"]
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              FileHistorySnapshotLogEntry(data)
+            )
+          ) =>
+        assertEquals(data("files"), List("/a.txt", "/b.txt"))
+      case Some(entry) =>
+        fail(s"Expected FileHistorySnapshotLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(""""last_prompt" type with data produces LastPromptLogEntry"""):
+    val line =
+      """{
+        "type":"last_prompt",
+        "uuid":"u13",
+        "sessionId":"s13",
+        "promptText":"what is 2+2?"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(_, _, _, _, _, _, _, LastPromptLogEntry(data))
+          ) =>
+        assertEquals(data("promptText"), "what is 2+2?")
+      case Some(entry) =>
+        fail(s"Expected LastPromptLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test("unknown type produces RawLogEntry with preserved JSON"):
+    val line =
+      """{
+        "type":"future_type_v99",
+        "uuid":"u14",
+        "sessionId":"s14",
+        "someField":"someValue"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              RawLogEntry(entryType, json)
+            )
+          ) =>
+        assertEquals(entryType, "future_type_v99")
+        assert(json.isObject, "Expected preserved JSON object")
+      case Some(entry) => fail(s"Expected RawLogEntry, got: ${entry.payload}")
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  // --- TokenUsage tests ---
+
+  test("parses full token usage (all fields including cache and service_tier)"):
+    val line =
+      """{
+        "type":"assistant",
+        "uuid":"u15",
+        "sessionId":"s15",
+        "message":{
+          "content":[],
+          "usage":{
+            "input_tokens":200,
+            "output_tokens":80,
+            "cache_creation_input_tokens":30,
+            "cache_read_input_tokens":15,
+            "service_tier":"standard"
+          }
+        }
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AssistantLogEntry(_, _, Some(usage), _)
+            )
+          ) =>
+        assertEquals(usage.inputTokens, 200)
+        assertEquals(usage.outputTokens, 80)
+        assertEquals(usage.cacheCreationInputTokens, Some(30))
+        assertEquals(usage.cacheReadInputTokens, Some(15))
+        assertEquals(usage.serviceTier, Some("standard"))
+      case Some(entry) =>
+        fail(s"Expected AssistantLogEntry with usage, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test("parses minimal token usage (only input_tokens and output_tokens)"):
+    val line =
+      """{
+        "type":"assistant",
+        "uuid":"u16",
+        "sessionId":"s16",
+        "message":{
+          "content":[],
+          "usage":{
+            "input_tokens":10,
+            "output_tokens":5
+          }
+        }
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AssistantLogEntry(_, _, Some(usage), _)
+            )
+          ) =>
+        assertEquals(usage.inputTokens, 10)
+        assertEquals(usage.outputTokens, 5)
+        assertEquals(usage.cacheCreationInputTokens, None)
+        assertEquals(usage.cacheReadInputTokens, None)
+        assertEquals(usage.serviceTier, None)
+      case Some(entry) =>
+        fail(s"Expected AssistantLogEntry with usage, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  // --- Error path tests ---
+
+  test("\"system\" type without subtype returns None"):
+    val line =
+      """{"type":"system","uuid":"u20","sessionId":"s20","apiKeySource":"env"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"queue_operation\" type without operation returns None"):
+    val line =
+      """{"type":"queue_operation","uuid":"u21","sessionId":"s21","content":"msg"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"human\" type without message field returns None"):
+    val line =
+      """{"type":"human","uuid":"u22","sessionId":"s22"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"assistant\" type without message field returns None"):
+    val line =
+      """{"type":"assistant","uuid":"u23","sessionId":"s23"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("parseLogEntry with missing required type field returns None"):
+    val json = parser
+      .parse("""{"uuid":"u24","sessionId":"s24","message":{"content":"hi"}}""")
+      .getOrElse(fail("parse failed"))
+    assertEquals(ConversationLogParser.parseLogEntry(json), None)
+
+  test("malformed timestamp string results in None timestamp"):
+    val line =
+      """{
+        "type":"human",
+        "uuid":"u25",
+        "sessionId":"s25",
+        "timestamp":"not-a-date",
+        "message":{"content":"hi"}
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.timestamp, None)
+      case None        => fail("Expected Some(ConversationLogEntry)")

--- a/test/works/iterative/claude/core/model/ContentBlockTest.scala
+++ b/test/works/iterative/claude/core/model/ContentBlockTest.scala
@@ -1,0 +1,46 @@
+package works.iterative.claude.core.model
+
+// PURPOSE: Unit tests for ContentBlock sealed trait and all its variants
+// PURPOSE: Verifies ThinkingBlock and RedactedThinkingBlock are valid ContentBlock instances
+
+import munit.FunSuite
+
+class ContentBlockTest extends FunSuite:
+
+  test("ThinkingBlock should be a ContentBlock"):
+    val block: ContentBlock =
+      ThinkingBlock("some thinking content", "sig-abc123")
+    block match
+      case ThinkingBlock(thinking, signature) =>
+        assertEquals(thinking, "some thinking content")
+        assertEquals(signature, "sig-abc123")
+      case _ => fail("Expected ThinkingBlock")
+
+  test("RedactedThinkingBlock should be a ContentBlock"):
+    val block: ContentBlock = RedactedThinkingBlock("redacted-data-xyz")
+    block match
+      case RedactedThinkingBlock(data) =>
+        assertEquals(data, "redacted-data-xyz")
+      case _ => fail("Expected RedactedThinkingBlock")
+
+  test(
+    "ContentBlock variants include TextBlock, ToolUseBlock, ToolResultBlock, ThinkingBlock, RedactedThinkingBlock"
+  ):
+    val blocks: List[ContentBlock] = List(
+      TextBlock("hello"),
+      ToolUseBlock("id-1", "bash", Map.empty),
+      ToolResultBlock("id-1", Some("result"), None),
+      ThinkingBlock("thinking", "sig"),
+      RedactedThinkingBlock("redacted")
+    )
+    assertEquals(blocks.size, 5)
+
+  test("ThinkingBlock equality is structural"):
+    val a = ThinkingBlock("same", "sig")
+    val b = ThinkingBlock("same", "sig")
+    assertEquals(a, b)
+
+  test("RedactedThinkingBlock equality is structural"):
+    val a = RedactedThinkingBlock("data")
+    val b = RedactedThinkingBlock("data")
+    assertEquals(a, b)

--- a/test/works/iterative/claude/core/parsing/ContentBlockParserTest.scala
+++ b/test/works/iterative/claude/core/parsing/ContentBlockParserTest.scala
@@ -1,0 +1,74 @@
+package works.iterative.claude.core.parsing
+
+// PURPOSE: Unit tests for ContentBlockParser covering all five content block types
+// PURPOSE: Verifies correct parsing of text, tool_use, tool_result, thinking, and redacted_thinking blocks
+
+import munit.FunSuite
+import io.circe.parser
+import works.iterative.claude.core.model.*
+
+class ContentBlockParserTest extends FunSuite:
+
+  private def parseJson(jsonStr: String) =
+    parser
+      .parse(jsonStr)
+      .getOrElse(fail(s"Failed to parse test JSON: $jsonStr"))
+
+  test("parse text block returns TextBlock"):
+    val json = parseJson("""{"type":"text","text":"Hello world"}""")
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, Some(TextBlock("Hello world")))
+
+  test("parse tool_use block returns ToolUseBlock"):
+    val json = parseJson(
+      """{"type":"tool_use","id":"toolu_01","name":"Bash","input":{}}"""
+    )
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, Some(ToolUseBlock("toolu_01", "Bash", Map.empty)))
+
+  test("parse tool_result block returns ToolResultBlock"):
+    val json = parseJson(
+      """{"type":"tool_result","tool_use_id":"toolu_01","content":"output","is_error":false}"""
+    )
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(
+      result,
+      Some(ToolResultBlock("toolu_01", Some("output"), Some(false)))
+    )
+
+  test(
+    "parse tool_result block with optional fields absent returns ToolResultBlock"
+  ):
+    val json = parseJson(
+      """{"type":"tool_result","tool_use_id":"toolu_02"}"""
+    )
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, Some(ToolResultBlock("toolu_02", None, None)))
+
+  test("parse thinking block returns ThinkingBlock"):
+    val json = parseJson(
+      """{"type":"thinking","thinking":"I think therefore I am","signature":"sig123"}"""
+    )
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(
+      result,
+      Some(ThinkingBlock("I think therefore I am", "sig123"))
+    )
+
+  test("parse redacted_thinking block returns RedactedThinkingBlock"):
+    val json = parseJson(
+      """{"type":"redacted_thinking","data":"opaque_data_blob"}"""
+    )
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, Some(RedactedThinkingBlock("opaque_data_blob")))
+
+  test("parse unknown type returns None"):
+    val json =
+      parseJson("""{"type":"image","url":"https://example.com/img.png"}""")
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, None)
+
+  test("parse JSON without type field returns None"):
+    val json = parseJson("""{"text":"no type here"}""")
+    val result = ContentBlockParser.parseContentBlock(json)
+    assertEquals(result, None)

--- a/test/works/iterative/claude/direct/DirectPackageReexportTest.scala
+++ b/test/works/iterative/claude/direct/DirectPackageReexportTest.scala
@@ -1,0 +1,102 @@
+// PURPOSE: Compilation tests verifying works.iterative.claude.direct.* re-exports
+// PURPOSE: all log-related types, thinking block types, service traits and implementations
+
+package works.iterative.claude.direct
+
+import munit.FunSuite
+
+class DirectPackageReexportTest extends FunSuite:
+
+  test("direct.* re-exports ThinkingBlock"):
+    val block: ContentBlock = ThinkingBlock("some thoughts", "sig-abc")
+    block match
+      case ThinkingBlock(thinking, signature) =>
+        assertEquals(thinking, "some thoughts")
+        assertEquals(signature, "sig-abc")
+      case _ => fail("Expected ThinkingBlock")
+
+  test("direct.* re-exports RedactedThinkingBlock"):
+    val block: ContentBlock = RedactedThinkingBlock("redacted-data")
+    block match
+      case RedactedThinkingBlock(data) =>
+        assertEquals(data, "redacted-data")
+      case _ => fail("Expected RedactedThinkingBlock")
+
+  test("direct.* re-exports ConversationLogEntry"):
+    val _: Class[ConversationLogEntry] = classOf[ConversationLogEntry]
+
+  test("direct.* re-exports LogEntryPayload sealed trait"):
+    val _: Class[LogEntryPayload] = classOf[LogEntryPayload]
+
+  test("direct.* re-exports UserLogEntry"):
+    val entry = UserLogEntry(List(TextBlock("hello")))
+    assertEquals(entry.content.size, 1)
+
+  test("direct.* re-exports AssistantLogEntry"):
+    val entry = AssistantLogEntry(
+      content = List(TextBlock("hello")),
+      model = Some("claude-3-5-sonnet"),
+      usage = None,
+      requestId = None
+    )
+    assertEquals(entry.model, Some("claude-3-5-sonnet"))
+
+  test("direct.* re-exports SystemLogEntry"):
+    val entry = SystemLogEntry("init", Map.empty)
+    assertEquals(entry.subtype, "init")
+
+  test("direct.* re-exports ProgressLogEntry"):
+    val entry = ProgressLogEntry(Map.empty, None)
+    assertEquals(entry.parentToolUseId, None)
+
+  test("direct.* re-exports QueueOperationLogEntry"):
+    val entry = QueueOperationLogEntry("enqueue", Some("content"))
+    assertEquals(entry.operation, "enqueue")
+
+  test("direct.* re-exports FileHistorySnapshotLogEntry"):
+    val entry = FileHistorySnapshotLogEntry(Map("key" -> "value"))
+    assertEquals(entry.data.size, 1)
+
+  test("direct.* re-exports LastPromptLogEntry"):
+    val entry = LastPromptLogEntry(Map.empty)
+    assertEquals(entry.data.size, 0)
+
+  test("direct.* re-exports RawLogEntry"):
+    val json = io.circe.Json.fromString("raw")
+    val entry = RawLogEntry("unknown", json)
+    assertEquals(entry.entryType, "unknown")
+
+  test("direct.* re-exports TokenUsage"):
+    val usage = TokenUsage(100, 50, None, None, None)
+    assertEquals(usage.inputTokens, 100)
+    assertEquals(usage.outputTokens, 50)
+
+  test("direct.* re-exports LogFileMetadata"):
+    val _: Class[LogFileMetadata] = classOf[LogFileMetadata]
+
+  test("direct.* re-exports ConversationLogIndex trait"):
+    val _: Class[ConversationLogIndex[?]] = classOf[ConversationLogIndex[?]]
+
+  test("direct.* re-exports ConversationLogReader trait"):
+    val _: Class[ConversationLogReader[?]] = classOf[ConversationLogReader[?]]
+
+  test("direct.* re-exports DirectConversationLogIndex"):
+    val index: ConversationLogIndex[[A] =>> A] = DirectConversationLogIndex()
+    val tmpDir = os.temp.dir()
+    try
+      val sessions: Seq[LogFileMetadata] = index.listSessions(tmpDir)
+      assertEquals(sessions.size, 0)
+    finally os.remove.all(tmpDir)
+
+  test("direct.* re-exports DirectConversationLogReader"):
+    val reader: ConversationLogReader[[A] =>> A] = DirectConversationLogReader()
+    val tmpDir = os.temp.dir()
+    try
+      val emptyFile = tmpDir / "empty.jsonl"
+      os.write(emptyFile, "")
+      assertEquals(reader.readAll(emptyFile).size, 0)
+    finally os.remove.all(tmpDir)
+
+  test("direct.* re-exports ProjectPathDecoder"):
+    val decoded = ProjectPathDecoder.decode("-home-user-project")
+    assertEquals(decoded, "/home/user/project")

--- a/test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
+++ b/test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
@@ -96,6 +96,14 @@ class JsonParserTest extends munit.FunSuite with munit.ScalaCheckSuite:
         ).filter(_.nonEmpty)
         s"""{"type":"tool_result",${fields.mkString(",")}}"""
 
+      case ThinkingBlock(thinking, signature) =>
+        s"""{"type":"thinking","thinking":${escapeJsonString(
+            thinking
+          )},"signature":${escapeJsonString(signature)}}"""
+
+      case RedactedThinkingBlock(data) =>
+        s"""{"type":"redacted_thinking","data":${escapeJsonString(data)}}"""
+
     private def escapeJsonString(str: String): String =
       "\"" + str
         .replace("\\", "\\\\")

--- a/test/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+++ b/test/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
@@ -1,0 +1,110 @@
+// PURPOSE: Integration tests for DirectConversationLogIndex using real temp directories
+// PURPOSE: Verifies listSessions and forSession with actual file system operations
+
+package works.iterative.claude.direct.log
+
+import munit.FunSuite
+import java.time.Instant
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+class DirectConversationLogIndexTest extends FunSuite:
+
+  private val index = DirectConversationLogIndex()
+
+  // Helper to create a temp project directory with .jsonl session files
+  private def withProjectDir(
+      dirName: String,
+      sessionIds: List[String]
+  )(body: os.Path => Unit): Unit =
+    val tmpRoot = os.temp.dir()
+    try
+      val projectDir = tmpRoot / dirName
+      os.makeDir.all(projectDir)
+      sessionIds.foreach: sid =>
+        os.write(projectDir / s"$sid.jsonl", "")
+      body(projectDir)
+    finally os.remove.all(tmpRoot)
+
+  test("listSessions returns empty Seq for empty project directory"):
+    withProjectDir("-home-mph-test-project", List.empty): projectDir =>
+      val result = index.listSessions(projectDir)
+      assertEquals(result, Seq.empty[LogFileMetadata])
+
+  test("listSessions finds all .jsonl files as sessions"):
+    val sessionIds = List("session-aaa", "session-bbb", "session-ccc")
+    withProjectDir("-home-mph-test-project", sessionIds): projectDir =>
+      val result = index.listSessions(projectDir)
+      assertEquals(result.length, 3)
+      val found = result.map(_.sessionId).toSet
+      assertEquals(found, sessionIds.toSet)
+
+  test("listSessions populates path pointing to .jsonl file"):
+    withProjectDir("-home-mph-test-project", List("my-session")): projectDir =>
+      val result = index.listSessions(projectDir)
+      assertEquals(result.length, 1)
+      assert(
+        result.head.path.last == "my-session.jsonl",
+        s"Expected .jsonl file path but got ${result.head.path}"
+      )
+
+  test(
+    "listSessions populates sessionId from filename without .jsonl extension"
+  ):
+    withProjectDir("-home-mph-test-project", List("abc-def-123")): projectDir =>
+      val result = index.listSessions(projectDir)
+      assertEquals(result.head.sessionId, "abc-def-123")
+
+  test("listSessions decodes cwd from parent directory name"):
+    withProjectDir("-home-mph-Devel-myproject", List("session-x")):
+      projectDir =>
+        val result = index.listSessions(projectDir)
+        assertEquals(result.head.cwd, Some("/home/mph/Devel/myproject"))
+
+  test("listSessions populates fileSize from stat"):
+    withProjectDir("-home-mph-test", List("session-y")): projectDir =>
+      val jsonlPath = projectDir / "session-y.jsonl"
+      os.write.over(jsonlPath, "some content here")
+      val result = index.listSessions(projectDir)
+      assert(result.head.fileSize > 0L, "Expected non-zero file size")
+
+  test("listSessions sets summary, gitBranch, createdAt to None"):
+    withProjectDir("-home-mph-test", List("session-z")): projectDir =>
+      val result = index.listSessions(projectDir)
+      assertEquals(result.head.summary, None)
+      assertEquals(result.head.gitBranch, None)
+      assertEquals(result.head.createdAt, None)
+
+  test("listSessions ignores non-.jsonl files"):
+    val tmpRoot = os.temp.dir()
+    try
+      val projectDir = tmpRoot / "-home-mph-proj"
+      os.makeDir.all(projectDir)
+      os.write(projectDir / "session-good.jsonl", "")
+      os.write(projectDir / "notes.txt", "")
+      os.write(projectDir / "data.json", "")
+      val result = index.listSessions(projectDir)
+      assertEquals(result.length, 1)
+      assertEquals(result.head.sessionId, "session-good")
+    finally os.remove.all(tmpRoot)
+
+  test("forSession returns Some(metadata) when session exists"):
+    withProjectDir("-home-mph-test", List("session-find-me")): projectDir =>
+      val result = index.forSession(projectDir, "session-find-me")
+      assert(
+        result.isDefined,
+        "Expected Some(LogFileMetadata) for existing session"
+      )
+      assertEquals(result.get.sessionId, "session-find-me")
+
+  test("forSession returns None when session does not exist"):
+    withProjectDir("-home-mph-test", List("other-session")): projectDir =>
+      val result = index.forSession(projectDir, "nonexistent-session")
+      assertEquals(result, None)
+
+  test("forSession returns metadata with correct path"):
+    withProjectDir("-home-mph-test", List("target-session")): projectDir =>
+      val result = index.forSession(projectDir, "target-session")
+      result match
+        case Some(meta) =>
+          assertEquals(meta.path, projectDir / "target-session.jsonl")
+        case None => fail("Expected Some(LogFileMetadata)")

--- a/test/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+++ b/test/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
@@ -1,0 +1,92 @@
+// PURPOSE: Integration tests for DirectConversationLogReader using real temp .jsonl files
+// PURPOSE: Verifies readAll and stream parse log entries correctly with actual file I/O
+
+package works.iterative.claude.direct.log
+
+import munit.FunSuite
+import ox.*
+import works.iterative.claude.core.log.model.*
+
+class DirectConversationLogReaderTest extends FunSuite:
+
+  private val reader = DirectConversationLogReader()
+
+  private val humanLine =
+    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val assistantLine =
+    """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
+  private val systemLine =
+    """{"type":"system","uuid":"u3","sessionId":"s1","subtype":"init","apiKeySource":"env"}"""
+  private val emptyLine = ""
+  private val blankLine = "   "
+
+  private def withLogFile(lines: List[String])(body: os.Path => Unit): Unit =
+    val tmpDir = os.temp.dir()
+    try
+      val logFile = tmpDir / "test-session.jsonl"
+      os.write(logFile, lines.mkString("\n"))
+      body(logFile)
+    finally os.remove.all(tmpDir)
+
+  test("readAll returns empty list for empty file"):
+    withLogFile(List.empty): path =>
+      val result = reader.readAll(path)
+      assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("readAll skips blank lines"):
+    withLogFile(List(emptyLine, blankLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("readAll parses a single human entry"):
+    withLogFile(List(humanLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result.length, 1)
+      assertEquals(result.head.sessionId, "s1")
+      assert(
+        result.head.payload.isInstanceOf[UserLogEntry],
+        s"Expected UserLogEntry but got ${result.head.payload}"
+      )
+
+  test("readAll parses multiple entries of different types"):
+    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result.length, 3)
+
+  test("readAll preserves order of entries"):
+    withLogFile(List(humanLine, assistantLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result.length, 2)
+      assert(result(0).payload.isInstanceOf[UserLogEntry])
+      assert(result(1).payload.isInstanceOf[AssistantLogEntry])
+
+  test("readAll skips malformed JSON lines silently"):
+    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result.length, 2)
+
+  test("readAll handles mixed blank and valid lines"):
+    withLogFile(List(emptyLine, humanLine, blankLine, assistantLine)): path =>
+      val result = reader.readAll(path)
+      assertEquals(result.length, 2)
+
+  test("stream produces same entries as readAll"):
+    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+      val fromReadAll = reader.readAll(path)
+      val fromStream = supervised:
+        reader.stream(path).runToList()
+      assertEquals(fromStream, fromReadAll)
+
+  test("stream returns empty flow for empty file"):
+    withLogFile(List.empty): path =>
+      val result = supervised:
+        reader.stream(path).runToList()
+      assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("stream skips blank and malformed lines"):
+    withLogFile(
+      List(emptyLine, humanLine, "{not json}", blankLine, assistantLine)
+    ): path =>
+      val result = supervised:
+        reader.stream(path).runToList()
+      assertEquals(result.length, 2)

--- a/test/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+++ b/test/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
@@ -1,0 +1,113 @@
+// PURPOSE: Compilation tests verifying works.iterative.claude.effectful.* re-exports
+// PURPOSE: all types including existing core types, log types, and effectful implementations
+
+package works.iterative.claude.effectful
+
+import munit.CatsEffectSuite
+import cats.effect.IO
+
+class EffectfulPackageReexportTest extends CatsEffectSuite:
+
+  test("effectful.* re-exports QueryOptions"):
+    val opts = QueryOptions.simple("hello")
+    assertEquals(opts.prompt, "hello")
+
+  test("effectful.* re-exports UserMessage"):
+    val msg: Message = UserMessage("hello")
+    assert(msg.isInstanceOf[UserMessage])
+
+  test("effectful.* re-exports AssistantMessage"):
+    val msg: Message = AssistantMessage(List.empty)
+    assert(msg.isInstanceOf[AssistantMessage])
+
+  test("effectful.* re-exports SystemMessage"):
+    val msg: Message = SystemMessage("init", Map.empty)
+    assert(msg.isInstanceOf[SystemMessage])
+
+  test("effectful.* re-exports ContentBlock types"):
+    val blocks: List[ContentBlock] = List(
+      TextBlock("text"),
+      ToolUseBlock("id", "tool", Map.empty),
+      ToolResultBlock("id", None, None),
+      ThinkingBlock("thoughts", "sig"),
+      RedactedThinkingBlock("redacted")
+    )
+    assertEquals(blocks.size, 5)
+
+  test("effectful.* re-exports PermissionMode"):
+    val mode = PermissionMode.AcceptEdits
+    assert(mode.isInstanceOf[PermissionMode])
+
+  test("effectful.* re-exports ConversationLogEntry"):
+    val _: Class[ConversationLogEntry] = classOf[ConversationLogEntry]
+
+  test("effectful.* re-exports LogEntryPayload sealed trait"):
+    val _: Class[LogEntryPayload] = classOf[LogEntryPayload]
+
+  test("effectful.* re-exports UserLogEntry"):
+    val entry = UserLogEntry(List(TextBlock("hello")))
+    assertEquals(entry.content.size, 1)
+
+  test("effectful.* re-exports AssistantLogEntry"):
+    val entry = AssistantLogEntry(List.empty, Some("model"), None, None)
+    assertEquals(entry.model, Some("model"))
+
+  test("effectful.* re-exports SystemLogEntry"):
+    val entry = SystemLogEntry("init", Map.empty)
+    assertEquals(entry.subtype, "init")
+
+  test("effectful.* re-exports ProgressLogEntry"):
+    val entry = ProgressLogEntry(Map.empty, None)
+    assertEquals(entry.parentToolUseId, None)
+
+  test("effectful.* re-exports QueueOperationLogEntry"):
+    val entry = QueueOperationLogEntry("enqueue", None)
+    assertEquals(entry.operation, "enqueue")
+
+  test("effectful.* re-exports FileHistorySnapshotLogEntry"):
+    val entry = FileHistorySnapshotLogEntry(Map.empty)
+    assertEquals(entry.data.size, 0)
+
+  test("effectful.* re-exports LastPromptLogEntry"):
+    val entry = LastPromptLogEntry(Map.empty)
+    assertEquals(entry.data.size, 0)
+
+  test("effectful.* re-exports RawLogEntry"):
+    val json = io.circe.Json.fromString("raw")
+    val entry = RawLogEntry("unknown", json)
+    assertEquals(entry.entryType, "unknown")
+
+  test("effectful.* re-exports TokenUsage"):
+    val usage = TokenUsage(100, 50, None, None, None)
+    assertEquals(usage.inputTokens, 100)
+
+  test("effectful.* re-exports LogFileMetadata"):
+    val _: Class[LogFileMetadata] = classOf[LogFileMetadata]
+
+  test("effectful.* re-exports ConversationLogIndex trait"):
+    val _: Class[ConversationLogIndex[?]] = classOf[ConversationLogIndex[?]]
+
+  test("effectful.* re-exports ConversationLogReader trait"):
+    val _: Class[ConversationLogReader[?]] = classOf[ConversationLogReader[?]]
+
+  test("effectful.* re-exports EffectfulConversationLogIndex"):
+    val index: ConversationLogIndex[IO] = EffectfulConversationLogIndex()
+    val tmpDir = os.temp.dir()
+    for sessions <- index.listSessions(tmpDir)
+    yield
+      assertEquals(sessions.size, 0)
+      os.remove.all(tmpDir)
+
+  test("effectful.* re-exports EffectfulConversationLogReader"):
+    val reader: ConversationLogReader[IO] = EffectfulConversationLogReader()
+    val tmpDir = os.temp.dir()
+    val emptyFile = tmpDir / "empty.jsonl"
+    os.write(emptyFile, "")
+    for entries <- reader.readAll(emptyFile)
+    yield
+      assertEquals(entries.size, 0)
+      os.remove.all(tmpDir)
+
+  test("effectful.* re-exports ProjectPathDecoder"):
+    val decoded = ProjectPathDecoder.decode("-home-user-project")
+    assertEquals(decoded, "/home/user/project")

--- a/test/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
+++ b/test/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
@@ -1,0 +1,105 @@
+// PURPOSE: Integration tests for EffectfulConversationLogIndex using real temp directories
+// PURPOSE: Verifies listSessions and forSession with cats-effect IO assertions
+
+package works.iterative.claude.effectful.log
+
+import munit.CatsEffectSuite
+import cats.effect.IO
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+class EffectfulConversationLogIndexTest extends CatsEffectSuite:
+
+  private val index = EffectfulConversationLogIndex()
+
+  private def withProjectDir(
+      dirName: String,
+      sessionIds: List[String]
+  )(body: os.Path => IO[Unit]): IO[Unit] =
+    IO(os.temp.dir()).flatMap: tmpRoot =>
+      val projectDir = tmpRoot / dirName
+      IO(os.makeDir.all(projectDir)) >>
+        IO(
+          sessionIds.foreach(sid => os.write(projectDir / s"$sid.jsonl", ""))
+        ) >>
+        body(projectDir).guarantee(IO(os.remove.all(tmpRoot)))
+
+  test("listSessions returns empty Seq for empty project directory"):
+    withProjectDir("-home-mph-test-project", List.empty): projectDir =>
+      index
+        .listSessions(projectDir)
+        .map: result =>
+          assertEquals(result.toList, List.empty[LogFileMetadata])
+
+  test("listSessions finds all .jsonl files as sessions"):
+    val sessionIds = List("session-aaa", "session-bbb", "session-ccc")
+    withProjectDir("-home-mph-test-project", sessionIds): projectDir =>
+      index
+        .listSessions(projectDir)
+        .map: result =>
+          assertEquals(result.length, 3)
+          val found = result.map(_.sessionId).toSet
+          assertEquals(found, sessionIds.toSet)
+
+  test("listSessions populates sessionId from filename without extension"):
+    withProjectDir("-home-mph-test-project", List("abc-def-123")): projectDir =>
+      index
+        .listSessions(projectDir)
+        .map: result =>
+          assertEquals(result.head.sessionId, "abc-def-123")
+
+  test("listSessions decodes cwd from parent directory name"):
+    withProjectDir("-home-mph-Devel-myproject", List("session-x")):
+      projectDir =>
+        index
+          .listSessions(projectDir)
+          .map: result =>
+            assertEquals(result.head.cwd, Some("/home/mph/Devel/myproject"))
+
+  test("listSessions sets summary, gitBranch, createdAt to None"):
+    withProjectDir("-home-mph-test", List("session-z")): projectDir =>
+      index
+        .listSessions(projectDir)
+        .map: result =>
+          assertEquals(result.head.summary, None)
+          assertEquals(result.head.gitBranch, None)
+          assertEquals(result.head.createdAt, None)
+
+  test("listSessions ignores non-.jsonl files"):
+    IO(os.temp.dir()).flatMap: tmpRoot =>
+      val projectDir = tmpRoot / "-home-mph-proj"
+      IO(os.makeDir.all(projectDir)) >>
+        IO(os.write(projectDir / "session-good.jsonl", "")) >>
+        IO(os.write(projectDir / "notes.txt", "")) >>
+        index
+          .listSessions(projectDir)
+          .map: result =>
+            assertEquals(result.length, 1)
+            assertEquals(result.head.sessionId, "session-good")
+          .guarantee(IO(os.remove.all(tmpRoot)))
+
+  test("forSession returns Some(metadata) when session exists"):
+    withProjectDir("-home-mph-test", List("session-find-me")): projectDir =>
+      index
+        .forSession(projectDir, "session-find-me")
+        .map: result =>
+          assert(
+            result.isDefined,
+            "Expected Some(LogFileMetadata) for existing session"
+          )
+          assertEquals(result.get.sessionId, "session-find-me")
+
+  test("forSession returns None when session does not exist"):
+    withProjectDir("-home-mph-test", List("other-session")): projectDir =>
+      index
+        .forSession(projectDir, "nonexistent-session")
+        .map: result =>
+          assertEquals(result, None)
+
+  test("forSession returns metadata with correct path"):
+    withProjectDir("-home-mph-test", List("target-session")): projectDir =>
+      index
+        .forSession(projectDir, "target-session")
+        .map:
+          case Some(meta) =>
+            assertEquals(meta.path, projectDir / "target-session.jsonl")
+          case None => fail("Expected Some(LogFileMetadata)")

--- a/test/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
+++ b/test/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
@@ -1,0 +1,102 @@
+// PURPOSE: Integration tests for EffectfulConversationLogReader using real temp .jsonl files
+// PURPOSE: Verifies readAll and stream parse log entries correctly via cats-effect IO
+
+package works.iterative.claude.effectful.log
+
+import munit.CatsEffectSuite
+import cats.effect.IO
+import works.iterative.claude.core.log.model.*
+
+class EffectfulConversationLogReaderTest extends CatsEffectSuite:
+
+  private val reader = EffectfulConversationLogReader()
+
+  private val humanLine =
+    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val assistantLine =
+    """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
+  private val systemLine =
+    """{"type":"system","uuid":"u3","sessionId":"s1","subtype":"init","apiKeySource":"env"}"""
+
+  private def withLogFile(lines: List[String])(
+      body: os.Path => IO[Unit]
+  ): IO[Unit] =
+    IO(os.temp.dir()).flatMap: tmpDir =>
+      val logFile = tmpDir / "test-session.jsonl"
+      IO(os.write(logFile, lines.mkString("\n"))) >>
+        body(logFile).guarantee(IO(os.remove.all(tmpDir)))
+
+  test("readAll returns empty list for empty file"):
+    withLogFile(List.empty): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("readAll skips blank lines"):
+    withLogFile(List("", "   ")): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("readAll parses a single human entry"):
+    withLogFile(List(humanLine)): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result.length, 1)
+          assertEquals(result.head.sessionId, "s1")
+          assert(
+            result.head.payload.isInstanceOf[UserLogEntry],
+            s"Expected UserLogEntry but got ${result.head.payload}"
+          )
+
+  test("readAll parses multiple entries of different types"):
+    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result.length, 3)
+
+  test("readAll preserves order of entries"):
+    withLogFile(List(humanLine, assistantLine)): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result.length, 2)
+          assert(result(0).payload.isInstanceOf[UserLogEntry])
+          assert(result(1).payload.isInstanceOf[AssistantLogEntry])
+
+  test("readAll skips malformed JSON lines silently"):
+    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+      reader
+        .readAll(path)
+        .map: result =>
+          assertEquals(result.length, 2)
+
+  test("stream produces same entries as readAll"):
+    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+      for
+        fromReadAll <- reader.readAll(path)
+        fromStream <- reader.stream(path).compile.toList
+      yield assertEquals(fromStream, fromReadAll)
+
+  test("stream returns empty for empty file"):
+    withLogFile(List.empty): path =>
+      reader
+        .stream(path)
+        .compile
+        .toList
+        .map: result =>
+          assertEquals(result, List.empty[ConversationLogEntry])
+
+  test("stream skips blank and malformed lines"):
+    withLogFile(List("", humanLine, "{not json}", "   ", assistantLine)):
+      path =>
+        reader
+          .stream(path)
+          .compile
+          .toList
+          .map: result =>
+            assertEquals(result.length, 2)

--- a/works/iterative/claude/core/log/ConversationLogIndex.scala
+++ b/works/iterative/claude/core/log/ConversationLogIndex.scala
@@ -1,0 +1,13 @@
+// PURPOSE: Abstract contract for discovering and looking up Claude Code conversation log files
+// PURPOSE: Parameterised by effect type F so both direct and effectful implementations can satisfy it
+
+package works.iterative.claude.core.log
+
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+trait ConversationLogIndex[F[_]]:
+  def listSessions(projectPath: os.Path): F[Seq[LogFileMetadata]]
+  def forSession(
+      projectPath: os.Path,
+      sessionId: String
+  ): F[Option[LogFileMetadata]]

--- a/works/iterative/claude/core/log/ConversationLogReader.scala
+++ b/works/iterative/claude/core/log/ConversationLogReader.scala
@@ -1,0 +1,11 @@
+// PURPOSE: Abstract contract for reading entries from a Claude Code conversation log file
+// PURPOSE: Parameterised by effect type F; the EntryStream type member lets each implementation choose its stream type
+
+package works.iterative.claude.core.log
+
+import works.iterative.claude.core.log.model.ConversationLogEntry
+
+trait ConversationLogReader[F[_]]:
+  type EntryStream
+  def readAll(path: os.Path): F[List[ConversationLogEntry]]
+  def stream(path: os.Path): EntryStream

--- a/works/iterative/claude/core/log/LogFileMetadataBuilder.scala
+++ b/works/iterative/claude/core/log/LogFileMetadataBuilder.scala
@@ -1,0 +1,24 @@
+// PURPOSE: Builds LogFileMetadata from filesystem stat information and path decoding
+// PURPOSE: Shared pure logic used by both direct and effectful ConversationLogIndex implementations
+
+package works.iterative.claude.core.log
+
+import java.time.Instant
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+object LogFileMetadataBuilder:
+
+  def fromStat(projectPath: os.Path, path: os.Path): LogFileMetadata =
+    val stat = os.stat(path)
+    val sessionId = path.last.stripSuffix(".jsonl")
+    val cwd = ProjectPathDecoder.decode(projectPath.last)
+    LogFileMetadata(
+      path = path,
+      sessionId = sessionId,
+      summary = None,
+      lastModified = Instant.ofEpochMilli(stat.mtime.toMillis),
+      fileSize = stat.size,
+      cwd = if cwd.isEmpty then None else Some(cwd),
+      gitBranch = None,
+      createdAt = None
+    )

--- a/works/iterative/claude/core/log/ProjectPathDecoder.scala
+++ b/works/iterative/claude/core/log/ProjectPathDecoder.scala
@@ -1,0 +1,22 @@
+// PURPOSE: Pure utility for decoding Claude project directory names to filesystem path strings
+// PURPOSE: Converts the dash-encoded directory names back to absolute path strings
+
+package works.iterative.claude.core.log
+
+object ProjectPathDecoder:
+
+  /** Decodes a Claude project directory name to a best-effort filesystem path.
+    *
+    * Claude encodes project paths by replacing each `/` separator with `-`.
+    * This reverses the encoding by replacing every `-` with `/`. The result is
+    * ambiguous when original path segments contained `-` characters; callers
+    * should validate against the filesystem if accuracy is required.
+    *
+    * Examples:
+    *   - "-home-mph-Devel" → "/home/mph/Devel"
+    *   - "-" → "/"
+    *   - "" → ""
+    */
+  def decode(dirName: String): String =
+    if dirName.isEmpty then ""
+    else dirName.replace('-', '/')

--- a/works/iterative/claude/core/log/model/ConversationLogEntry.scala
+++ b/works/iterative/claude/core/log/model/ConversationLogEntry.scala
@@ -1,0 +1,17 @@
+package works.iterative.claude.core.log.model
+
+// PURPOSE: Envelope type for a single entry in a Claude Code conversation log file
+// PURPOSE: Carries common metadata shared across all log entry types
+
+import java.time.Instant
+
+case class ConversationLogEntry(
+    uuid: String,
+    parentUuid: Option[String],
+    timestamp: Option[Instant],
+    sessionId: String,
+    isSidechain: Boolean,
+    cwd: Option[String],
+    version: Option[String],
+    payload: LogEntryPayload
+)

--- a/works/iterative/claude/core/log/model/LogEntryPayload.scala
+++ b/works/iterative/claude/core/log/model/LogEntryPayload.scala
@@ -1,0 +1,48 @@
+package works.iterative.claude.core.log.model
+
+// PURPOSE: Sealed type hierarchy for conversation log entry payloads
+// PURPOSE: Represents all known entry types in Claude Code conversation log files
+
+import works.iterative.claude.core.model.ContentBlock
+import io.circe.Json
+
+sealed trait LogEntryPayload
+
+case class UserLogEntry(
+    content: List[ContentBlock]
+) extends LogEntryPayload
+
+case class AssistantLogEntry(
+    content: List[ContentBlock],
+    model: Option[String],
+    usage: Option[TokenUsage],
+    requestId: Option[String]
+) extends LogEntryPayload
+
+case class SystemLogEntry(
+    subtype: String,
+    data: Map[String, Any]
+) extends LogEntryPayload
+
+case class ProgressLogEntry(
+    data: Map[String, Any],
+    parentToolUseId: Option[String]
+) extends LogEntryPayload
+
+case class QueueOperationLogEntry(
+    operation: String,
+    content: Option[String]
+) extends LogEntryPayload
+
+case class FileHistorySnapshotLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
+case class LastPromptLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
+case class RawLogEntry(
+    entryType: String,
+    json: Json
+) extends LogEntryPayload

--- a/works/iterative/claude/core/log/model/LogFileMetadata.scala
+++ b/works/iterative/claude/core/log/model/LogFileMetadata.scala
@@ -1,0 +1,17 @@
+package works.iterative.claude.core.log.model
+
+// PURPOSE: Metadata about a Claude Code conversation log file for index and discovery
+// PURPOSE: Provides session identification and file statistics without loading the full log
+
+import java.time.Instant
+
+case class LogFileMetadata(
+    path: os.Path,
+    sessionId: String,
+    summary: Option[String],
+    lastModified: Instant,
+    fileSize: Long,
+    cwd: Option[String],
+    gitBranch: Option[String],
+    createdAt: Option[Instant]
+)

--- a/works/iterative/claude/core/log/model/TokenUsage.scala
+++ b/works/iterative/claude/core/log/model/TokenUsage.scala
@@ -1,0 +1,12 @@
+package works.iterative.claude.core.log.model
+
+// PURPOSE: Token usage statistics from Claude API responses in conversation logs
+// PURPOSE: Captures input/output tokens and optional cache-related token counts
+
+case class TokenUsage(
+    inputTokens: Int,
+    outputTokens: Int,
+    cacheCreationInputTokens: Option[Int],
+    cacheReadInputTokens: Option[Int],
+    serviceTier: Option[String]
+)

--- a/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+++ b/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
@@ -1,0 +1,177 @@
+package works.iterative.claude.core.log.parsing
+
+// PURPOSE: Pure parsing of JSONL conversation log lines into typed ConversationLogEntry values
+// PURPOSE: Dispatches to per-type payload parsers and reuses ContentBlockParser for content blocks
+
+import io.circe.{HCursor, Json, parser}
+import java.time.Instant
+import works.iterative.claude.core.log.model.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.core.parsing.ContentBlockParser
+
+object ConversationLogParser:
+
+  private val EnvelopeKeys: Set[String] =
+    Set(
+      "type",
+      "uuid",
+      "parentUuid",
+      "timestamp",
+      "sessionId",
+      "isSidechain",
+      "cwd",
+      "version"
+    )
+
+  def parseLogLine(line: String): Option[ConversationLogEntry] =
+    if line.trim.isEmpty then None
+    else
+      parser.parse(line) match
+        case Right(json) => parseLogEntry(json)
+        case Left(_)     => None
+
+  def parseLogEntry(json: Json): Option[ConversationLogEntry] =
+    val cursor = json.hcursor
+    for
+      uuid <- cursor.get[String]("uuid").toOption
+      sessionId <- cursor.get[String]("sessionId").toOption
+      entryType <- cursor.get[String]("type").toOption
+      parentUuid = cursor.get[String]("parentUuid").toOption
+      timestamp = cursor.get[String]("timestamp").toOption.flatMap(parseInstant)
+      isSidechain = cursor.get[Boolean]("isSidechain").toOption.getOrElse(false)
+      cwd = cursor.get[String]("cwd").toOption
+      version = cursor.get[String]("version").toOption
+      payload <- parsePayload(entryType, cursor, json)
+    yield ConversationLogEntry(
+      uuid,
+      parentUuid,
+      timestamp,
+      sessionId,
+      isSidechain,
+      cwd,
+      version,
+      payload
+    )
+
+  private def parseInstant(s: String): Option[Instant] =
+    try Some(Instant.parse(s))
+    catch case _: java.time.format.DateTimeParseException => None
+
+  private def parsePayload(
+      entryType: String,
+      cursor: HCursor,
+      json: Json
+  ): Option[LogEntryPayload] =
+    entryType match
+      case "human"                 => parseUserPayload(cursor)
+      case "assistant"             => parseAssistantPayload(cursor)
+      case "system"                => parseSystemPayload(cursor, json)
+      case "progress"              => Some(parseProgressPayload(cursor, json))
+      case "queue_operation"       => parseQueueOperationPayload(cursor)
+      case "file_history_snapshot" =>
+        Some(parseDataOnlyPayload(json, FileHistorySnapshotLogEntry.apply))
+      case "last_prompt" =>
+        Some(parseDataOnlyPayload(json, LastPromptLogEntry.apply))
+      case _ => Some(RawLogEntry(entryType, json))
+
+  private def parseContentBlocks(cursor: HCursor): List[ContentBlock] =
+    cursor
+      .get[List[Json]]("content")
+      .toOption
+      .map(_.flatMap(ContentBlockParser.parseContentBlock))
+      .orElse(
+        cursor.get[String]("content").toOption.map(s => List(TextBlock(s)))
+      )
+      .getOrElse(List.empty)
+
+  private def parseUserPayload(cursor: HCursor): Option[LogEntryPayload] =
+    cursor
+      .get[Json]("message")
+      .toOption
+      .map: messageJson =>
+        UserLogEntry(parseContentBlocks(messageJson.hcursor))
+
+  private def parseAssistantPayload(cursor: HCursor): Option[LogEntryPayload] =
+    cursor
+      .get[Json]("message")
+      .toOption
+      .map: messageJson =>
+        val messageCursor = messageJson.hcursor
+        val content = parseContentBlocks(messageCursor)
+        val model = messageCursor.get[String]("model").toOption
+        val usage =
+          messageCursor.get[Json]("usage").toOption.flatMap(parseTokenUsage)
+        val requestId = cursor.get[String]("requestId").toOption
+        AssistantLogEntry(content, model, usage, requestId)
+
+  private def parseTokenUsage(json: Json): Option[TokenUsage] =
+    val cursor = json.hcursor
+    for
+      inputTokens <- cursor.get[Int]("input_tokens").toOption
+      outputTokens <- cursor.get[Int]("output_tokens").toOption
+    yield TokenUsage(
+      inputTokens = inputTokens,
+      outputTokens = outputTokens,
+      cacheCreationInputTokens =
+        cursor.get[Int]("cache_creation_input_tokens").toOption,
+      cacheReadInputTokens =
+        cursor.get[Int]("cache_read_input_tokens").toOption,
+      serviceTier = cursor.get[String]("service_tier").toOption
+    )
+
+  private def parseSystemPayload(
+      cursor: HCursor,
+      json: Json
+  ): Option[LogEntryPayload] =
+    cursor
+      .get[String]("subtype")
+      .toOption
+      .map: subtype =>
+        val data = extractDataMap(json, EnvelopeKeys + "subtype")
+        SystemLogEntry(subtype, data)
+
+  private def parseProgressPayload(
+      cursor: HCursor,
+      json: Json
+  ): LogEntryPayload =
+    val parentToolUseId = cursor.get[String]("parentToolUseId").toOption
+    val data = extractDataMap(json, EnvelopeKeys + "parentToolUseId")
+    ProgressLogEntry(data, parentToolUseId)
+
+  private def parseQueueOperationPayload(
+      cursor: HCursor
+  ): Option[LogEntryPayload] =
+    cursor
+      .get[String]("operation")
+      .toOption
+      .map: operation =>
+        val content = cursor.get[String]("content").toOption
+        QueueOperationLogEntry(operation, content)
+
+  // Generic parser for entry types that just need a data map (excluding envelope keys)
+  private def parseDataOnlyPayload(
+      json: Json,
+      wrap: Map[String, Any] => LogEntryPayload
+  ): LogEntryPayload =
+    val data = extractDataMap(json, EnvelopeKeys)
+    wrap(data)
+
+  private def extractDataMap(
+      json: Json,
+      excludeKeys: Set[String]
+  ): Map[String, Any] =
+    json.asObject
+      .map(_.toMap.filter { case (key, _) => !excludeKeys.contains(key) }.map {
+        case (key, value) => key -> extractJsonValue(value)
+      })
+      .getOrElse(Map.empty)
+
+  private def extractJsonValue(json: Json): Any =
+    json.fold(
+      jsonNull = null,
+      jsonBoolean = identity,
+      jsonNumber = num => num.toInt.orElse(num.toLong).getOrElse(num.toDouble),
+      jsonString = identity,
+      jsonArray = _.map(extractJsonValue).toList,
+      jsonObject = _.toMap.map { case (k, v) => k -> extractJsonValue(v) }
+    )

--- a/works/iterative/claude/core/model/ContentBlock.scala
+++ b/works/iterative/claude/core/model/ContentBlock.scala
@@ -19,3 +19,10 @@ case class ToolResultBlock(
     content: Option[String] = None,
     isError: Option[Boolean] = None
 ) extends ContentBlock
+
+case class ThinkingBlock(
+    thinking: String,
+    signature: String
+) extends ContentBlock
+
+case class RedactedThinkingBlock(data: String) extends ContentBlock

--- a/works/iterative/claude/core/parsing/ContentBlockParser.scala
+++ b/works/iterative/claude/core/parsing/ContentBlockParser.scala
@@ -1,0 +1,38 @@
+package works.iterative.claude.core.parsing
+
+// PURPOSE: Pure parsing of content blocks from Claude CLI JSON output
+// PURPOSE: Handles text, tool_use, tool_result, thinking, and redacted_thinking block types
+
+import io.circe.Json
+import works.iterative.claude.core.model.*
+
+object ContentBlockParser:
+
+  def parseContentBlock(json: Json): Option[ContentBlock] =
+    val cursor = json.hcursor
+    cursor
+      .get[String]("type")
+      .toOption
+      .flatMap:
+        case "text" =>
+          cursor.get[String]("text").toOption.map(TextBlock.apply)
+        case "tool_use" =>
+          for
+            id <- cursor.get[String]("id").toOption
+            name <- cursor.get[String]("name").toOption
+            input = Map.empty[String, Any] // Simplified for now
+          yield ToolUseBlock(id, name, input)
+        case "tool_result" =>
+          for
+            toolUseId <- cursor.get[String]("tool_use_id").toOption
+            content = cursor.get[String]("content").toOption
+            isError = cursor.get[Boolean]("is_error").toOption
+          yield ToolResultBlock(toolUseId, content, isError)
+        case "thinking" =>
+          for
+            thinking <- cursor.get[String]("thinking").toOption
+            signature <- cursor.get[String]("signature").toOption
+          yield ThinkingBlock(thinking, signature)
+        case "redacted_thinking" =>
+          cursor.get[String]("data").toOption.map(RedactedThinkingBlock.apply)
+        case _ => None

--- a/works/iterative/claude/core/parsing/JsonParser.scala
+++ b/works/iterative/claude/core/parsing/JsonParser.scala
@@ -40,31 +40,8 @@ object JsonParser:
       contentArray <- messageJson.hcursor
         .get[List[Json]]("content")
         .toOption
-      content = contentArray.flatMap(parseContentBlock)
+      content = contentArray.flatMap(ContentBlockParser.parseContentBlock)
     yield AssistantMessage(content)
-
-  // Content block parsing - handles different content types within messages
-  private def parseContentBlock(json: Json): Option[ContentBlock] =
-    val cursor = json.hcursor
-    cursor
-      .get[String]("type")
-      .toOption
-      .flatMap:
-        case "text" =>
-          cursor.get[String]("text").toOption.map(TextBlock.apply)
-        case "tool_use" =>
-          for
-            id <- cursor.get[String]("id").toOption
-            name <- cursor.get[String]("name").toOption
-            input = Map.empty[String, Any] // Simplified for now
-          yield ToolUseBlock(id, name, input)
-        case "tool_result" =>
-          for
-            toolUseId <- cursor.get[String]("tool_use_id").toOption
-            content = cursor.get[String]("content").toOption
-            isError = cursor.get[Boolean]("is_error").toOption
-          yield ToolResultBlock(toolUseId, content, isError)
-        case _ => None
 
   private def parseSystemMessage(
       json: Json,

--- a/works/iterative/claude/direct/log/DirectConversationLogIndex.scala
+++ b/works/iterative/claude/direct/log/DirectConversationLogIndex.scala
@@ -1,0 +1,29 @@
+// PURPOSE: Synchronous ConversationLogIndex that discovers and looks up .jsonl session files
+// PURPOSE: Returns plain values; no effect type required by callers
+
+package works.iterative.claude.direct.log
+
+import works.iterative.claude.core.log.ConversationLogIndex
+import works.iterative.claude.core.log.LogFileMetadataBuilder
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+class DirectConversationLogIndex extends ConversationLogIndex[[A] =>> A]:
+
+  def listSessions(projectPath: os.Path): Seq[LogFileMetadata] =
+    if !os.exists(projectPath) then Seq.empty
+    else
+      os.list(projectPath)
+        .filter(p => os.isFile(p) && p.last.endsWith(".jsonl"))
+        .map(LogFileMetadataBuilder.fromStat(projectPath, _))
+
+  def forSession(
+      projectPath: os.Path,
+      sessionId: String
+  ): Option[LogFileMetadata] =
+    val candidate = projectPath / s"$sessionId.jsonl"
+    if os.exists(candidate) && os.isFile(candidate) then
+      Some(LogFileMetadataBuilder.fromStat(projectPath, candidate))
+    else None
+
+object DirectConversationLogIndex:
+  def apply(): DirectConversationLogIndex = new DirectConversationLogIndex()

--- a/works/iterative/claude/direct/log/DirectConversationLogReader.scala
+++ b/works/iterative/claude/direct/log/DirectConversationLogReader.scala
@@ -1,0 +1,32 @@
+// PURPOSE: Synchronous ConversationLogReader that reads and streams .jsonl session log entries
+// PURPOSE: Returns plain values and lazy Flow; no effect type required by callers
+
+package works.iterative.claude.direct.log
+
+import ox.flow.Flow
+import works.iterative.claude.core.log.ConversationLogReader
+import works.iterative.claude.core.log.model.ConversationLogEntry
+import works.iterative.claude.core.log.parsing.ConversationLogParser
+
+class DirectConversationLogReader extends ConversationLogReader[[A] =>> A]:
+  type EntryStream = Flow[ConversationLogEntry]
+
+  def readAll(path: os.Path): List[ConversationLogEntry] =
+    os.read
+      .lines(path)
+      .flatMap(ConversationLogParser.parseLogLine)
+      .toList
+
+  def stream(path: os.Path): Flow[ConversationLogEntry] =
+    Flow
+      .usingEmit: emit =>
+        val source = scala.io.Source.fromFile(path.toIO)
+        try
+          source
+            .getLines()
+            .foreach: line =>
+              ConversationLogParser.parseLogLine(line).foreach(emit.apply)
+        finally source.close()
+
+object DirectConversationLogReader:
+  def apply(): DirectConversationLogReader = new DirectConversationLogReader()

--- a/works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala
+++ b/works/iterative/claude/effectful/log/EffectfulConversationLogIndex.scala
@@ -1,0 +1,43 @@
+// PURPOSE: IO-based ConversationLogIndex that discovers and looks up .jsonl session files
+// PURPOSE: All operations are deferred and composable within IO programs
+
+package works.iterative.claude.effectful.log
+
+import cats.effect.IO
+import fs2.io.file.{Files, Path => Fs2Path}
+import works.iterative.claude.core.log.ConversationLogIndex
+import works.iterative.claude.core.log.LogFileMetadataBuilder
+import works.iterative.claude.core.log.model.LogFileMetadata
+
+class EffectfulConversationLogIndex extends ConversationLogIndex[IO]:
+
+  def listSessions(projectPath: os.Path): IO[Seq[LogFileMetadata]] =
+    IO(os.exists(projectPath)).flatMap:
+      case false => IO.pure(Seq.empty)
+      case true  =>
+        val dir = Fs2Path.fromNioPath(projectPath.toNIO)
+        Files[IO]
+          .list(dir)
+          .filter(p => p.fileName.toString.endsWith(".jsonl"))
+          .evalMap(p =>
+            IO(
+              LogFileMetadataBuilder.fromStat(projectPath, os.Path(p.toNioPath))
+            )
+          )
+          .compile
+          .toList
+          .map(_.toSeq)
+
+  def forSession(
+      projectPath: os.Path,
+      sessionId: String
+  ): IO[Option[LogFileMetadata]] =
+    val candidate = projectPath / s"$sessionId.jsonl"
+    IO(os.exists(candidate) && os.isFile(candidate)).flatMap:
+      case true =>
+        IO(LogFileMetadataBuilder.fromStat(projectPath, candidate)).map(Some(_))
+      case false => IO.pure(None)
+
+object EffectfulConversationLogIndex:
+  def apply(): EffectfulConversationLogIndex =
+    new EffectfulConversationLogIndex()

--- a/works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala
+++ b/works/iterative/claude/effectful/log/EffectfulConversationLogReader.scala
@@ -1,0 +1,29 @@
+// PURPOSE: IO-based ConversationLogReader that reads and streams .jsonl session log entries
+// PURPOSE: All operations are deferred and composable within IO programs
+
+package works.iterative.claude.effectful.log
+
+import cats.effect.IO
+import fs2.Stream
+import fs2.io.file.{Files, Path => Fs2Path}
+import works.iterative.claude.core.log.ConversationLogReader
+import works.iterative.claude.core.log.model.ConversationLogEntry
+import works.iterative.claude.core.log.parsing.ConversationLogParser
+
+class EffectfulConversationLogReader extends ConversationLogReader[IO]:
+  type EntryStream = Stream[IO, ConversationLogEntry]
+
+  def readAll(path: os.Path): IO[List[ConversationLogEntry]] =
+    stream(path).compile.toList
+
+  def stream(path: os.Path): Stream[IO, ConversationLogEntry] =
+    Files[IO]
+      .readAll(Fs2Path.fromNioPath(path.toNIO))
+      .through(fs2.text.utf8.decode)
+      .through(fs2.text.lines)
+      .map(ConversationLogParser.parseLogLine)
+      .collect { case Some(entry) => entry }
+
+object EffectfulConversationLogReader:
+  def apply(): EffectfulConversationLogReader =
+    new EffectfulConversationLogReader()

--- a/works/iterative/claude/effectful/package.scala
+++ b/works/iterative/claude/effectful/package.scala
@@ -1,9 +1,9 @@
-// PURPOSE: Package object for direct API with convenient imports and type aliases
+// PURPOSE: Package object for effectful API with convenient imports and type aliases
 // PURPOSE: Enables single-import usage with all necessary model classes available
 
 package works.iterative.claude
 
-package object direct:
+package object effectful:
   // Type aliases for convenient usage
   type QueryOptions = works.iterative.claude.core.model.QueryOptions
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
@@ -75,15 +75,15 @@ package object direct:
   type ConversationLogReader[F[_]] =
     works.iterative.claude.core.log.ConversationLogReader[F]
 
-  // Direct log implementations
-  type DirectConversationLogIndex =
-    works.iterative.claude.direct.log.DirectConversationLogIndex
-  val DirectConversationLogIndex =
-    works.iterative.claude.direct.log.DirectConversationLogIndex
-  type DirectConversationLogReader =
-    works.iterative.claude.direct.log.DirectConversationLogReader
-  val DirectConversationLogReader =
-    works.iterative.claude.direct.log.DirectConversationLogReader
+  // Effectful log implementations
+  type EffectfulConversationLogIndex =
+    works.iterative.claude.effectful.log.EffectfulConversationLogIndex
+  val EffectfulConversationLogIndex =
+    works.iterative.claude.effectful.log.EffectfulConversationLogIndex
+  type EffectfulConversationLogReader =
+    works.iterative.claude.effectful.log.EffectfulConversationLogReader
+  val EffectfulConversationLogReader =
+    works.iterative.claude.effectful.log.EffectfulConversationLogReader
 
   // Utility
   type ProjectPathDecoder =


### PR DESCRIPTION
## Summary

- Add complete conversation log parsing for JSONL files stored in `~/.claude/projects/`, enabling access to thinking blocks, token usage, and full conversation structure that is unavailable through the streaming interface
- Introduce domain types (`ConversationLogEntry`, `LogEntryPayload` variants, `TokenUsage`, `LogFileMetadata`), extend `ContentBlock` with `ThinkingBlock` and `RedactedThinkingBlock`
- Extract `ContentBlockParser` from `JsonParser` for shared content block parsing between stream and log parsers
- Add `ConversationLogIndex` and `ConversationLogReader` service traits with both direct (os-lib/Ox) and effectful (cats-effect/fs2) implementations

## Implementation

6 phases completed, each with automated code review:

1. **Domain types** — `core.log.model` + `core.model` extensions
2. **Content block parsing extraction** — `core.parsing.ContentBlockParser`
3. **Log entry parser** — `core.log.parsing.ConversationLogParser`
4. **Service traits** — `core.log.ConversationLogIndex`, `ConversationLogReader`
5. **Service implementations** — `direct.log` + `effectful.log`
6. **Re-exports and documentation** — package objects, ARCHITECTURE.md, README.md

## Test plan

- [x] 103+ unit and integration tests across all phases
- [x] Domain type construction and field access tests
- [x] Content block parsing for all 5 block types (text, tool_use, tool_result, thinking, redacted_thinking)
- [x] Log parser tests for all 8 entry types + error paths + malformed input
- [x] Service trait compilation tests with Identity and IO type constructors
- [x] Direct and effectful index/reader integration tests with real temp directories and files
- [x] Package re-export compilation verification tests
- [x] Existing JsonParser tests pass unchanged (regression)

## Review

See `project-management/issues/CC-4/review-packet.md` for detailed review packet with entry points, diagrams, and scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)