### PR TITLE
Fix publish workflow secret names and conventions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,38 +7,26 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Cache Mill
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: |
-            ~/.mill
-            ~/.cache/mill
-            out/
-          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill') }}
-          restore-keys: |
-            ${{ runner.os }}-mill-
+          distribution: temurin
+          java-version: 21
+      - uses: coursier/cache-action@v6
 
       - name: Run tests
         run: ./mill __.test
 
       - name: Publish to Sonatype Central
         env:
-          MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}
-          MILL_PGP_PASSPHRASE: ${{ secrets.MILL_PGP_PASSPHRASE }}
-        run: ./mill mill.javalib.SonatypeCentralPublishModule/publishAll
+          MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}
+        run: ./mill mill.javalib.SonatypeCentralPublishModule/publishAll --publishArtifacts __.publishArtifacts


### PR DESCRIPTION
## Summary

- Align publish workflow with scalatags-web-awesome conventions
- Use same secret names (`MILL_SONATYPE_USERNAME`/`MILL_SONATYPE_PASSWORD`)
- Use `coursier/cache-action` instead of manual cache config
- Pass `--publishArtifacts __.publishArtifacts` explicitly
- Drop unused `MILL_PGP_PASSPHRASE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)