### PR TITLE
Fix CI: use released mill-iw-support 0.1.3

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mvnDeps: ["works.iterative::mill-iw-support::0.1.4-SNAPSHOT"]
+//| mvnDeps: ["works.iterative::mill-iw-support::0.1.3"]
 // PURPOSE: Mill build definition for the claude-code-query Scala SDK.
 // PURPOSE: Defines three modules: core (shared types/parsing), direct (Ox-based sync API), effectful (cats-effect/fs2 async API).
 package build


### PR DESCRIPTION
## Summary

- Switch from `mill-iw-support` 0.1.4-SNAPSHOT (only in local .ivy2) to 0.1.3 (published on Maven Central)
- Fixes publish workflow failure: CI couldn't resolve the SNAPSHOT dependency

## Test plan

- [x] All 397 tests pass locally
- [ ] CI publish workflow succeeds after merge + re-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)