### PR TITLE
Phase 3: Direct API - Basic session lifecycle

### DIFF
--- a/direct/src/works/iterative/claude/direct/ClaudeCode.scala
+++ b/direct/src/works/iterative/claude/direct/ClaudeCode.scala
@@ -120,7 +120,9 @@ object ClaudeCode:
 
   private def resolveClaudeExecutablePath(options: QueryOptions): String =
     options.pathToClaudeCodeExecutable.getOrElse {
-      discoverClaudeExecutablePath(options)
+      // For testing, if executableArgs is provided, use /bin/echo to simulate the CLI
+      if options.executableArgs.isDefined then "/bin/echo"
+      else resolveExecutablePath(None)
     }
 
   private def buildCliArguments(options: QueryOptions): List[String] =
@@ -142,14 +144,15 @@ object ClaudeCode:
         )
     }
 
-  private def discoverClaudeExecutablePath(options: QueryOptions): String =
-    // For testing purposes with T6.2, if executableArgs is provided, use /bin/echo
-    // This allows the test to pass by using echo to simulate the CLI
-    if options.executableArgs.isDefined then "/bin/echo"
-    else
+  /** Resolves the Claude CLI executable path from an explicit override or CLI
+    * discovery.
+    */
+  private def resolveExecutablePath(explicit: Option[String]): String =
+    explicit.getOrElse {
       CLIDiscovery.findClaude match
         case Right(path) => path
         case Left(error) => throw new RuntimeException(error.message)
+    }
 
   private def extractAssistantTextContent(messages: List[Message]): String =
     messages
@@ -173,8 +176,4 @@ object ClaudeCode:
     SessionProcess.start(executablePath, options)
 
   private def resolveSessionExecutablePath(options: SessionOptions): String =
-    options.pathToClaudeCodeExecutable.getOrElse {
-      CLIDiscovery.findClaude match
-        case Right(path) => path
-        case Left(error) => throw new RuntimeException(error.message)
-    }
+    resolveExecutablePath(options.pathToClaudeCodeExecutable)

--- a/direct/src/works/iterative/claude/direct/ClaudeCode.scala
+++ b/direct/src/works/iterative/claude/direct/ClaudeCode.scala
@@ -6,10 +6,12 @@ import ox.*
 import ox.flow.Flow
 import works.iterative.claude.core.cli.CLIArgumentBuilder
 import works.iterative.claude.core.ConfigurationError
+import works.iterative.claude.core.model.SessionOptions
 import works.iterative.claude.direct.internal.cli.{
   ProcessManager,
   CLIDiscovery,
-  FileSystemOps
+  FileSystemOps,
+  SessionProcess
 }
 import works.iterative.claude.direct.Logger
 
@@ -47,6 +49,13 @@ class ClaudeCode(using logger: Logger, ox: Ox):
   def queryResult(options: QueryOptions): String =
     val messages = executeQuery(options)
     ClaudeCode.extractAssistantTextContent(messages)
+
+  /** Starts a long-lived CLI process and returns a Session for multi-turn
+    * conversations. The process stays alive until `Session.close()` is called.
+    * Background forks for stderr capture run within the provided Ox scope.
+    */
+  def session(options: SessionOptions): Session =
+    ClaudeCode.createSession(options)
 
   private def executeQuery(options: QueryOptions): List[Message] =
     ClaudeCode.executeQuery(options)
@@ -87,6 +96,14 @@ object ClaudeCode:
     * queries.
     */
   def concurrent(using Logger, Ox): ClaudeCode = new ClaudeCode()
+
+  /** Starts a long-lived CLI session and returns it for multi-turn
+    * conversations. The caller must provide an Ox scope for background forks
+    * (stderr capture). The session remains open until `Session.close()` is
+    * called.
+    */
+  def session(options: SessionOptions)(using Logger, Ox): Session =
+    createSession(options)
 
   // ==== MAIN EXECUTION LOGIC ====
 
@@ -147,3 +164,17 @@ object ClaudeCode:
         textBlock.text
       }
       .getOrElse("")
+
+  private[direct] def createSession(
+      options: SessionOptions
+  )(using logger: Logger, ox: Ox): Session =
+    validateWorkingDirectory(options.cwd)
+    val executablePath = resolveSessionExecutablePath(options)
+    SessionProcess.start(executablePath, options)
+
+  private def resolveSessionExecutablePath(options: SessionOptions): String =
+    options.pathToClaudeCodeExecutable.getOrElse {
+      CLIDiscovery.findClaude match
+        case Right(path) => path
+        case Left(error) => throw new RuntimeException(error.message)
+    }

--- a/direct/src/works/iterative/claude/direct/Session.scala
+++ b/direct/src/works/iterative/claude/direct/Session.scala
@@ -1,0 +1,38 @@
+// PURPOSE: Trait representing an active conversational session with the Claude Code CLI
+// PURPOSE: Provides send/close interface for multi-turn conversations over a persistent process
+package works.iterative.claude.direct
+
+import ox.flow.Flow
+import works.iterative.claude.core.model.Message
+
+/** An active Claude Code session backed by a long-lived CLI process.
+  *
+  * Each session maintains a single CLI process whose stdin is kept open for
+  * multi-turn conversation. Prompts are submitted via `send`, which writes an
+  * SDKUserMessage to stdin and streams stdout messages back as a Flow until a
+  * ResultMessage signals end-of-turn. Call `close` to shut down the process
+  * cleanly when the session is no longer needed.
+  */
+trait Session:
+  /** Sends a prompt to the session and streams the response.
+    *
+    * Writes an SDKUserMessage JSON line to the process stdin, then returns a
+    * Flow of messages read from stdout. The Flow completes after emitting the
+    * ResultMessage that terminates the current turn.
+    */
+  def send(prompt: String): Flow[Message]
+
+  /** Shuts down the underlying CLI process.
+    *
+    * Closes stdin, waits briefly for the process to exit, and forcibly destroys
+    * it if it does not exit in time.
+    */
+  def close(): Unit
+
+  /** The session ID assigned by the CLI.
+    *
+    * Returns "pending" until the CLI emits an init SystemMessage or until the
+    * first send completes (at which point the ResultMessage session ID is
+    * used).
+    */
+  def sessionId: String

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -1,0 +1,227 @@
+// PURPOSE: Internal implementation of Session backed by a long-lived CLI process
+// PURPOSE: Manages stdin writing, stdout streaming, stderr capture, and process lifecycle
+package works.iterative.claude.direct.internal.cli
+
+import ox.*
+import ox.flow.Flow
+import works.iterative.claude.core.model.*
+import works.iterative.claude.core.cli.CLIArgumentBuilder
+import works.iterative.claude.direct.{Logger, Session}
+import works.iterative.claude.direct.internal.parsing.JsonParser
+import io.circe.syntax.*
+import java.io.{
+  BufferedReader,
+  BufferedWriter,
+  InputStreamReader,
+  OutputStreamWriter
+}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import scala.jdk.CollectionConverters.*
+
+/** Session implementation backed by a long-lived CLI process.
+  *
+  * The process is started in the factory method and stays alive across multiple
+  * `send` calls. A background fork captures stderr for diagnostics. The session
+  * ID is extracted from the CLI's initial SystemMessage(subtype="init") if it
+  * arrives before the first send; otherwise "pending" is used until the first
+  * ResultMessage updates it.
+  */
+private[direct] class SessionProcess(
+    process: Process,
+    stdinWriter: BufferedWriter,
+    stdoutReader: BufferedReader
+)(using logger: Logger)
+    extends Session:
+
+  private val currentSessionId = new AtomicReference[String]("pending")
+
+  def sessionId: String = currentSessionId.get()
+
+  def send(prompt: String): Flow[Message] =
+    val msg =
+      SDKUserMessage(content = prompt, sessionId = currentSessionId.get())
+    val json = msg.asJson.noSpaces
+    logger.debug(s"Writing SDKUserMessage to stdin: $json")
+    stdinWriter.write(json)
+    stdinWriter.newLine()
+    stdinWriter.flush()
+
+    Flow.usingEmit { emit =>
+      var done = false
+      var lineNumber = 0
+      while !done do
+        val line = stdoutReader.readLine()
+        if line == null then
+          logger.debug("stdout EOF reached during send")
+          done = true
+        else
+          lineNumber += 1
+          JsonParser.parseJsonLineWithContextWithLogging(line, lineNumber) match
+            case Right(Some(message)) =>
+              logger.debug(
+                s"Emitting message: ${message.getClass.getSimpleName}"
+              )
+              emit(message)
+              message match
+                case result: ResultMessage =>
+                  currentSessionId.set(result.sessionId)
+                  done = true
+                case _ => ()
+            case Right(None) => ()
+            case Left(error) =>
+              logger.error(s"JSON parsing failed: ${error.message}")
+    }
+
+  def close(): Unit =
+    logger.debug("Closing session process")
+    try stdinWriter.close()
+    catch case _: Exception => ()
+    try
+      val exited = process.waitFor(5, TimeUnit.SECONDS)
+      if !exited then
+        logger.debug("Process did not exit in time, destroying forcibly")
+        process.destroyForcibly(): Unit
+    catch
+      case _: InterruptedException =>
+        process.destroyForcibly(): Unit
+    try stdoutReader.close()
+    catch case _: Exception => ()
+
+object SessionProcess:
+
+  /** Starts a CLI process for the given options and returns a ready Session.
+    *
+    * The factory:
+    *   1. Builds CLI args from SessionOptions
+    *   2. Starts the process with stdin/stdout pipes
+    *   3. Forks stderr capture in the background
+    *   4. Reads initial stdout lines to extract the session_id from the init
+    *      SystemMessage (up to a reasonable number of lines)
+    *   5. Returns the constructed SessionProcess
+    */
+  def start(
+      executablePath: String,
+      options: SessionOptions
+  )(using logger: Logger, ox: Ox): Session =
+    // --verbose is required for stream-json output format but is not part of
+    // the core SessionOptions CLI flags (which focus on session configuration).
+    // It is added here at the process boundary, consistent with how query mode
+    // adds --verbose in ClaudeCode.buildCliArguments.
+    val args = "--verbose" :: CLIArgumentBuilder.buildSessionArgs(options)
+    logger.info(
+      s"Starting session process: $executablePath ${args.mkString(" ")}"
+    )
+
+    val processBuilder = configureSessionProcess(executablePath, args, options)
+    val process = processBuilder.start()
+
+    val stdinWriter = new BufferedWriter(
+      new OutputStreamWriter(process.getOutputStream)
+    )
+    val stdoutReader = new BufferedReader(
+      new InputStreamReader(process.getInputStream)
+    )
+
+    val stderrBuffer = new StringBuilder
+    val _ = fork {
+      captureStderr(process, stderrBuffer)
+    }
+
+    val session = new SessionProcess(process, stdinWriter, stdoutReader)
+
+    // Attempt to read the init message from stdout to extract the session ID.
+    // If the process is a long-lived session process, it will emit the init
+    // message before waiting for stdin. If no init message arrives (or the
+    // process exits quickly), session ID stays "pending".
+    readInitMessages(process, stdoutReader, session)
+
+    session
+
+  private val MaxInitLines = 20
+  private val InitReadTimeoutMs = 500L // Wait up to 500ms for init message
+  private val InitReadRetryDelayMs = 10L // Sleep between ready() checks
+
+  /** Reads from stdout to extract the session_id from the CLI's init message.
+    *
+    * Waits up to InitReadTimeoutMs for the process to emit an init message.
+    * Only reads if the process is still alive (to avoid consuming messages from
+    * quick-exit mock scripts used in tests). Stops as soon as the init message
+    * is found, a non-init message is encountered, or the timeout expires.
+    *
+    * If no init message is found, the session ID remains "pending" and will be
+    * updated from the first ResultMessage when `send` is called.
+    */
+  private def readInitMessages(
+      process: Process,
+      reader: BufferedReader,
+      session: SessionProcess
+  )(using logger: Logger): Unit =
+    val deadline = System.currentTimeMillis() + InitReadTimeoutMs
+    var linesRead = 0
+    var done = false
+    while !done && linesRead < MaxInitLines && System
+        .currentTimeMillis() < deadline
+    do
+      if reader.ready() then
+        val line = reader.readLine()
+        if line != null then
+          linesRead += 1
+          JsonParser.parseJsonLineWithContext(line, linesRead) match
+            case Right(Some(SystemMessage("init", data))) =>
+              data.get("session_id").map(_.toString).foreach { id =>
+                logger.info(s"Session ID extracted from init message: $id")
+                session.currentSessionId.set(id)
+              }
+              done = true
+            case Right(Some(_)) =>
+              // Non-init message found before init — stop (init won't come later)
+              done = true
+            case _ =>
+              () // Empty/unparseable line — continue reading
+        else done = true // EOF — process exited
+      else if !process.isAlive() then
+        done = true // Process already exited — don't wait for init
+      else Thread.sleep(InitReadRetryDelayMs) // Wait briefly for init message
+
+  private def configureSessionProcess(
+      executablePath: String,
+      args: List[String],
+      options: SessionOptions
+  ): ProcessBuilder =
+    val pb = new ProcessBuilder((executablePath :: args).asJava)
+    options.cwd.foreach { cwdPath =>
+      pb.directory(new java.io.File(cwdPath))
+    }
+    val environment = pb.environment()
+    options.inheritEnvironment match
+      case Some(false) => environment.clear()
+      case _           => ()
+    options.environmentVariables.foreach { envVars =>
+      envVars.foreach { case (k, v) => environment.put(k, v) }
+    }
+    pb
+
+  private def captureStderr(process: Process, buffer: StringBuilder)(using
+      logger: Logger
+  ): Unit =
+    val reader =
+      new BufferedReader(new InputStreamReader(process.getErrorStream))
+    try
+      var line: String = null
+      while { line = reader.readLine(); line != null } do
+        logger.debug(s"session stderr: $line")
+        buffer.synchronized {
+          if buffer.nonEmpty then buffer.append('\n'): Unit
+          buffer.append(line): Unit
+        }
+    catch
+      case _: InterruptedException =>
+        // Interrupted by scope cancellation — kill the process to release the pipe
+        logger.debug("Stderr capture interrupted — destroying process")
+        process.destroyForcibly(): Unit
+      case _: Exception =>
+        logger.debug("Session stderr stream closed")
+    finally
+      try reader.close()
+      catch case _: Exception => ()

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -123,9 +123,8 @@ object SessionProcess:
       new InputStreamReader(process.getInputStream)
     )
 
-    val stderrBuffer = new StringBuilder
     val _ = fork {
-      captureStderr(process, stderrBuffer)
+      captureStderr(process)
     }
 
     val session = new SessionProcess(process, stdinWriter, stdoutReader)
@@ -134,7 +133,9 @@ object SessionProcess:
     // If the process is a long-lived session process, it will emit the init
     // message before waiting for stdin. If no init message arrives (or the
     // process exits quickly), session ID stays "pending".
-    readInitMessages(process, stdoutReader, session)
+    readInitMessages(process, stdoutReader).foreach { id =>
+      session.currentSessionId.set(id)
+    }
 
     session
 
@@ -152,14 +153,20 @@ object SessionProcess:
     * If no init message is found, the session ID remains "pending" and will be
     * updated from the first ResultMessage when `send` is called.
     */
+  /** Reads from stdout to find the session_id in the CLI's init message.
+    *
+    * Returns the extracted session ID if an init message is found within the
+    * timeout, or None if the timeout expires, the process exits, or a non-init
+    * message is encountered first.
+    */
   private def readInitMessages(
       process: Process,
-      reader: BufferedReader,
-      session: SessionProcess
-  )(using logger: Logger): Unit =
+      reader: BufferedReader
+  )(using logger: Logger): Option[String] =
     val deadline = System.currentTimeMillis() + InitReadTimeoutMs
     var linesRead = 0
     var done = false
+    var result: Option[String] = None
     while !done && linesRead < MaxInitLines && System
         .currentTimeMillis() < deadline
     do
@@ -169,9 +176,9 @@ object SessionProcess:
           linesRead += 1
           JsonParser.parseJsonLineWithContext(line, linesRead) match
             case Right(Some(SystemMessage("init", data))) =>
-              data.get("session_id").map(_.toString).foreach { id =>
+              result = data.get("session_id").map(_.toString)
+              result.foreach { id =>
                 logger.info(s"Session ID extracted from init message: $id")
-                session.currentSessionId.set(id)
               }
               done = true
             case Right(Some(_)) =>
@@ -183,6 +190,7 @@ object SessionProcess:
       else if !process.isAlive() then
         done = true // Process already exited — don't wait for init
       else Thread.sleep(InitReadRetryDelayMs) // Wait briefly for init message
+    result
 
   private def configureSessionProcess(
       executablePath: String,
@@ -202,7 +210,7 @@ object SessionProcess:
     }
     pb
 
-  private def captureStderr(process: Process, buffer: StringBuilder)(using
+  private def captureStderr(process: Process)(using
       logger: Logger
   ): Unit =
     val reader =
@@ -211,10 +219,6 @@ object SessionProcess:
       var line: String = null
       while { line = reader.readLine(); line != null } do
         logger.debug(s"session stderr: $line")
-        buffer.synchronized {
-          if buffer.nonEmpty then buffer.append('\n'): Unit
-          buffer.append(line): Unit
-        }
     catch
       case _: InterruptedException =>
         // Interrupted by scope cancellation — kill the process to release the pipe

--- a/direct/src/works/iterative/claude/direct/package.scala
+++ b/direct/src/works/iterative/claude/direct/package.scala
@@ -7,6 +7,10 @@ package object direct:
   // Type aliases for convenient usage
   type QueryOptions = works.iterative.claude.core.model.QueryOptions
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
+  type SessionOptions = works.iterative.claude.core.model.SessionOptions
+  val SessionOptions = works.iterative.claude.core.model.SessionOptions
+  type SDKUserMessage = works.iterative.claude.core.model.SDKUserMessage
+  val SDKUserMessage = works.iterative.claude.core.model.SDKUserMessage
 
   // Re-export all model classes that users need
   type Message = works.iterative.claude.core.model.Message

--- a/direct/src/works/iterative/claude/direct/package.scala
+++ b/direct/src/works/iterative/claude/direct/package.scala
@@ -9,8 +9,6 @@ package object direct:
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
   type SessionOptions = works.iterative.claude.core.model.SessionOptions
   val SessionOptions = works.iterative.claude.core.model.SessionOptions
-  type SDKUserMessage = works.iterative.claude.core.model.SDKUserMessage
-  val SDKUserMessage = works.iterative.claude.core.model.SDKUserMessage
 
   // Re-export all model classes that users need
   type Message = works.iterative.claude.core.model.Message

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -4,23 +4,9 @@ package works.iterative.claude.direct
 
 import ox.*
 import works.iterative.claude.core.model.*
-import works.iterative.claude.direct.Logger
-import works.iterative.claude.direct.internal.testing.TestConstants
+import works.iterative.claude.direct.internal.testing.MockLogger
 
 class SessionE2ETest extends munit.FunSuite:
-
-  class MockLogger extends Logger:
-    var debugMessages: List[String] = List.empty
-    var infoMessages: List[String] = List.empty
-    var warnMessages: List[String] = List.empty
-    var errorMessages: List[String] = List.empty
-
-    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
-    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
-    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
-    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
-    def error(msg: => String, exception: Throwable): Unit = errorMessages =
-      s"$msg: ${exception.getMessage}" :: errorMessages
 
   private def isClaudeCliInstalled(): Boolean =
     try

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -1,0 +1,101 @@
+// PURPOSE: End-to-end tests for Session using the real Claude Code CLI
+// PURPOSE: Tests are gated on CLI availability and skip gracefully when not present
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.Logger
+import works.iterative.claude.direct.internal.testing.TestConstants
+
+class SessionE2ETest extends munit.FunSuite:
+
+  class MockLogger extends Logger:
+    var debugMessages: List[String] = List.empty
+    var infoMessages: List[String] = List.empty
+    var warnMessages: List[String] = List.empty
+    var errorMessages: List[String] = List.empty
+
+    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
+    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
+    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
+    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
+    def error(msg: => String, exception: Throwable): Unit = errorMessages =
+      s"$msg: ${exception.getMessage}" :: errorMessages
+
+  private def isClaudeCliInstalled(): Boolean =
+    try
+      val process = ProcessBuilder("claude", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def isNodeJsAvailable(): Boolean =
+    try
+      val process = ProcessBuilder("node", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def hasApiKeyOrCredentials(): Boolean =
+    val hasApiKey = sys.env.contains("ANTHROPIC_API_KEY")
+    val homeDir = sys.env.get("HOME").orElse(sys.env.get("USERPROFILE"))
+    val hasCredentials = homeDir.exists { home =>
+      val path = java.nio.file.Paths.get(home, ".claude", ".credentials.json")
+      java.nio.file.Files.exists(path)
+    }
+    hasApiKey || hasCredentials
+
+  test("E2E: real CLI session completes a single turn") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
+      assume(
+        hasApiKeyOrCredentials(),
+        "Test requires API key or credentials file"
+      )
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val messages =
+          session.send("What is 1+1? Reply with just the number.").runToList()
+
+        assert(messages.nonEmpty, "Expected messages from real CLI session")
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          "Expected AssistantMessage in response"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          "Expected ResultMessage signalling end of turn"
+        )
+      finally session.close()
+    }
+  }
+
+  test("E2E: session ID is a valid non-pending value after first turn") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
+      assume(
+        hasApiKeyOrCredentials(),
+        "Test requires API key or credentials file"
+      )
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val _ =
+          session.send("What is 1+1? Reply with just the number.").runToList()
+
+        assert(
+          session.sessionId != "pending",
+          s"Expected a real session ID after first turn, got: ${session.sessionId}"
+        )
+        assert(
+          session.sessionId.nonEmpty,
+          "Session ID should not be empty after first turn"
+        )
+      finally session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -1,0 +1,288 @@
+// PURPOSE: Integration tests for Session using mock CLI scripts that simulate stream-json protocol
+// PURPOSE: Verifies full send/receive lifecycle, stdin JSON format, and session ID extraction
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.Logger
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import java.nio.file.{Files, Path}
+
+class SessionIntegrationTest extends munit.FunSuite:
+
+  class MockLogger extends Logger:
+    var debugMessages: List[String] = List.empty
+    var infoMessages: List[String] = List.empty
+    var warnMessages: List[String] = List.empty
+    var errorMessages: List[String] = List.empty
+
+    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
+    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
+    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
+    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
+    def error(msg: => String, exception: Throwable): Unit = errorMessages =
+      s"$msg: ${exception.getMessage}" :: errorMessages
+
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+  private val createdFiles = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach(SessionMockCliScript.cleanup)
+    createdFiles.foreach(p => if Files.exists(p) then Files.delete(p))
+    createdScripts.clear()
+    createdFiles.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // IT1: Full single-turn session lifecycle
+  // ============================================================
+
+  test("full single-turn session lifecycle with mock CLI") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "integ-session-001"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "The answer is 42"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("What is the answer?").runToList()
+
+        // Should have assistant + result
+        assertEquals(messages.length, 2)
+
+        messages.head match
+          case AssistantMessage(content) =>
+            val texts = content.collect { case TextBlock(t) => t }
+            assert(texts.exists(_.contains("The answer is 42")))
+          case other => fail(s"Expected AssistantMessage, got: $other")
+
+        messages.last match
+          case ResultMessage(
+                subtype,
+                _,
+                _,
+                isError,
+                _,
+                resultSessionId,
+                _,
+                _,
+                _
+              ) =>
+            assertEquals(subtype, "conversation_result")
+            assertEquals(isError, false)
+            assertEquals(resultSessionId, sessionId)
+          case other => fail(s"Expected ResultMessage, got: $other")
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT2: Mock CLI receives correct stdin JSON
+  // ============================================================
+
+  test("mock CLI receives correct SDKUserMessage JSON on stdin") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val captureFile = Files.createTempFile("stdin-capture-", ".jsonl")
+      createdFiles += captureFile
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage()
+            )
+          )
+        ),
+        captureStdinFile = Some(captureFile)
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val _ = session.send("Hello from test").runToList()
+      finally session.close()
+
+      // Give a moment for the file to be flushed
+      Thread.sleep(50)
+
+      val capturedLines = Files.readAllLines(captureFile)
+      assert(
+        capturedLines.size >= 1,
+        "Expected at least one stdin line captured"
+      )
+
+      val firstLine = capturedLines.get(0)
+      import io.circe.parser
+      val json = parser
+        .parse(firstLine)
+        .toOption
+        .getOrElse(
+          fail(s"stdin line was not valid JSON: $firstLine")
+        )
+      val cursor = json.hcursor
+      assertEquals(
+        cursor.downField("type").as[String].toOption,
+        Some("user")
+      )
+      assertEquals(
+        cursor
+          .downField("message")
+          .downField("content")
+          .as[String]
+          .toOption,
+        Some("Hello from test")
+      )
+    }
+  }
+
+  // ============================================================
+  // IT3: Session extracts session ID from init message
+  // ============================================================
+
+  test("session extracts session ID from init SystemMessage") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val expectedSessionId = "extracted-from-init-999"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage(
+                expectedSessionId
+              )
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        // Session ID should be extracted from init message before any send
+        assertEquals(session.sessionId, expectedSessionId)
+      finally
+        session.close()
+    }
+  }
+
+  // ============================================================
+  // IT4: KeepAlive and StreamEvent messages emitted in Flow
+  // ============================================================
+
+  test("KeepAlive and StreamEvent messages are emitted in the Flow") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "keepalive-stream-session"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.keepAliveMessage,
+              SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Answer with events"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("test").runToList()
+
+        assert(
+          messages.exists(_ == KeepAliveMessage),
+          s"Expected KeepAliveMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[StreamEventMessage]),
+          s"Expected StreamEventMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          s"Expected AssistantMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          s"Expected ResultMessage in flow: $messages"
+        )
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT5: ClaudeCode.session factory creates a working session
+  // ============================================================
+
+  test(
+    "ClaudeCode.session factory creates a working session via instance API"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "factory-session-002"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Factory response"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+
+      // Use the instance API (ClaudeCode class)
+      val claude = ClaudeCode.concurrent
+      val session = claude.session(options)
+      try
+        val messages = session.send("factory test").runToList()
+
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          "Expected AssistantMessage from factory session"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          "Expected ResultMessage from factory session"
+        )
+      finally session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -4,24 +4,13 @@ package works.iterative.claude.direct
 
 import ox.*
 import works.iterative.claude.core.model.*
-import works.iterative.claude.direct.Logger
-import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import works.iterative.claude.direct.internal.testing.{
+  MockLogger,
+  SessionMockCliScript
+}
 import java.nio.file.{Files, Path}
 
 class SessionIntegrationTest extends munit.FunSuite:
-
-  class MockLogger extends Logger:
-    var debugMessages: List[String] = List.empty
-    var infoMessages: List[String] = List.empty
-    var warnMessages: List[String] = List.empty
-    var errorMessages: List[String] = List.empty
-
-    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
-    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
-    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
-    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
-    def error(msg: => String, exception: Throwable): Unit = errorMessages =
-      s"$msg: ${exception.getMessage}" :: errorMessages
 
   private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
   private val createdFiles = scala.collection.mutable.ListBuffer[Path]()
@@ -120,9 +109,6 @@ class SessionIntegrationTest extends munit.FunSuite:
       try
         val _ = session.send("Hello from test").runToList()
       finally session.close()
-
-      // Give a moment for the file to be flushed
-      Thread.sleep(50)
 
       val capturedLines = Files.readAllLines(captureFile)
       assert(

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -4,9 +4,9 @@ package works.iterative.claude.direct
 
 import ox.*
 import works.iterative.claude.core.model.*
-import works.iterative.claude.direct.Logger
 import works.iterative.claude.direct.internal.testing.{
   MockCliScript,
+  MockLogger,
   SessionMockCliScript
 }
 import io.circe.syntax.*
@@ -14,20 +14,6 @@ import io.circe.parser
 import java.nio.file.Path
 
 class SessionTest extends munit.FunSuite:
-
-  // Mock Logger for testing
-  class MockLogger extends Logger:
-    var debugMessages: List[String] = List.empty
-    var infoMessages: List[String] = List.empty
-    var warnMessages: List[String] = List.empty
-    var errorMessages: List[String] = List.empty
-
-    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
-    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
-    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
-    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
-    def error(msg: => String, exception: Throwable): Unit = errorMessages =
-      s"$msg: ${exception.getMessage}" :: errorMessages
 
   // Track created mock scripts for cleanup
   private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
@@ -39,21 +25,6 @@ class SessionTest extends munit.FunSuite:
     }
     createdScripts.clear()
     super.afterEach(context)
-
-  // ============================================================
-  // T1: Session trait compilation test
-  // Verifies the trait compiles with expected method signatures
-  // ============================================================
-
-  test("Session trait compiles with expected method signatures") {
-    // Compile-time check: if Session has the wrong signatures, the type
-    // ascriptions below will cause a compile error.
-    val sendType = classOf[ox.flow.Flow[?]]
-    val closeType = classOf[Unit]
-    val sessionIdType = classOf[String]
-    // Runtime check just confirms we reached this point
-    assert(sendType != null && closeType != null && sessionIdType != null)
-  }
 
   // ============================================================
   // T2: SDKUserMessage stdin encoding test
@@ -233,12 +204,11 @@ class SessionTest extends munit.FunSuite:
   test("close() terminates the underlying process") {
     given logger: MockLogger = MockLogger()
     supervised {
-      // Use a script that sleeps forever (would hang without close)
-      val hangingScript = MockCliScript.createSimpleScript(
-        List(
-          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"sess-close-test"}"""
-        ),
-        delayMs = 0
+      // Create a session script that stays alive waiting for stdin (no turnResponses
+      // means it just reads until EOF, simulating a long-lived process)
+      val hangingScript = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = Nil
       )
       createdScripts += hangingScript
 
@@ -246,10 +216,19 @@ class SessionTest extends munit.FunSuite:
         SessionOptions().withClaudeExecutable(hangingScript.toString)
       val session = ClaudeCode.session(options)
 
-      // Close should terminate without hanging
+      // The session wraps a Process — extract it to verify it's terminated after close
+      // We know SessionProcess holds the process, so we verify indirectly:
+      // after close(), sending should fail because stdin is closed
       session.close()
 
-      // If we get here without hanging, close worked
-      assert(true)
+      // Verify the session is no longer usable — send should throw because
+      // the underlying stdin writer is closed
+      val caught = intercept[Exception] {
+        session.send("should fail").runToList()
+      }
+      assert(
+        caught != null,
+        "Expected an exception when sending to a closed session"
+      )
     }
   }

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -1,0 +1,255 @@
+// PURPOSE: Unit tests for Session trait and SessionProcess implementation
+// PURPOSE: Verifies session lifecycle, message flow, and session ID extraction
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.Logger
+import works.iterative.claude.direct.internal.testing.{
+  MockCliScript,
+  SessionMockCliScript
+}
+import io.circe.syntax.*
+import io.circe.parser
+import java.nio.file.Path
+
+class SessionTest extends munit.FunSuite:
+
+  // Mock Logger for testing
+  class MockLogger extends Logger:
+    var debugMessages: List[String] = List.empty
+    var infoMessages: List[String] = List.empty
+    var warnMessages: List[String] = List.empty
+    var errorMessages: List[String] = List.empty
+
+    def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
+    def info(msg: => String): Unit = infoMessages = msg :: infoMessages
+    def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
+    def error(msg: => String): Unit = errorMessages = msg :: errorMessages
+    def error(msg: => String, exception: Throwable): Unit = errorMessages =
+      s"$msg: ${exception.getMessage}" :: errorMessages
+
+  // Track created mock scripts for cleanup
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach { path =>
+      val _ = MockCliScript.cleanup(path)
+      val _ = SessionMockCliScript.cleanup(path)
+    }
+    createdScripts.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // T1: Session trait compilation test
+  // Verifies the trait compiles with expected method signatures
+  // ============================================================
+
+  test("Session trait compiles with expected method signatures") {
+    // Compile-time check: if Session has the wrong signatures, the type
+    // ascriptions below will cause a compile error.
+    val sendType = classOf[ox.flow.Flow[?]]
+    val closeType = classOf[Unit]
+    val sessionIdType = classOf[String]
+    // Runtime check just confirms we reached this point
+    assert(sendType != null && closeType != null && sessionIdType != null)
+  }
+
+  // ============================================================
+  // T2: SDKUserMessage stdin encoding test
+  // ============================================================
+
+  test("SDKUserMessage is correctly encoded for stdin") {
+    val msg = SDKUserMessage(content = "Hello, Claude!", sessionId = "sess-42")
+    val json = msg.asJson.noSpaces
+
+    val parsed = parser.parse(json).toOption.get
+    val cursor = parsed.hcursor
+
+    assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
+    assertEquals(
+      cursor
+        .downField("message")
+        .downField("role")
+        .as[String]
+        .toOption,
+      Some("user")
+    )
+    assertEquals(
+      cursor
+        .downField("message")
+        .downField("content")
+        .as[String]
+        .toOption,
+      Some("Hello, Claude!")
+    )
+    assertEquals(
+      cursor.downField("session_id").as[String].toOption,
+      Some("sess-42")
+    )
+  }
+
+  test("SDKUserMessage with pending session ID uses 'pending' literal") {
+    val msg = SDKUserMessage(content = "First prompt", sessionId = "pending")
+    val json = msg.asJson.noSpaces
+    val parsed = parser.parse(json).toOption.get
+    assertEquals(
+      parsed.hcursor.downField("session_id").as[String].toOption,
+      Some("pending")
+    )
+  }
+
+  // ============================================================
+  // T3: Session ID extraction from SystemMessage init
+  // ============================================================
+
+  test("Session ID is extracted from SystemMessage with subtype init") {
+    val initMsg = SystemMessage(
+      subtype = "init",
+      data = Map("session_id" -> "extracted-session-id-123")
+    )
+    val extracted = initMsg.data.get("session_id").map(_.toString)
+    assertEquals(extracted, Some("extracted-session-id-123"))
+  }
+
+  test("Non-init SystemMessage does not provide session ID") {
+    val userContextMsg = SystemMessage(
+      subtype = "user_context",
+      data = Map("context_user_id" -> "user_123")
+    )
+    // We only extract from "init" subtype
+    val extracted =
+      if userContextMsg.subtype == "init" then
+        userContextMsg.data.get("session_id").map(_.toString)
+      else None
+    assertEquals(extracted, None)
+  }
+
+  // ============================================================
+  // T4: Session ID defaults to "pending"
+  // ============================================================
+
+  test("Session ID defaults to 'pending' when no init message received") {
+    // This is a behavioral test: if we create a session against a script
+    // that doesn't emit an init message before the first send, we get "pending"
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val noInitScript = MockCliScript.createSimpleScript(
+        List(
+          // No init message - just jump straight to result
+          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"real-session-id"}"""
+        ),
+        delayMs = 0
+      )
+      createdScripts += noInitScript
+
+      val options = SessionOptions().withClaudeExecutable(noInitScript.toString)
+      val session = ClaudeCode.session(options)
+
+      // Before any send, if no init message was received, sessionId is "pending"
+      assertEquals(session.sessionId, "pending")
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // T5: ResultMessage signals end of Flow
+  // ============================================================
+
+  test("Flow completes after emitting ResultMessage") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "sess-flow-test"
+      // Session script emits assistant + result for the first turn,
+      // then ignores subsequent turns (no more responses configured)
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              """{"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}""",
+              s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$sessionId"}"""
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("test").runToList()
+
+        // Should have assistant + result only
+        val resultMessages = messages.collect { case r: ResultMessage => r }
+        assertEquals(resultMessages.length, 1)
+
+        val assistantMessages = messages.collect { case a: AssistantMessage =>
+          a
+        }
+        assertEquals(assistantMessages.length, 1)
+
+        // Total should be 2 (assistant + result)
+        assertEquals(messages.length, 2)
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T6: Session ID updated from ResultMessage
+  // ============================================================
+
+  test("Session ID is updated from ResultMessage after send completes") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"updated-session-id-456"}"""
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        // Run the flow to completion
+        val _ = session.send("test").runToList()
+
+        // After send completes, session ID should be updated from ResultMessage
+        assertEquals(session.sessionId, "updated-session-id-456")
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T7: Close terminates process
+  // ============================================================
+
+  test("close() terminates the underlying process") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      // Use a script that sleeps forever (would hang without close)
+      val hangingScript = MockCliScript.createSimpleScript(
+        List(
+          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"sess-close-test"}"""
+        ),
+        delayMs = 0
+      )
+      createdScripts += hangingScript
+
+      val options =
+        SessionOptions().withClaudeExecutable(hangingScript.toString)
+      val session = ClaudeCode.session(options)
+
+      // Close should terminate without hanging
+      session.close()
+
+      // If we get here without hanging, close worked
+      assert(true)
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
@@ -1,0 +1,18 @@
+// PURPOSE: Shared mock Logger for testing that captures log messages by level
+// PURPOSE: Used across unit, integration, and E2E test suites
+package works.iterative.claude.direct.internal.testing
+
+import works.iterative.claude.direct.Logger
+
+class MockLogger extends Logger:
+  var debugMessages: List[String] = List.empty
+  var infoMessages: List[String] = List.empty
+  var warnMessages: List[String] = List.empty
+  var errorMessages: List[String] = List.empty
+
+  def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
+  def info(msg: => String): Unit = infoMessages = msg :: infoMessages
+  def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
+  def error(msg: => String): Unit = errorMessages = msg :: errorMessages
+  def error(msg: => String, exception: Throwable): Unit = errorMessages =
+    s"$msg: ${exception.getMessage}" :: errorMessages

--- a/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
@@ -1,0 +1,167 @@
+// PURPOSE: Mock CLI scripts that simulate the stream-json session protocol
+// PURPOSE: Scripts read SDKUserMessage JSON from stdin and write response JSON to stdout
+package works.iterative.claude.direct.internal.testing
+
+import java.io.{FileWriter, PrintWriter}
+import java.nio.file.{Files, Path}
+import java.nio.file.attribute.PosixFilePermissions
+import scala.util.{Try, Using}
+
+/** Utilities for creating mock CLI scripts that simulate the Claude Code
+  * stream-json session protocol.
+  *
+  * Unlike query-mode mocks (which output all content and exit), session-mode
+  * mocks keep running and read prompts from stdin as newline-delimited JSON
+  * (SDKUserMessage). For each prompt received, the script writes a sequence of
+  * response JSON lines to stdout, ending with a ResultMessage. The script
+  * remains alive until stdin is closed, at which point it exits normally.
+  */
+object SessionMockCliScript:
+
+  /** Configuration for a single turn's response in a session mock. */
+  case class TurnResponse(
+      /** Messages to write to stdout when this turn's prompt is received. */
+      messages: List[String]
+  )
+
+  /** Common pre-built responses for typical session scenarios. */
+  object CommonResponses:
+
+    val initSessionId = "test-session-id-init-001"
+
+    /** The system init message that the CLI emits when first started. */
+    def initMessage(sessionId: String = initSessionId): String =
+      s"""{"type":"system","subtype":"init","session_id":"$sessionId","tools":[],"mcp_servers":[]}"""
+
+    /** A simple assistant response with text content. */
+    def assistantMessage(text: String): String =
+      s"""{"type":"assistant","message":{"content":[{"type":"text","text":"$text"}]}}"""
+
+    /** A ResultMessage signalling end-of-turn. */
+    def resultMessage(
+        sessionId: String = initSessionId,
+        durationMs: Int = 100,
+        numTurns: Int = 1
+    ): String =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":$durationMs,"duration_api_ms":50,"is_error":false,"num_turns":$numTurns,"session_id":"$sessionId"}"""
+
+    /** A keep_alive message. */
+    val keepAliveMessage: String =
+      """{"type":"keep_alive"}"""
+
+    /** A stream_event message. */
+    def streamEventMessage(event: String = "start"): String =
+      s"""{"type":"stream_event","data":{"event":"$event"}}"""
+
+    /** Standard single-turn session: init + one assistant response + result. */
+    def singleTurnSession(
+        prompt: String = "test",
+        sessionId: String = initSessionId
+    ): (String, TurnResponse) =
+      val init = initMessage(sessionId)
+      val response = TurnResponse(
+        List(
+          assistantMessage(s"Response to: $prompt"),
+          resultMessage(sessionId)
+        )
+      )
+      (init, response)
+
+  /** Creates a temporary executable shell script that simulates a session
+    * process. The script:
+    *   1. Writes the given initMessage to stdout (if provided)
+    *   2. Enters a read loop: for each line read from stdin, writes one turn
+    *      response to stdout
+    *   3. Exits when stdin closes (EOF)
+    *
+    * The turn responses are cycled: the nth prompt receives responses[n %
+    * responses.length]. If responses is empty, the script just echoes a default
+    * result for every prompt.
+    *
+    * @param initMessages
+    *   Lines to emit to stdout before reading any stdin (e.g., init message)
+    * @param turnResponses
+    *   Ordered list of response sequences, one per stdin line received
+    * @param captureStdinFile
+    *   If provided, each stdin line is appended to this file for verification
+    */
+  def createSessionScript(
+      initMessages: List[String] = Nil,
+      turnResponses: List[TurnResponse] = Nil,
+      captureStdinFile: Option[Path] = None
+  ): Path =
+    val tempDir = Files.createTempDirectory("mock-session-claude-")
+    val scriptPath = tempDir.resolve(
+      s"mock-session-${System.currentTimeMillis()}"
+    )
+    val content = generateSessionScript(
+      initMessages,
+      turnResponses,
+      captureStdinFile
+    )
+    Using.resource(new PrintWriter(new FileWriter(scriptPath.toFile))) {
+      _.write(content)
+    }
+    Files.setPosixFilePermissions(
+      scriptPath,
+      PosixFilePermissions.fromString("rwxr-xr-x")
+    )
+    scriptPath
+
+  def cleanup(scriptPath: Path): Try[Unit] = Try {
+    if Files.exists(scriptPath) then
+      Files.delete(scriptPath)
+      val parent = scriptPath.getParent
+      if Files.exists(parent) && Files.list(parent).count() == 0 then
+        Files.delete(parent)
+  }
+
+  private def generateSessionScript(
+      initMessages: List[String],
+      turnResponses: List[TurnResponse],
+      captureStdinFile: Option[Path]
+  ): String =
+    val sb = new StringBuilder
+    sb.append("#!/bin/bash\n")
+    sb.append("# Auto-generated mock session CLI script\n\n")
+
+    // Emit init messages immediately at startup
+    initMessages.foreach { msg =>
+      sb.append(s"echo '${escapeSingleQuote(msg)}'\n")
+    }
+
+    if turnResponses.nonEmpty then
+      val turnCount = turnResponses.length
+      sb.append(s"TURN_COUNT=$turnCount\n")
+      sb.append("TURN_INDEX=0\n\n")
+
+      // Read loop: for each line from stdin, cycle through the configured responses
+      sb.append("while IFS= read -r line; do\n")
+      captureStdinFile.foreach { f =>
+        sb.append(s"""  printf '%s\\n' "$$line" >> '${f.toAbsolutePath}'\n""")
+      }
+      sb.append("  IDX=$((TURN_INDEX % TURN_COUNT))\n")
+      sb.append("  case \"$IDX\" in\n")
+      turnResponses.zipWithIndex.foreach { case (turn, idx) =>
+        sb.append(s"    $idx)\n")
+        turn.messages.foreach { msg =>
+          sb.append(s"      echo '${escapeSingleQuote(msg)}'\n")
+        }
+        sb.append("      ;;\n")
+      }
+      sb.append("  esac\n")
+      sb.append("  TURN_INDEX=$((TURN_INDEX + 1))\n")
+      sb.append("done\n")
+    else
+      // No responses configured: just read (and optionally capture) stdin until EOF
+      sb.append("while IFS= read -r line; do\n")
+      captureStdinFile.foreach { f =>
+        sb.append(s"""  printf '%s\\n' "$$line" >> '${f.toAbsolutePath}'\n""")
+      }
+      sb.append("  true\n")
+      sb.append("done\n")
+
+    sb.toString()
+
+  private def escapeSingleQuote(s: String): String =
+    s.replace("'", "'\\''")

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -96,3 +96,62 @@ A  core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
 ```
 
 ---
+
+## Phase 3: Direct API - Basic session lifecycle (2026-04-05)
+
+**What was built:**
+- `works/iterative/claude/direct/Session.scala` — `Session` trait with `send(prompt: String): Flow[Message]`, `close(): Unit`, and `sessionId: String`
+- `works/iterative/claude/direct/internal/cli/SessionProcess.scala` — Internal implementation managing a long-lived CLI process with stdin writer, stdout reader, and background stderr capture
+- `works/iterative/claude/direct/ClaudeCode.scala` — Added `session(SessionOptions): Session` factory method on both the `ClaudeCode` class (instance, uses existing Ox scope) and companion object (static, requires `using Logger, Ox`)
+- `works/iterative/claude/direct/package.scala` — Added `SessionOptions` re-export to direct package
+- `works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — Mock CLI script generator that reads stdin JSON and writes stdout JSON responses, simulating the stream-json protocol
+- `works/iterative/claude/direct/internal/testing/MockLogger.scala` — Shared mock logger extracted from test files during code review
+
+**Decisions made:**
+- `--verbose` flag injected at the process boundary in `SessionProcess.configureSessionProcess` rather than in `CLIArgumentBuilder`, matching how the query path adds it in `buildCliArguments` — keeps CLI arg building focused on user-visible options
+- `readInitMessages` uses a polling loop with `reader.ready()` and deadline to distinguish long-lived session processes (which emit init before stdin) from quick-exit mock scripts — avoids blocking on `readLine()` indefinitely
+- `send()` writes the `SDKUserMessage` JSON to stdin eagerly (before returning the Flow), ensuring the CLI starts processing immediately; the Flow then reads stdout until `ResultMessage`
+- `captureStderr` destroys the process on `InterruptedException` to unblock the pipe and prevent scope cancellation from hanging
+- `SDKUserMessage` not re-exported in package.scala — it's an internal protocol detail, not a user-facing type
+- `configureSessionProcess` duplicates a small amount of `ProcessBuilder` configuration from `ProcessManager.configureProcess` rather than extracting a shared helper — both methods are small and the `QueryOptions` vs `SessionOptions` types differ; extraction deferred until a third call site appears
+
+**Patterns applied:**
+- Trait + internal implementation: Public `Session` trait with package-private `SessionProcess` implementation, matching the existing `ClaudeCode` / `ProcessManager` split
+- Factory method: `SessionProcess.start` companion object factory that constructs the process, reads init messages, and returns a ready-to-use `Session`
+- Mock CLI scripts: Extended `MockCliScript` pattern for session protocol — scripts read stdin JSON and respond with stdout JSON, supporting multi-turn simulation
+- Shared test utilities: `MockLogger` extracted to `internal/testing` package for reuse across test suites
+
+**Testing:**
+- Unit tests: 8 tests in `SessionTest.scala` (SDKUserMessage encoding, session ID extraction/defaults/updates, ResultMessage flow termination, close behavior, factory method)
+- Integration tests: 5 tests in `SessionIntegrationTest.scala` (full lifecycle, stdin JSON verification, session ID from init, KeepAlive/StreamEvent passthrough, ClaudeCode.session factory)
+- E2E tests: 2 tests in `SessionE2ETest.scala` (real CLI single turn, session ID validation — gated on CLI availability)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-03-20260405-101513.md
+- Skills applied: architecture, scala3, composition, testing, style
+- Critical findings: 3 (vacuous T1 test, vacuous T7 assertion, MockLogger duplication) — all fixed
+- Major warnings addressed: dead stderrBuffer removed, readInitMessages encapsulated to return Option[String], shared resolveExecutablePath helper extracted, SDKUserMessage re-export removed, Thread.sleep removed from integration test
+- Deferred: `sessionId` as `Option[String]` vs magic string (follow-up), `package object` to top-level definitions (pre-existing, separate refactoring)
+
+**For next phases:**
+- `Session` trait and `ClaudeCode.session` factory are ready for multi-turn conversation support (Phase 4)
+- `SessionProcess.send` already supports multiple sequential calls — Phase 4 adds turn sequencing tests and context verification
+- `SessionMockCliScript` supports multi-turn simulation via `turnResponses: Map[String, TurnResponse]` — Phase 4 can use this directly
+- The effectful API (Phase 5) can reference `SessionProcess` patterns for process lifecycle management with fs2
+- Error handling (Phase 6) can add process liveness checks and typed errors to the existing `send`/`close` methods
+
+**Files changed:**
+```
+M  direct/src/works/iterative/claude/direct/ClaudeCode.scala
+A  direct/src/works/iterative/claude/direct/Session.scala
+A  direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+M  direct/src/works/iterative/claude/direct/package.scala
+A  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+A  direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+A  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+A  direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
+A  direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+```
+
+---

--- a/project-management/issues/CC-15/phase-03-context.md
+++ b/project-management/issues/CC-15/phase-03-context.md
@@ -1,0 +1,239 @@
+# Phase 03: Direct API - Basic session lifecycle
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 12-16 hours
+**Status:** Not started
+
+## Goals
+
+1. Create a `Session` trait in the direct module representing an active conversational session with `send` and `close` methods
+2. Add a `ClaudeCode.session(SessionOptions)` factory method (both instance and companion object variants) that starts a CLI process and returns a `Session`
+3. Implement `Session.send(prompt: String): Flow[Message]` that writes an `SDKUserMessage` to stdin and returns a streaming `Flow[Message]` terminating at `ResultMessage`
+4. Implement `Session.close(): Unit` that terminates the underlying CLI process cleanly
+5. The CLI process starts once at session creation and stays alive across `send` calls
+6. Extract session ID from the CLI's initial `SystemMessage` (subtype `init`) for use in subsequent `SDKUserMessage` payloads
+
+## Scope
+
+### In scope
+
+- `Session` trait with `send(prompt: String): Flow[Message]` and `close(): Unit`
+- `SessionProcess` (or similar internal implementation) managing the long-lived CLI process, its stdin writer, and its stdout reader
+- `ClaudeCode.session(SessionOptions): Session` factory method on the class (requires `Ox`, `Logger`)
+- `ClaudeCode.session(SessionOptions)(using Logger): Session` blocking factory on the companion object
+- Writing `SDKUserMessage` JSON to process stdin (newline-delimited)
+- Reading stdout lines, parsing via `JsonParser`, and emitting as `Flow[Message]`
+- Detecting `ResultMessage` as end-of-turn delimiter to complete the `Flow`
+- Extracting `session_id` from the initial `SystemMessage` for use in `SDKUserMessage`
+- Using `"pending"` as the session ID for the first `send` if no init message arrives before first send
+- Process cleanup on `close()` (close stdin, wait briefly, destroy if needed)
+- Re-exporting `Session` and `SessionOptions` in `direct` package object
+- Mock CLI scripts for integration testing that simulate the stream-json protocol (read stdin, write stdout)
+
+### Out of scope
+
+- Turn sequencing enforcement (Phase 04 adds multi-turn; Phase 03 only needs single-turn to work, but does not prevent multiple sends)
+- Client-side concurrency guards on `send` (per RESOLVED decision: delegate to CLI)
+- Effectful API session (Phase 05)
+- Error handling for process crashes mid-session (Phase 06 hardens error paths)
+- `control_request` / `control_response` messages
+- Timeout on individual `send` calls (session-level timeout can be added later)
+
+## Dependencies
+
+**Phase 01 delivered:**
+- `SDKUserMessage` case class with circe `Encoder` at `core/src/works/iterative/claude/core/model/SDKUserMessage.scala`
+- `KeepAliveMessage` and `StreamEventMessage` types in `Message` hierarchy at `core/src/works/iterative/claude/core/model/Message.scala`
+- `ResultMessage` confirmed as end-of-turn delimiter
+- `JsonParser.parseMessage` handles all message types including `keep_alive` and `stream_event`
+
+**Phase 02 delivered:**
+- `SessionOptions` case class at `core/src/works/iterative/claude/core/model/SessionOptions.scala`
+- `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions): List[String]` at `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`
+- Produces correct CLI flags including `--print --input-format stream-json --output-format stream-json`
+
+## Approach
+
+### 1. Define the `Session` trait
+
+Create `direct/src/works/iterative/claude/direct/Session.scala`.
+
+```scala
+trait Session:
+  def send(prompt: String): Flow[Message]
+  def close(): Unit
+  def sessionId: String
+```
+
+- `send` writes an `SDKUserMessage` to stdin and returns a `Flow[Message]` that emits messages until a `ResultMessage` is received
+- `close` shuts down the underlying process
+- `sessionId` exposes the session ID assigned by the CLI (or `"pending"` before the first init message)
+
+### 2. Implement `SessionProcess` (internal)
+
+Create `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala`.
+
+This is the core implementation managing the long-lived process. Key design:
+
+**Process lifecycle:**
+- Constructor starts the CLI process using `ProcessBuilder` with args from `CLIArgumentBuilder.buildSessionArgs`
+- Reuse the existing `ProcessManager.configureProcess` pattern for setting cwd, environment, etc. — but note that `configureProcess` currently takes `QueryOptions`. Create a new overload or extract a helper that takes the common fields (executable path, args, cwd, inheritEnvironment, environmentVariables). The simplest approach: create a `configureSessionProcess` method that takes `SessionOptions` directly, duplicating the small amount of process builder configuration.
+- stdin is kept open (do NOT close it like `ProcessManager` does for queries)
+- stdout is read via a `BufferedReader` stored as a field
+- stderr is captured in a background fork (reuse pattern from `ProcessManager.captureStderrStream`)
+
+**Session ID extraction:**
+- After process starts, read stdout lines until a `SystemMessage` with subtype `"init"` arrives
+- Extract `session_id` from the init message's `data` map
+- Store the session ID in a `@volatile var` (or `AtomicReference`) for thread safety
+- If no init message arrives before the first `send`, use `"pending"`
+
+**`send` implementation:**
+- Construct an `SDKUserMessage(content = prompt, sessionId = currentSessionId)`
+- Encode to JSON using the circe `Encoder`, append newline, write to stdin, flush
+- Return a `Flow.usingEmit` that reads stdout lines, parses them via `JsonParser.parseJsonLineWithContextWithLogging`, and emits parsed `Message` values
+- When a `ResultMessage` is encountered, emit it and then stop (complete the Flow)
+- Update stored `sessionId` from the `ResultMessage.sessionId` field (it may differ from the init one)
+- `KeepAliveMessage` and `StreamEventMessage` are emitted like any other message — the caller decides what to do with them
+
+**`close` implementation:**
+- Close the stdin `OutputStream`
+- Wait briefly for the process to exit (e.g., `process.waitFor(5, TimeUnit.SECONDS)`)
+- If still alive, call `process.destroyForcibly()`
+- Close the stdout reader
+
+### 3. Add `ClaudeCode.session` factory methods
+
+Modify `direct/src/works/iterative/claude/direct/ClaudeCode.scala`.
+
+**Instance method** (within supervised scope):
+```scala
+def session(options: SessionOptions): Session =
+  ClaudeCode.createSession(options)
+```
+
+**Companion object method:**
+```scala
+def session(options: SessionOptions)(using Logger, Ox): Session
+```
+
+The factory method requires `(using Logger, Ox)` because the session's background forks (stderr capture) need a supervised scope. The caller must provide the `Ox` scope (e.g., inside `supervised { ... }`), since the session must outlive the factory call.
+
+- **Instance method:** `def session(options: SessionOptions): Session` — uses the existing `Ox` scope from the class constructor
+- **Companion object:** `def session(options: SessionOptions)(using Logger, Ox): Session` — requires the caller to provide an `Ox` scope
+
+Validate the session options (cwd exists) using the same `validateWorkingDirectory` logic.
+
+Resolve the executable path using the same `resolveClaudeExecutablePath` logic, adapted to read from `SessionOptions` fields.
+
+Build CLI args via `CLIArgumentBuilder.buildSessionArgs(options)`.
+
+Construct and return a `SessionProcess` instance.
+
+### 4. Wire up process startup in `SessionProcess`
+
+The constructor or a factory method should:
+1. Build args: `CLIArgumentBuilder.buildSessionArgs(options)`
+2. Resolve executable: `options.pathToClaudeCodeExecutable.getOrElse(CLIDiscovery.findClaude.getOrElse(throw ...))`
+3. Create `ProcessBuilder` with `(executablePath :: args).asJava`
+4. Set cwd from `options.cwd`
+5. Configure environment from `options.inheritEnvironment` / `options.environmentVariables`
+6. Start process
+7. Fork stderr capture in background
+8. Read initial messages from stdout to extract session ID
+9. Return ready-to-use `Session`
+
+### 5. Re-export types in package object
+
+Add to `direct/src/works/iterative/claude/direct/package.scala`:
+```scala
+type Session = works.iterative.claude.direct.Session
+type SessionOptions = works.iterative.claude.core.model.SessionOptions
+val SessionOptions = works.iterative.claude.core.model.SessionOptions
+```
+
+### 6. Write tests (TDD)
+
+Follow TDD: write failing test first, then implement.
+
+**Order of implementation via TDD cycles:**
+
+1. Test: `Session` trait compiles with expected method signatures → Implement trait
+2. Test: `SessionProcess` can start a mock CLI process and extract session ID from init message → Implement process startup + init reading
+3. Test: `send` writes correct JSON to stdin → Implement stdin writing
+4. Test: `send` returns Flow that emits parsed messages up to ResultMessage → Implement stdout reading + Flow emission
+5. Test: `close` terminates the process → Implement close logic
+6. Test: `ClaudeCode.session` factory creates a working Session → Wire up factory
+7. Integration test: full send/receive cycle with mock CLI script
+8. E2E test: real CLI session (gated on CLI availability)
+
+## Files to Modify/Create
+
+### New files
+
+- `direct/src/works/iterative/claude/direct/Session.scala` — Session trait definition
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` — internal implementation of Session backed by a long-lived CLI process
+- `direct/test/src/works/iterative/claude/direct/SessionTest.scala` — unit tests for Session trait and SessionProcess
+- `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` — integration tests with mock CLI scripts
+- `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` — E2E tests with real CLI (gated on availability)
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — mock CLI script generator for session protocol (reads stdin JSON, writes stdout JSON responses)
+
+### Files to modify
+
+- `direct/src/works/iterative/claude/direct/ClaudeCode.scala` — add `session(SessionOptions): Session` factory methods
+- `direct/src/works/iterative/claude/direct/package.scala` — add `Session` and `SessionOptions` re-exports
+
+### Reference files (no changes)
+
+- `core/src/works/iterative/claude/core/model/SDKUserMessage.scala` — stdin message format and Encoder
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` — session configuration
+- `core/src/works/iterative/claude/core/model/Message.scala` — Message hierarchy (ResultMessage as delimiter)
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — `buildSessionArgs` for CLI flag generation
+- `core/src/works/iterative/claude/core/parsing/JsonParser.scala` — message parsing logic
+- `direct/src/works/iterative/claude/direct/internal/cli/ProcessManager.scala` — reference for process management patterns (configureProcess, stderr capture, stdout reading)
+- `direct/src/works/iterative/claude/direct/internal/parsing/JsonParser.scala` — direct-style JSON parsing with logging
+- `direct/src/works/iterative/claude/direct/Logger.scala` — Logger trait
+- `direct/src/works/iterative/claude/direct/internal/testing/MockCliScript.scala` — existing mock CLI script patterns
+- `direct/src/works/iterative/claude/direct/internal/testing/TestConstants.scala` — test constants
+- `direct/test/src/works/iterative/claude/direct/ClaudeCodeIntegrationTest.scala` — reference for integration test patterns
+
+## Testing Strategy
+
+### Unit tests (`SessionTest.scala`)
+
+1. **Session trait has expected method signatures** — compile-time verification that `send` returns `Flow[Message]` and `close` returns `Unit`
+2. **SDKUserMessage is correctly encoded for stdin** — verify JSON output matches expected format with session ID and content
+3. **ResultMessage signals end of Flow** — given a sequence of messages including a ResultMessage, verify the Flow emits up to and including ResultMessage then completes
+4. **Session ID is extracted from SystemMessage init** — given a SystemMessage with subtype "init" and session_id in data, verify extraction
+5. **Session ID defaults to "pending" when no init received** — verify fallback behavior
+6. **Session ID is updated from ResultMessage** — after a send completes, verify sessionId reflects the ResultMessage's sessionId
+7. **Close terminates process** — verify that close destroys the process
+
+### Integration tests (`SessionIntegrationTest.scala`)
+
+1. **Full single-turn session lifecycle** — start session with mock CLI, send one message, receive streaming response ending with ResultMessage, close session, verify process exited
+2. **Mock CLI receives correct stdin JSON** — mock CLI script captures stdin input to a temp file; verify the written JSON matches `SDKUserMessage` format
+3. **Session extracts session ID from init message** — mock CLI outputs a system/init message with session_id; verify `session.sessionId` returns it
+4. **KeepAlive and StreamEvent messages are emitted in Flow** — mock CLI outputs keep_alive and stream_event messages interleaved with assistant messages; verify all appear in the collected Flow
+5. **ClaudeCode.session factory creates working session** — use `ClaudeCode.session(options)` to create session, send a message, verify response
+
+### E2E tests (`SessionE2ETest.scala`)
+
+1. **Real CLI session with single turn** — gated on CLI availability (same pattern as `ClaudeCodeIntegrationTest`); open session, send "What is 1+1?", verify response contains assistant message and ResultMessage, close session
+2. **Session ID is a valid non-pending value after first turn** — after completing a turn with real CLI, verify `session.sessionId` is not "pending"
+
+## Acceptance Criteria
+
+1. `Session` trait exists at `works.iterative.claude.direct.Session` with `send(prompt: String): Flow[Message]`, `close(): Unit`, and `sessionId: String`
+2. `ClaudeCode.session(SessionOptions): Session` factory method exists on the `ClaudeCode` class (requires `Ox`, `Logger`)
+3. `ClaudeCode.session(SessionOptions)(using Logger, Ox): Session` factory method exists on the `ClaudeCode` companion object
+4. `send` writes a correctly-formatted `SDKUserMessage` JSON line to the process stdin
+5. `send` returns a `Flow[Message]` that streams parsed messages from stdout and completes after emitting a `ResultMessage`
+6. The underlying CLI process starts once at session creation and remains alive after `send` completes
+7. `close` terminates the CLI process (stdin closed, process destroyed if necessary)
+8. Session ID is extracted from the CLI's initial `SystemMessage` and used in `SDKUserMessage` payloads
+9. `Session` and `SessionOptions` are re-exported in the `direct` package object
+10. All new files start with the required two-line PURPOSE comments
+11. All unit, integration, and E2E tests pass with no compilation warnings
+12. All existing tests continue to pass (no regressions)
+13. Mock CLI script for session testing reads stdin and writes stdout, simulating the stream-json protocol

--- a/project-management/issues/CC-15/phase-03-tasks.md
+++ b/project-management/issues/CC-15/phase-03-tasks.md
@@ -40,3 +40,5 @@
 - [x] [integ] E2E test: real CLI session with single turn (gated on CLI availability)
 - [x] [integ] E2E test: session ID is valid non-pending after first turn
 - [x] [integ] Verify all existing tests still pass (no regressions)
+
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-03-tasks.md
+++ b/project-management/issues/CC-15/phase-03-tasks.md
@@ -7,36 +7,36 @@
 
 ### Setup
 
-- [ ] [setup] Review existing ProcessManager, MockCliScript, and ClaudeCode patterns for reuse
+- [x] [setup] Review existing ProcessManager, MockCliScript, and ClaudeCode patterns for reuse
 
 ### Tests First (TDD)
 
-- [ ] [test] Session trait compilation test - verify trait compiles with expected method signatures
-- [ ] [test] SDKUserMessage stdin encoding test - verify JSON written to stdin matches expected format with session ID
-- [ ] [test] Session ID extraction test - extract session_id from SystemMessage init
-- [ ] [test] Session ID pending default test - defaults to "pending" when no init received
-- [ ] [test] ResultMessage end-of-flow test - Flow emits up to and including ResultMessage then completes
-- [ ] [test] Session ID update from ResultMessage test - sessionId updated after send completes
-- [ ] [test] Close terminates process test - verify close destroys process
+- [x] [test] Session trait compilation test - verify trait compiles with expected method signatures
+- [x] [test] SDKUserMessage stdin encoding test - verify JSON written to stdin matches expected format with session ID
+- [x] [test] Session ID extraction test - extract session_id from SystemMessage init
+- [x] [test] Session ID pending default test - defaults to "pending" when no init received
+- [x] [test] ResultMessage end-of-flow test - Flow emits up to and including ResultMessage then completes
+- [x] [test] Session ID update from ResultMessage test - sessionId updated after send completes
+- [x] [test] Close terminates process test - verify close destroys process
 
 ### Implementation
 
-- [ ] [impl] Create Session trait with send, close, sessionId methods
-- [ ] [impl] Create SessionProcess - process startup, stdin/stdout management, stderr capture
-- [ ] [impl] Implement session ID extraction from init SystemMessage
-- [ ] [impl] Implement send() - write SDKUserMessage to stdin, return Flow[Message] up to ResultMessage
-- [ ] [impl] Implement close() - close stdin, wait, destroy if needed
-- [ ] [impl] Add ClaudeCode.session factory methods (instance and companion)
-- [ ] [impl] Add Session and SessionOptions re-exports to package.scala
+- [x] [impl] Create Session trait with send, close, sessionId methods
+- [x] [impl] Create SessionProcess - process startup, stdin/stdout management, stderr capture
+- [x] [impl] Implement session ID extraction from init SystemMessage
+- [x] [impl] Implement send() - write SDKUserMessage to stdin, return Flow[Message] up to ResultMessage
+- [x] [impl] Implement close() - close stdin, wait, destroy if needed
+- [x] [impl] Add ClaudeCode.session factory methods (instance and companion)
+- [x] [impl] Add Session and SessionOptions re-exports to package.scala
 
 ### Integration
 
-- [ ] [integ] Create SessionMockCliScript for session protocol simulation
-- [ ] [integ] Integration test: full single-turn session lifecycle with mock CLI
-- [ ] [integ] Integration test: mock CLI receives correct stdin JSON
-- [ ] [integ] Integration test: session extracts session ID from init message
-- [ ] [integ] Integration test: KeepAlive and StreamEvent messages emitted in Flow
-- [ ] [integ] Integration test: ClaudeCode.session factory creates working session
-- [ ] [integ] E2E test: real CLI session with single turn (gated on CLI availability)
-- [ ] [integ] E2E test: session ID is valid non-pending after first turn
-- [ ] [integ] Verify all existing tests still pass (no regressions)
+- [x] [integ] Create SessionMockCliScript for session protocol simulation
+- [x] [integ] Integration test: full single-turn session lifecycle with mock CLI
+- [x] [integ] Integration test: mock CLI receives correct stdin JSON
+- [x] [integ] Integration test: session extracts session ID from init message
+- [x] [integ] Integration test: KeepAlive and StreamEvent messages emitted in Flow
+- [x] [integ] Integration test: ClaudeCode.session factory creates working session
+- [x] [integ] E2E test: real CLI session with single turn (gated on CLI availability)
+- [x] [integ] E2E test: session ID is valid non-pending after first turn
+- [x] [integ] Verify all existing tests still pass (no regressions)

--- a/project-management/issues/CC-15/phase-03-tasks.md
+++ b/project-management/issues/CC-15/phase-03-tasks.md
@@ -1,0 +1,42 @@
+# Phase 03 Tasks: Direct API - Basic session lifecycle
+
+**Issue:** CC-15
+**Phase Context:** phase-03-context.md
+
+## Tasks
+
+### Setup
+
+- [ ] [setup] Review existing ProcessManager, MockCliScript, and ClaudeCode patterns for reuse
+
+### Tests First (TDD)
+
+- [ ] [test] Session trait compilation test - verify trait compiles with expected method signatures
+- [ ] [test] SDKUserMessage stdin encoding test - verify JSON written to stdin matches expected format with session ID
+- [ ] [test] Session ID extraction test - extract session_id from SystemMessage init
+- [ ] [test] Session ID pending default test - defaults to "pending" when no init received
+- [ ] [test] ResultMessage end-of-flow test - Flow emits up to and including ResultMessage then completes
+- [ ] [test] Session ID update from ResultMessage test - sessionId updated after send completes
+- [ ] [test] Close terminates process test - verify close destroys process
+
+### Implementation
+
+- [ ] [impl] Create Session trait with send, close, sessionId methods
+- [ ] [impl] Create SessionProcess - process startup, stdin/stdout management, stderr capture
+- [ ] [impl] Implement session ID extraction from init SystemMessage
+- [ ] [impl] Implement send() - write SDKUserMessage to stdin, return Flow[Message] up to ResultMessage
+- [ ] [impl] Implement close() - close stdin, wait, destroy if needed
+- [ ] [impl] Add ClaudeCode.session factory methods (instance and companion)
+- [ ] [impl] Add Session and SessionOptions re-exports to package.scala
+
+### Integration
+
+- [ ] [integ] Create SessionMockCliScript for session protocol simulation
+- [ ] [integ] Integration test: full single-turn session lifecycle with mock CLI
+- [ ] [integ] Integration test: mock CLI receives correct stdin JSON
+- [ ] [integ] Integration test: session extracts session ID from init message
+- [ ] [integ] Integration test: KeepAlive and StreamEvent messages emitted in Flow
+- [ ] [integ] Integration test: ClaudeCode.session factory creates working session
+- [ ] [integ] E2E test: real CLI session with single turn (gated on CLI availability)
+- [ ] [integ] E2E test: session ID is valid non-pending after first turn
+- [ ] [integ] Verify all existing tests still pass (no regressions)

--- a/project-management/issues/CC-15/review-packet-phase-03.md
+++ b/project-management/issues/CC-15/review-packet-phase-03.md
@@ -1,0 +1,204 @@
+---
+generated_from: 2ab28937c7df08e34b412c5f58fe2203261d23c9
+generated_at: 2026-04-05T08:13:25Z
+branch: CC-15-phase-03
+issue_id: CC-15
+phase: 3
+files_analyzed:
+  - direct/src/works/iterative/claude/direct/Session.scala
+  - direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+  - direct/src/works/iterative/claude/direct/ClaudeCode.scala
+  - direct/src/works/iterative/claude/direct/package.scala
+  - direct/test/src/works/iterative/claude/direct/SessionTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+  - direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+---
+
+# Review Packet: Phase 3 - Direct API Basic Session Lifecycle
+
+## Goals
+
+This phase delivers the core session API for the direct module, enabling callers to open a persistent Claude Code CLI process, exchange one or more messages over its stdin/stdout, and close it cleanly when done. Prior to this phase every interaction spawned a fresh process; now the process lives for the duration of the session, eliminating per-turn startup cost.
+
+Key objectives:
+
+- Define the `Session` trait (`send`, `close`, `sessionId`) as the public contract for an active conversational session
+- Implement `SessionProcess` — the internal class that manages the long-lived CLI process, writes `SDKUserMessage` JSON to stdin, reads response lines from stdout, and terminates the process on `close`
+- Add `ClaudeCode.session(SessionOptions)` factory methods on both the class and companion object
+- Extract the `session_id` from the CLI's initial `SystemMessage(subtype="init")` and keep it current via `ResultMessage` updates
+- Re-export `Session` and `SessionOptions` in the `direct` package object so callers need only one import
+- Provide a `SessionMockCliScript` utility that generates executable shell scripts simulating the stream-json protocol for integration tests
+
+## Scenarios
+
+- [ ] A session can be opened, a single message sent, a streaming `Flow[Message]` received, and the session closed
+- [ ] The underlying CLI process starts once at session creation and remains alive after `send` completes
+- [ ] `send` writes a correctly-formatted `SDKUserMessage` JSON line to process stdin
+- [ ] `send` returns a `Flow[Message]` that emits all messages from stdout and completes after the `ResultMessage`
+- [ ] `KeepAliveMessage` and `StreamEventMessage` are passed through to the caller's Flow unchanged
+- [ ] Session ID is extracted from the CLI's initial `SystemMessage(subtype="init")`
+- [ ] Session ID defaults to `"pending"` when no init message arrives before the first `send`
+- [ ] Session ID is updated to the value carried in the `ResultMessage` after each `send` completes
+- [ ] `close()` terminates the CLI process (stdin closed, forcibly destroyed if needed)
+- [ ] `Session` and `SessionOptions` are accessible via a single `import works.iterative.claude.direct.*`
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `direct/src/works/iterative/claude/direct/Session.scala` | `Session` trait | Public API contract — defines `send`, `close`, and `sessionId` |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | `SessionProcess.start` | Factory that creates the process, captures stderr, reads init message, returns a ready `Session` |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | `SessionProcess.send` | Core send logic: stdin write, stdout read loop, Flow emission, ResultMessage boundary detection |
+| `direct/src/works/iterative/claude/direct/ClaudeCode.scala` | `ClaudeCode.session` | Public factory on both class and companion object; validates cwd and resolves executable path |
+| `direct/src/works/iterative/claude/direct/package.scala` | package object | Confirm `Session` and `SessionOptions` re-exports are present |
+
+## Diagrams
+
+### Component Relationships
+
+```
+works.iterative.claude.direct
+│
+├── Session (trait)                          ← public contract
+│     send(prompt): Flow[Message]
+│     close(): Unit
+│     sessionId: String
+│
+├── ClaudeCode (class / companion)
+│     session(SessionOptions): Session       ← factory; delegates to createSession
+│
+└── internal.cli
+      └── SessionProcess                     ← implements Session
+            - process: java.lang.Process
+            - stdinWriter: BufferedWriter
+            - stdoutReader: BufferedReader
+            - currentSessionId: AtomicReference[String]
+            start(executablePath, options)   ← factory on companion object
+```
+
+### Session Lifecycle Flow
+
+```
+Caller                  ClaudeCode            SessionProcess          CLI Process
+  │                         │                       │                      │
+  │  session(opts)          │                       │                      │
+  │────────────────────────>│                       │                      │
+  │                         │  start(path, opts)    │                      │
+  │                         │──────────────────────>│                      │
+  │                         │                       │  ProcessBuilder.start()
+  │                         │                       │─────────────────────>│
+  │                         │                       │  fork: captureStderr │
+  │                         │                       │  readInitMessages()  │
+  │                         │                       │<──── SystemMessage(init, session_id)
+  │                         │                       │  currentSessionId.set(id)
+  │<────────────────────────────────────────────────│  return SessionProcess
+  │                         │                       │                      │
+  │  send("prompt")         │                       │                      │
+  │─────────────────────────────────────────────────>                      │
+  │  stdinWriter.write(SDKUserMessage JSON + newline)│                      │
+  │                         │                       │─────────────────────>│
+  │                         │   Flow.usingEmit reads stdout line by line   │
+  │<─── AssistantMessage ───────────────────────────│<─────────────────────│
+  │<─── KeepAliveMessage ───────────────────────────│<─────────────────────│
+  │<─── StreamEventMessage ─────────────────────────│<─────────────────────│
+  │<─── ResultMessage ──────────────────────────────│<─────────────────────│
+  │     (Flow completes; sessionId updated)          │                      │
+  │                         │                       │                      │
+  │  close()                │                       │                      │
+  │─────────────────────────────────────────────────>                      │
+  │                         │  stdinWriter.close()  │                      │
+  │                         │  process.waitFor(5s)  │                      │
+  │                         │  destroyForcibly if needed                   │
+  │                         │                       │─────────────────────>│ (exit)
+```
+
+### Session ID State Machine
+
+```
+  [created]
+      │
+      │ init message arrives during readInitMessages()
+      ├──────────────────────────────────> "extracted-id"
+      │
+      │ no init message before first send
+      └──────────────────────────────────> "pending"
+                                               │
+                                               │ ResultMessage received during send
+                                               └──────────────────────> "result-session-id"
+```
+
+### stdin/stdout Protocol (stream-json)
+
+```
+stdin  (Scala → CLI):   {"type":"user","message":{"role":"user","content":"..."},"session_id":"...","parent_tool_use_id":null}\n
+
+stdout (CLI → Scala):   {"type":"system","subtype":"init","session_id":"...","tools":[],...}\n   ← startup only
+                        {"type":"keep_alive"}\n                                                    ← periodic
+                        {"type":"stream_event","data":{...}}\n                                     ← streaming deltas
+                        {"type":"assistant","message":{...}}\n                                     ← full assistant turn
+                        {"type":"result","subtype":"conversation_result","session_id":"...","is_error":false,...}\n  ← end-of-turn
+```
+
+## Test Summary
+
+### Unit Tests — `SessionTest.scala` (9 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| Session trait compiles with expected method signatures | Unit | Compile-time verification that `send`, `close`, `sessionId` have correct types |
+| SDKUserMessage is correctly encoded for stdin | Unit | Verifies JSON shape: `type=user`, nested `message.role=user`, `message.content`, `session_id` |
+| SDKUserMessage with pending session ID uses 'pending' literal | Unit | Edge case: first-send encoding before session ID is known |
+| Session ID is extracted from SystemMessage with subtype init | Unit | Pattern-matches `SystemMessage("init", data)` and reads `session_id` key |
+| Non-init SystemMessage does not provide session ID | Unit | Confirms only `"init"` subtype triggers extraction |
+| Session ID defaults to 'pending' when no init message received | Unit | Uses a `MockCliScript` that skips the init message; asserts `sessionId == "pending"` |
+| Flow completes after emitting ResultMessage | Unit | Drives a `SessionMockCliScript` with one turn; asserts exactly 2 messages (assistant + result) |
+| Session ID is updated from ResultMessage after send completes | Unit | After `runToList()`, asserts `session.sessionId == "updated-session-id-456"` |
+| close() terminates the underlying process | Unit | Calls `close()` on a session backed by a simple script; passes if no hang |
+
+### Integration Tests — `SessionIntegrationTest.scala` (5 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| full single-turn session lifecycle with mock CLI | Integration | Full open/send/close using `SessionMockCliScript`; verifies assistant text and ResultMessage fields |
+| mock CLI receives correct SDKUserMessage JSON on stdin | Integration | `captureStdinFile` option captures what the process received; parses JSON and checks `type` and `content` |
+| session extracts session ID from init SystemMessage | Integration | Script emits init with `session_id`; asserts `session.sessionId` matches before any send |
+| KeepAlive and StreamEvent messages are emitted in the Flow | Integration | Script emits `keep_alive` + `stream_event` interleaved; asserts all four message types present |
+| ClaudeCode.session factory creates a working session via instance API | Integration | Uses `ClaudeCode.concurrent` instance instead of companion object; verifies same behaviour |
+
+### E2E Tests — `SessionE2ETest.scala` (2 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| E2E: real CLI session completes a single turn | E2E | Gated on CLI availability and credentials; sends "What is 1+1?", asserts `AssistantMessage` and `ResultMessage` present |
+| E2E: session ID is a valid non-pending value after first turn | E2E | Same gate; asserts `session.sessionId` is non-empty and not `"pending"` after a completed turn |
+
+E2E tests skip automatically when `claude` binary is absent, Node.js is unavailable, or no API credentials are found (`ANTHROPIC_API_KEY` or `~/.claude/.credentials.json`).
+
+## Files Changed
+
+| File | Status | Description |
+|------|--------|-------------|
+| `direct/src/works/iterative/claude/direct/Session.scala` | New | Public `Session` trait |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | New | `SessionProcess` class + `start` factory; full process lifecycle management |
+| `direct/src/works/iterative/claude/direct/ClaudeCode.scala` | Modified | Added `session(SessionOptions)` on class and companion; added `createSession` and `resolveSessionExecutablePath` helpers |
+| `direct/src/works/iterative/claude/direct/package.scala` | Modified | Added `Session`, `SessionOptions`, `SDKUserMessage` re-exports (note: `SessionOptions` was already present from Phase 2; `SDKUserMessage` added here) |
+| `direct/test/src/works/iterative/claude/direct/SessionTest.scala` | New | 9 unit tests |
+| `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` | New | 5 integration tests |
+| `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` | New | 2 E2E tests |
+| `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` | New | Shell script generator for stream-json session protocol simulation |
+| `project-management/issues/CC-15/phase-03-tasks.md` | Modified | Task tracking updates |
+| `project-management/issues/CC-15/review-state.json` | Modified | Review state bookkeeping |
+
+<details>
+<summary>Notable implementation details worth reviewing</summary>
+
+**Init message reading (`readInitMessages`):** Uses a 500 ms deadline with 10 ms sleep-poll between `reader.ready()` checks. This avoids blocking indefinitely if the init message is delayed, but also avoids consuming the first user-turn message from the real CLI. Review whether the deadline and poll interval are appropriate for slow CI environments.
+
+**`--verbose` flag injection:** `SessionProcess.start` prepends `--verbose` to the CLI args rather than having it in `CLIArgumentBuilder.buildSessionArgs`. The comment explains this mirrors how query mode adds `--verbose` in `ClaudeCode.buildCliArguments`. Worth verifying the two places stay in sync as the API evolves.
+
+**`configureSessionProcess` duplication:** The process configuration logic (cwd, environment) is duplicated from `ProcessManager.configureProcess` because `configureProcess` takes `QueryOptions`. The comment in the approach doc notes this trade-off. If `ProcessManager` grows, consider extracting a shared helper.
+
+**Turn sequencing:** Per the analysis decision, no client-side guard prevents calling `send` before the previous `Flow` is fully consumed. The CLI queues messages internally. This is intentional and documented in the phase context.
+
+</details>

--- a/project-management/issues/CC-15/review-phase-03-20260405-101513.md
+++ b/project-management/issues/CC-15/review-phase-03-20260405-101513.md
@@ -1,0 +1,216 @@
+# Code Review Results
+
+**Review Context:** Phase 3: Direct API - Basic session lifecycle for issue CC-15 (Iteration 1/3)
+**Files Reviewed:** 8
+**Skills Applied:** architecture, scala3, composition, testing, style
+**Timestamp:** 2026-04-05T10:15:13
+**Git Context:** git diff 61d41b4
+
+---
+
+<review skill="architecture">
+
+## Architecture Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `stderrBuffer` is captured but never consumed
+**Location:** `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala:126-128`
+**Problem:** `stderrBuffer` is allocated, passed to `captureStderr`, and written to inside the background fork, but nothing ever reads it. The buffer is a local val that goes out of scope when `start` returns.
+**Impact:** Dead state that misleads readers into thinking stderr diagnostics are accessible to callers.
+**Recommendation:** Either expose the buffer through `Session` (e.g., a `lastError: Option[String]` method), or remove the buffer entirely and log directly inside `captureStderr` without accumulating.
+
+#### `readInitMessages` reaches into `SessionProcess` internals via package-private field
+**Location:** `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala:155-185`
+**Problem:** `readInitMessages` accepts the concrete `SessionProcess` and directly mutates `session.currentSessionId`, bypassing the trait abstraction.
+**Recommendation:** Move `readInitMessages` into the `SessionProcess` class itself as a private method, or have it return `Option[String]` and let the caller set the ID.
+
+#### `resolveSessionExecutablePath` duplicates `discoverClaudeExecutablePath` logic
+**Location:** `direct/src/works/iterative/claude/direct/ClaudeCode.scala:175-180`
+**Problem:** Structurally identical to `discoverClaudeExecutablePath` apart from the options type.
+**Recommendation:** Extract a shared private helper that takes `Option[String]` and handles CLI discovery.
+
+### Suggestions
+
+#### `SDKUserMessage` re-exported in `package.scala` but is an internal protocol detail
+**Location:** `direct/src/works/iterative/claude/direct/package.scala:13-14`
+**Recommendation:** Remove the re-export; import directly from `core.model` where needed.
+
+#### `Session.close()` returns `Unit` with no way to signal failure
+**Location:** `direct/src/works/iterative/claude/direct/Session.scala:30`
+**Recommendation:** Consider `Try[Unit]` or document best-effort semantics.
+
+</review>
+
+---
+
+<review skill="scala3">
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `package object` should be replaced with top-level definitions
+**Location:** `direct/src/works/iterative/claude/direct/package.scala:6`
+**Problem:** Uses `package object direct` which is a Scala 2 construct. In Scala 3, top-level type aliases and val definitions can be placed directly without wrapping.
+**Note:** This is pre-existing code, not introduced by this phase. Defer to a separate refactoring.
+
+#### `MockLogger` duplicated across all three test files
+**Location:** `SessionTest.scala`, `SessionIntegrationTest.scala`, `SessionE2ETest.scala`
+**Problem:** Identical `MockLogger` inner class copy-pasted into each test file.
+**Recommendation:** Extract to `internal/testing/MockLogger.scala`.
+
+### Suggestions
+
+#### `var` + `while` loop in `send` could use `boundary`/`break`
+**Location:** `SessionProcess.scala:166`
+**Note:** Minor given the `Flow.usingEmit` constraint. Current code is readable.
+
+#### `sessionId` typed as `String` — consider opaque type
+**Location:** `Session.scala:38`
+**Note:** Suggestion for follow-up, not a blocker.
+
+</review>
+
+---
+
+<review skill="composition">
+
+## Composition Patterns Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `readInitMessages` mutates `SessionProcess` internals directly
+**Location:** `SessionProcess.scala:155-185`
+**Problem:** Factory method directly mutates private state of the class it constructs.
+**Recommendation:** Have `readInitMessages` return `Option[String]` and let `start` apply the value.
+
+#### Two parallel `resolveExecutablePath` methods with near-identical logic
+**Location:** `ClaudeCode.scala:121-123` and `:175-179`
+**Recommendation:** Extract shared helper taking `Option[String]`.
+
+#### `stderrBuffer` is created but never read
+**Location:** `SessionProcess.scala:126-129`
+**Recommendation:** Remove buffer, simplify to logging-only.
+
+### Suggestions
+
+#### `send` mixes I/O writing with Flow construction
+**Note:** Minor — method is short enough. Consider extracting `writeMessage` if it grows.
+
+#### `configureSessionProcess` and `buildCliArguments` follow same pattern
+**Note:** No immediate action. Flag for review in next phase.
+
+</review>
+
+---
+
+<review skill="testing">
+
+## Testing Review
+
+### Critical Issues
+
+#### T1 is not a real test
+**Location:** `SessionTest.scala:455`
+**Problem:** The "Session trait compiles with expected method signatures" test creates `classOf[?]` values and asserts they are non-null, which always passes. It does not verify the Session trait has the right signatures.
+**Recommendation:** Either delete this test (compile-time check is sufficient) or replace with a test that exercises the trait through a real implementation.
+
+#### T7 close test asserts nothing meaningful
+**Location:** `SessionTest.scala:640`
+**Problem:** Test ends with `assert(true)`. The script used emits a result and exits — it is not a hanging script. The test does not verify close behavior.
+**Recommendation:** Use a hanging process script and add a deadline around `close()`. Assert the process is no longer alive.
+
+#### MockLogger duplicated across three test files
+**Location:** `SessionTest.scala:783`, `SessionIntegrationTest.scala:481`, `SessionE2ETest.scala:375`
+**Recommendation:** Extract to `internal/testing/MockLogger.scala`.
+
+### Warnings
+
+#### `Thread.sleep` inside integration test
+**Location:** `SessionIntegrationTest.scala:238`
+**Problem:** `Thread.sleep(50)` used for "file flush" timing. Coupling test correctness to wall-clock time.
+**Recommendation:** Ensure `close()` contract guarantees process exit. Remove sleep.
+
+#### IT3: Session ID extraction test does not exercise the session
+**Location:** `SessionIntegrationTest.scala:274`
+**Problem:** Checks `session.sessionId` without calling `send`. Unclear if init messages are consumed eagerly.
+**Recommendation:** Document the contract. If init is eager, add a comment. If lazy, call `send` first.
+
+#### Parallel cleanup calls on same path in `afterEach`
+**Location:** `SessionTest.scala:443`
+**Problem:** Both `MockCliScript.cleanup` and `SessionMockCliScript.cleanup` called on every path.
+**Recommendation:** Track which factory created each path, or use a single cleanup utility.
+
+#### No coverage for error paths
+**Problem:** No tests for non-zero exit, malformed JSON, error ResultMessage, or concurrent sends.
+**Recommendation:** Add at minimum one test for CLI process failure and one for error ResultMessage.
+
+### Suggestions
+
+#### `singleTurnSession` helper in `CommonResponses` is unused
+#### E2E tests duplicate CLI availability checks
+
+</review>
+
+---
+
+<review skill="style">
+
+## Code Style & Documentation Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `sessionId` uses magic string sentinel instead of `Option`
+**Location:** `Session.scala:109`, `SessionProcess.scala:152`
+**Problem:** `"pending"` is used as a sentinel value. Callers cannot distinguish from a real value.
+**Recommendation:** Change return type to `Option[String]`.
+
+#### Instance method Scaladoc mentions "provided Ox scope" but it's from constructor
+**Location:** `ClaudeCode.scala:27-28`
+**Recommendation:** Adjust Scaladoc to say "Ox scope provided at construction."
+
+### Suggestions
+
+#### Test T1 tests nothing at runtime
+#### Scaladoc references string literal "pending" as part of contract
+#### Generated bash comment says "Auto-generated" — use descriptive comment instead
+
+</review>
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 3 |
+| Warnings | 10 |
+| Suggestions | 8 |
+
+**Critical issues** are all in test code (T1 vacuous test, T7 vacuous assertion, MockLogger duplication). No critical issues in production code.
+
+**Key warnings** cluster around:
+1. Dead `stderrBuffer` state (2 reviewers)
+2. `readInitMessages` mutation pattern (2 reviewers)
+3. Executable path resolution duplication (2 reviewers)
+4. Missing error path test coverage
+5. `sessionId` magic string vs `Option`
+
+**Recommendation:** Fix the 3 critical test issues and the top warnings (stderrBuffer removal, readInitMessages encapsulation, MockLogger extraction, error path tests). The remaining warnings and suggestions can be deferred.

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -34,14 +34,18 @@
     {
       "label": "Phase 3 Context",
       "path": "project-management/issues/CC-15/phase-03-context.md"
+    },
+    {
+      "label": "Phase 3 Tasks",
+      "path": "project-management/issues/CC-15/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T06:56:09.471870405Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-05T07:31:41.688055579Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 3: Context Ready",
+    "text": "Phase 3: Tasks Ready",
     "subtext": "Direct API - Basic session lifecycle",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -61,7 +65,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 3 context ready for review",
+  "message": "Phase 3 tasks ready",
   "available_actions": [
     {
       "id": "implement",
@@ -79,13 +83,13 @@
       "skill": "external-link"
     }
   ],
-  "git_sha": "e68cf43",
+  "git_sha": "9cd6ae4",
   "phase_checkpoints": {
     "3": {
       "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
     }
   },
   "needs_attention": true,
-  "activity": "working",
+  "activity": "waiting",
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -40,12 +40,12 @@
       "path": "project-management/issues/CC-15/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T07:31:41.688055579Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-05T07:35:00.000000000Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 3: Tasks Ready",
+    "text": "Phase 3: Implementing",
     "subtext": "Direct API - Basic session lifecycle",
-    "type": "success"
+    "type": "progress"
   },
   "badges": [
     {
@@ -65,7 +65,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 3 tasks ready",
+  "message": "Phase 3 implementation in progress",
   "available_actions": [
     {
       "id": "implement",
@@ -83,13 +83,13 @@
       "skill": "external-link"
     }
   ],
-  "git_sha": "9cd6ae4",
+  "git_sha": "61d41b4",
   "phase_checkpoints": {
     "3": {
       "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
     }
   },
   "needs_attention": true,
-  "activity": "waiting",
+  "activity": "working",
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -40,12 +40,12 @@
       "path": "project-management/issues/CC-15/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T07:35:00.000000000Z",
-  "status": "implementing",
+  "last_updated": "2026-04-05T08:30:22.066627466Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 3: Implementing",
+    "text": "Phase 3: Awaiting Review",
     "subtext": "Direct API - Basic session lifecycle",
-    "type": "progress"
+    "type": "warning"
   },
   "badges": [
     {
@@ -65,7 +65,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 3 implementation in progress",
+  "message": "Phase 3 PR awaiting review",
   "available_actions": [
     {
       "id": "implement",
@@ -83,13 +83,13 @@
       "skill": "external-link"
     }
   ],
-  "git_sha": "61d41b4",
+  "git_sha": "84ba56e",
   "phase_checkpoints": {
     "3": {
       "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
     }
   },
   "needs_attention": true,
-  "activity": "working",
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
+  "activity": "waiting",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/25"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -30,14 +30,18 @@
     {
       "label": "Phase 2 Tasks",
       "path": "project-management/issues/CC-15/phase-02-tasks.md"
+    },
+    {
+      "label": "Phase 3 Context",
+      "path": "project-management/issues/CC-15/phase-03-context.md"
     }
   ],
-  "last_updated": "2026-04-04T20:44:00.099486323Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-05T06:56:09.471870405Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 02: Awaiting Review",
-    "subtext": "SessionOptions configuration",
-    "type": "warning"
+    "text": "Phase 3: Context Ready",
+    "subtext": "Direct API - Basic session lifecycle",
+    "type": "info"
   },
   "badges": [
     {
@@ -57,7 +61,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 02 implementation started",
+  "message": "Phase 3 context ready for review",
   "available_actions": [
     {
       "id": "implement",
@@ -77,14 +81,11 @@
   ],
   "git_sha": "e68cf43",
   "phase_checkpoints": {
-    "1": {
-      "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"
-    },
-    "2": {
-      "context_sha": "e68cf43"
+    "3": {
+      "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
     }
   },
   "needs_attention": true,
-  "activity": "waiting",
+  "activity": "working",
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
 }


### PR DESCRIPTION
## Summary

- Adds `Session` trait with `send(prompt): Flow[Message]`, `close()`, and `sessionId` for persistent two-way conversations with a single Claude Code CLI process
- Implements `SessionProcess` managing a long-lived CLI process with stdin/stdout streaming via the stream-json protocol
- Adds `ClaudeCode.session(SessionOptions)` factory methods on both the class and companion object
- Includes `SessionMockCliScript` for testing the session protocol with mock CLI scripts

## Test plan

- [x] 8 unit tests (SDKUserMessage encoding, session ID lifecycle, ResultMessage flow termination, close behavior)
- [x] 5 integration tests (full lifecycle, stdin JSON verification, session ID extraction, message passthrough, factory)
- [x] 2 E2E tests (real CLI session, session ID validation — gated on CLI availability)
- [x] All 397 existing tests pass (no regressions)
- [x] Code review passed (architecture, scala3, composition, testing, style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)