### PR TITLE
Phase 5: Effectful API - Session lifecycle with Resource

### DIFF
--- a/direct/src/works/iterative/claude/direct/Session.scala
+++ b/direct/src/works/iterative/claude/direct/Session.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Trait representing an active conversational session with the Claude Code CLI
-// PURPOSE: Provides send/close interface for multi-turn conversations over a persistent process
+// PURPOSE: Provides send/stream/close interface for multi-turn conversations over a persistent process
 package works.iterative.claude.direct
 
 import ox.flow.Flow
@@ -8,19 +8,21 @@ import works.iterative.claude.core.model.Message
 /** An active Claude Code session backed by a long-lived CLI process.
   *
   * Each session maintains a single CLI process whose stdin is kept open for
-  * multi-turn conversation. Prompts are submitted via `send`, which writes an
-  * SDKUserMessage to stdin and streams stdout messages back as a Flow until a
-  * ResultMessage signals end-of-turn. Call `close` to shut down the process
-  * cleanly when the session is no longer needed.
+  * multi-turn conversation. Each turn is initiated with `send` (which writes
+  * the prompt to stdin) and then consumed via `stream` (which reads stdout
+  * until the ResultMessage signals end-of-turn). Call `close` to shut down the
+  * process cleanly when the session is no longer needed.
   */
 trait Session:
-  /** Sends a prompt to the session and streams the response.
+  /** Writes a prompt to the session's stdin as an SDKUserMessage JSON line. */
+  def send(prompt: String): Unit
+
+  /** Reads stdout messages for the current turn until a ResultMessage.
     *
-    * Writes an SDKUserMessage JSON line to the process stdin, then returns a
-    * Flow of messages read from stdout. The Flow completes after emitting the
-    * ResultMessage that terminates the current turn.
+    * Returns a Flow of messages that completes after emitting the ResultMessage
+    * that terminates the current turn. Must be called after `send`.
     */
-  def send(prompt: String): Flow[Message]
+  def stream(): Flow[Message]
 
   /** Shuts down the underlying CLI process.
     *
@@ -32,7 +34,7 @@ trait Session:
   /** The session ID assigned by the CLI.
     *
     * Returns "pending" until the CLI emits an init SystemMessage or until the
-    * first send completes (at which point the ResultMessage session ID is
+    * first turn completes (at which point the ResultMessage session ID is
     * used).
     */
   def sessionId: String

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -38,7 +38,7 @@ private[direct] class SessionProcess(
 
   def sessionId: String = currentSessionId.get()
 
-  def send(prompt: String): Flow[Message] =
+  def send(prompt: String): Unit =
     val msg =
       SDKUserMessage(content = prompt, sessionId = currentSessionId.get())
     val json = msg.asJson.noSpaces
@@ -47,13 +47,14 @@ private[direct] class SessionProcess(
     stdinWriter.newLine()
     stdinWriter.flush()
 
+  def stream(): Flow[Message] =
     Flow.usingEmit { emit =>
       var done = false
       var lineNumber = 0
       while !done do
         val line = stdoutReader.readLine()
         if line == null then
-          logger.debug("stdout EOF reached during send")
+          logger.debug("stdout EOF reached during stream")
           done = true
         else
           lineNumber += 1
@@ -143,16 +144,6 @@ object SessionProcess:
   private val InitReadTimeoutMs = 500L // Wait up to 500ms for init message
   private val InitReadRetryDelayMs = 10L // Sleep between ready() checks
 
-  /** Reads from stdout to extract the session_id from the CLI's init message.
-    *
-    * Waits up to InitReadTimeoutMs for the process to emit an init message.
-    * Only reads if the process is still alive (to avoid consuming messages from
-    * quick-exit mock scripts used in tests). Stops as soon as the init message
-    * is found, a non-init message is encountered, or the timeout expires.
-    *
-    * If no init message is found, the session ID remains "pending" and will be
-    * updated from the first ResultMessage when `send` is called.
-    */
   /** Reads from stdout to find the session_id in the CLI's init message.
     *
     * Returns the extracted session ID if an init message is found within the

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -38,8 +38,8 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val messages =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val messages = session.stream().runToList()
 
         assert(messages.nonEmpty, "Expected messages from real CLI session")
         assert(
@@ -62,17 +62,13 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session
-            .send("Remember the number 42. Reply only with 'OK'.")
-            .runToList()
+        session.send("Remember the number 42. Reply only with 'OK'.")
+        val _ = session.stream().runToList()
 
-        val secondTurnMessages =
-          session
-            .send(
-              "What number did I ask you to remember? Reply with just the number."
-            )
-            .runToList()
+        session.send(
+          "What number did I ask you to remember? Reply with just the number."
+        )
+        val secondTurnMessages = session.stream().runToList()
 
         val assistantMessages =
           secondTurnMessages.collect { case a: AssistantMessage => a }
@@ -100,8 +96,8 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val _ = session.stream().runToList()
 
         assert(
           session.sessionId != "pending",
@@ -125,12 +121,12 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val _ = session.stream().runToList()
         val afterFirstTurn = session.sessionId
 
-        val _ =
-          session.send("What is 2+2? Reply with just the number.").runToList()
+        session.send("What is 2+2? Reply with just the number.")
+        val _ = session.stream().runToList()
         val afterSecondTurn = session.sessionId
 
         assert(

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -51,7 +51,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("What is the answer?").runToList()
+        session.send("What is the answer?")
+        val messages = session.stream().runToList()
 
         // Should have assistant + result
         assertEquals(messages.length, 2)
@@ -108,7 +109,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("Hello from test").runToList()
+        session.send("Hello from test")
+        val _ = session.stream().runToList()
       finally session.close()
 
       val capturedLines = Files.readAllLines(captureFile)
@@ -204,7 +206,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("test").runToList()
+        session.send("test")
+        val messages = session.stream().runToList()
 
         assert(
           messages.exists(_ == KeepAliveMessage),
@@ -259,7 +262,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val claude = ClaudeCode.concurrent
       val session = claude.session(options)
       try
-        val messages = session.send("factory test").runToList()
+        session.send("factory test")
+        val messages = session.stream().runToList()
 
         assert(
           messages.exists(_.isInstanceOf[AssistantMessage]),
@@ -315,7 +319,8 @@ class SessionIntegrationTest extends munit.FunSuite:
         // Init message is consumed before any send
         assertEquals(session.sessionId, initSessionId)
 
-        val turn1Messages = session.send("First question").runToList()
+        session.send("First question")
+        val turn1Messages = session.stream().runToList()
         assertEquals(turn1Messages.length, 2)
         turn1Messages.head match
           case AssistantMessage(content) =>
@@ -328,7 +333,8 @@ class SessionIntegrationTest extends munit.FunSuite:
 
         assertEquals(session.sessionId, turn1SessionId)
 
-        val turn2Messages = session.send("Second question").runToList()
+        session.send("Second question")
+        val turn2Messages = session.stream().runToList()
         assertEquals(turn2Messages.length, 2)
         turn2Messages.head match
           case AssistantMessage(content) =>
@@ -383,8 +389,10 @@ class SessionIntegrationTest extends munit.FunSuite:
       val session = ClaudeCode.session(options)
       try
         assertEquals(session.sessionId, initSessionId)
-        val _ = session.send("Prompt one").runToList()
-        val _ = session.send("Prompt two").runToList()
+        session.send("Prompt one")
+        val _ = session.stream().runToList()
+        session.send("Prompt two")
+        val _ = session.stream().runToList()
       finally session.close()
 
       val lines = Files.readAllLines(captureFile)
@@ -451,7 +459,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val turn1Messages = session.send("Short turn").runToList()
+        session.send("Short turn")
+        val turn1Messages = session.stream().runToList()
         assertEquals(
           turn1Messages.length,
           2,
@@ -470,7 +479,8 @@ class SessionIntegrationTest extends munit.FunSuite:
           "Turn 1 must not contain KeepAliveMessage"
         )
 
-        val turn2Messages = session.send("Verbose turn").runToList()
+        session.send("Verbose turn")
+        val turn2Messages = session.stream().runToList()
         assertEquals(
           turn2Messages.length,
           4,

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -152,7 +152,8 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("test").runToList()
+        session.send("test")
+        val messages = session.stream().runToList()
 
         // Should have assistant + result only
         val resultMessages = messages.collect { case r: ResultMessage => r }
@@ -191,10 +192,11 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        // Run the flow to completion
-        val _ = session.send("test").runToList()
+        // Run the stream to completion
+        session.send("test")
+        val _ = session.stream().runToList()
 
-        // After send completes, session ID should be updated from ResultMessage
+        // After stream completes, session ID should be updated from ResultMessage
         assertEquals(session.sessionId, "updated-session-id-456")
       finally session.close()
     }
@@ -228,8 +230,10 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val turn1Messages = session.send("First prompt").runToList()
-        val turn2Messages = session.send("Second prompt").runToList()
+        session.send("First prompt")
+        val turn1Messages = session.stream().runToList()
+        session.send("Second prompt")
+        val turn2Messages = session.stream().runToList()
 
         // Turn 1 should have exactly assistant + result
         assertEquals(turn1Messages.length, 2)
@@ -298,12 +302,14 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("First prompt").runToList()
+        session.send("First prompt")
+        val _ = session.stream().runToList()
 
-        // After first send, sessionId must be updated from the ResultMessage
+        // After first turn, sessionId must be updated from the ResultMessage
         assertEquals(session.sessionId, firstTurnSessionId)
 
-        val _ = session.send("Second prompt").runToList()
+        session.send("Second prompt")
+        val _ = session.stream().runToList()
       finally session.close()
 
       // Verify the second SDKUserMessage sent to stdin contained the first turn's session ID
@@ -354,10 +360,12 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("First prompt").runToList()
+        session.send("First prompt")
+        val _ = session.stream().runToList()
         assertEquals(session.sessionId, turn1SessionId)
 
-        val _ = session.send("Second prompt").runToList()
+        session.send("Second prompt")
+        val _ = session.stream().runToList()
         assertEquals(session.sessionId, turn2SessionId)
       finally session.close()
     }
@@ -389,7 +397,8 @@ class SessionTest extends munit.FunSuite:
       val session = ClaudeCode.session(options)
       try
         val results = (1 to 3).map { i =>
-          val messages = session.send(s"Prompt $i").runToList()
+          session.send(s"Prompt $i")
+          val messages = session.stream().runToList()
           // Each turn must end with its own ResultMessage
           val resultMsg = messages
             .collectFirst { case r: ResultMessage => r }
@@ -448,12 +457,8 @@ class SessionTest extends munit.FunSuite:
 
       // Verify the session is no longer usable — send should throw because
       // the underlying stdin writer is closed
-      val caught = intercept[Exception] {
-        session.send("should fail").runToList()
+      intercept[Exception] {
+        session.send("should fail")
       }
-      assert(
-        caught != null,
-        "Expected an exception when sending to a closed session"
-      )
     }
   }

--- a/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+++ b/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
@@ -24,21 +24,9 @@ object ClaudeCode:
   def session(options: SessionOptions)(using
       logger: Logger[IO]
   ): Resource[IO, Session] =
-    discoverExecutableForSession(options).flatMap { executablePath =>
-      SessionProcess.start(executablePath, options)
-    }
-
-  private def discoverExecutableForSession(
-      options: SessionOptions
-  )(using logger: Logger[IO]): Resource[IO, String] =
-    options.pathToClaudeCodeExecutable match
-      case Some(path) => Resource.pure(path)
-      case None       =>
-        Resource
-          .eval(CLIDiscovery.findClaude(logger))
-          .flatMap:
-            case Right(path) => Resource.pure(path)
-            case Left(error) => Resource.eval(IO.raiseError(error))
+    Resource
+      .eval(resolveExecutable(options.pathToClaudeCodeExecutable))
+      .flatMap(SessionProcess.start(_, options))
 
   def queryResult(options: QueryOptions)(using logger: Logger[IO]): IO[String] =
     querySync(options)(using logger).map(extractTextFromMessages)
@@ -75,17 +63,21 @@ object ClaudeCode:
   ): Stream[IO, Unit] =
     Stream.eval(logger.info(s"Initiating query with prompt: $prompt"))
 
+  private def resolveExecutable(
+      path: Option[String]
+  )(using logger: Logger[IO]): IO[String] =
+    path match
+      case Some(p) => IO.pure(p)
+      case None    =>
+        CLIDiscovery.findClaude(logger).flatMap {
+          case Right(p)    => IO.pure(p)
+          case Left(error) => IO.raiseError(error)
+        }
+
   private def discoverExecutablePath(options: QueryOptions)(using
       logger: Logger[IO]
   ): Stream[IO, String] =
-    options.pathToClaudeCodeExecutable match
-      case Some(explicitPath) => Stream.eval(IO.pure(explicitPath))
-      case None               =>
-        Stream
-          .eval(CLIDiscovery.findClaude(logger))
-          .flatMap:
-            case Right(path) => Stream.emit(path)
-            case Left(error) => Stream.raiseError[IO](error)
+    Stream.eval(resolveExecutable(options.pathToClaudeCodeExecutable))
 
   private def buildCLIArguments(options: QueryOptions): List[String] =
     List("--print", "--verbose", "--output-format", "stream-json") ++

--- a/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+++ b/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
@@ -2,29 +2,44 @@
 // PURPOSE: Provides streaming query interface to Claude Code CLI functionality
 package works.iterative.claude.effectful
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import fs2.Stream
-import fs2.io.process.{Process, ProcessBuilder}
-import fs2.io.file.Path
 import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import works.iterative.claude.core.model.*
-import works.iterative.claude.core.model.QueryOptions
-import works.iterative.claude.effectful.internal.parsing.JsonParser
+import works.iterative.claude.core.model.{QueryOptions, SessionOptions}
 import works.iterative.claude.core.{
   ProcessExecutionError,
   JsonParsingError,
-  ProcessTimeoutError,
   ConfigurationError
 }
 import works.iterative.claude.effectful.internal.cli.{
   CLIDiscovery,
-  ProcessManager
+  ProcessManager,
+  SessionProcess
 }
 import works.iterative.claude.core.cli.CLIArgumentBuilder
 
 object ClaudeCode:
   // Public API - High-level "What" operations
+  def session(options: SessionOptions)(using
+      logger: Logger[IO]
+  ): Resource[IO, Session] =
+    discoverExecutableForSession(options).flatMap { executablePath =>
+      SessionProcess.start(executablePath, options)
+    }
+
+  private def discoverExecutableForSession(
+      options: SessionOptions
+  )(using logger: Logger[IO]): Resource[IO, String] =
+    options.pathToClaudeCodeExecutable match
+      case Some(path) => Resource.pure(path)
+      case None       =>
+        Resource
+          .eval(CLIDiscovery.findClaude(logger))
+          .flatMap:
+            case Right(path) => Resource.pure(path)
+            case Left(error) => Resource.eval(IO.raiseError(error))
+
   def queryResult(options: QueryOptions)(using logger: Logger[IO]): IO[String] =
     querySync(options)(using logger).map(extractTextFromMessages)
 

--- a/effectful/src/works/iterative/claude/effectful/Session.scala
+++ b/effectful/src/works/iterative/claude/effectful/Session.scala
@@ -1,0 +1,36 @@
+// PURPOSE: Trait representing an active conversational session with the Claude Code CLI
+// PURPOSE: Provides send/stream/sessionId interface for multi-turn conversations using cats-effect
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import fs2.Stream
+import works.iterative.claude.core.model.Message
+
+/** An active Claude Code session backed by a long-lived CLI process.
+  *
+  * Each session maintains a single CLI process whose stdin is kept open for
+  * multi-turn conversation. Each turn is initiated with `send` (which writes
+  * the prompt to stdin as an IO effect) and then consumed via `stream` (which
+  * reads stdout until the ResultMessage signals end-of-turn). The session is
+  * acquired as a Resource, which handles process cleanup on both normal exit
+  * and error.
+  */
+trait Session:
+  /** Writes a prompt to the session's stdin as an SDKUserMessage JSON line. */
+  def send(prompt: String): IO[Unit]
+
+  /** Reads stdout messages for the current turn until a ResultMessage.
+    *
+    * Returns a Stream of messages that completes after emitting the
+    * ResultMessage that terminates the current turn. Must be called after
+    * `send`.
+    */
+  def stream: Stream[IO, Message]
+
+  /** The session ID assigned by the CLI, wrapped in IO since it reads a Ref.
+    *
+    * Returns IO("pending") until the CLI emits an init SystemMessage or until
+    * the first turn completes (at which point the ResultMessage session ID is
+    * used).
+    */
+  def sessionId: IO[String]

--- a/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+++ b/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
@@ -1,0 +1,201 @@
+// PURPOSE: Resource-based effectful Session implementation backed by a long-lived CLI process
+// PURPOSE: Manages stdin writing, stdout streaming via Queue, stderr capture, and process lifecycle
+package works.iterative.claude.effectful.internal.cli
+
+import cats.effect.{IO, Ref, Resource}
+import cats.effect.std.Queue
+import fs2.{Chunk, Stream}
+import fs2.io.process.ProcessBuilder
+import fs2.io.file.Path
+import io.circe.syntax.*
+import org.typelevel.log4cats.Logger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.core.cli.CLIArgumentBuilder
+import works.iterative.claude.effectful.Session
+import works.iterative.claude.effectful.internal.parsing.JsonParser
+
+/** Starts and manages a long-lived Claude Code CLI session process.
+  *
+  * The process is spawned once and kept alive for multiple turns. A background
+  * fiber writes stdin from a queue (keeping the pipe open across sends); a
+  * second fiber continuously reads stdout lines into a message queue; a third
+  * fiber captures stderr for diagnostics. Cleanup is handled by the Resource
+  * finalizer.
+  */
+object SessionProcess:
+
+  def start(
+      executablePath: String,
+      options: SessionOptions
+  )(using logger: Logger[IO]): Resource[IO, Session] =
+    val args = "--verbose" :: CLIArgumentBuilder.buildSessionArgs(options)
+
+    for
+      process <- buildProcess(executablePath, args, options).spawn[IO]
+      // stdin queue: Some(chunk) = data, None = close signal
+      stdinQueue <- Resource.eval(Queue.unbounded[IO, Option[Chunk[Byte]]])
+      // message queue: Some(msg) = message, None = stdout EOF
+      messageQueue <- Resource.eval(Queue.unbounded[IO, Option[Message]])
+      sessionIdRef <- Resource.eval(Ref.of[IO, String]("pending"))
+      // Background fiber: drains stdinQueue into process.stdin
+      _ <- Resource.make(
+        startStdinWriter(process, stdinQueue).start
+      )(_.cancel)
+      // Background fiber: reads process.stdout into messageQueue
+      _ <- Resource.make(
+        startStdoutReader(process, messageQueue, sessionIdRef).start
+      )(_.cancel)
+      // Background fiber: captures stderr for diagnostics
+      _ <- Resource.make(
+        captureStderr(process).start
+      )(_.cancel)
+      // Read init message to prime sessionId before returning the session
+      _ <- Resource.eval(readInitMessage(messageQueue, sessionIdRef))
+    yield new SessionImpl(stdinQueue, sessionIdRef, messageQueue)
+
+  private def buildProcess(
+      executablePath: String,
+      args: List[String],
+      options: SessionOptions
+  ): ProcessBuilder =
+    val base = ProcessBuilder(executablePath, args)
+      .withInheritEnv(options.inheritEnvironment.getOrElse(true))
+
+    val withEnv = options.environmentVariables.fold(base)(envVars =>
+      base.withExtraEnv(envVars)
+    )
+
+    options.cwd.fold(withEnv)(cwd => withEnv.withWorkingDirectory(Path(cwd)))
+
+  /** Background fiber: reads from stdinQueue and writes to process.stdin.
+    * Terminates when None is dequeued (closes the pipe).
+    */
+  private def startStdinWriter(
+      process: fs2.io.process.Process[IO],
+      stdinQueue: Queue[IO, Option[Chunk[Byte]]]
+  ): IO[Unit] =
+    Stream
+      .fromQueueNoneTerminated(stdinQueue)
+      .flatMap(Stream.chunk)
+      .through(process.stdin)
+      .compile
+      .drain
+
+  /** Background fiber: reads stdout lines, parses into messages, and enqueues
+    * them. Also updates sessionIdRef on ResultMessage. Signals EOF with None.
+    */
+  private def startStdoutReader(
+      process: fs2.io.process.Process[IO],
+      messageQueue: Queue[IO, Option[Message]],
+      sessionIdRef: Ref[IO, String]
+  )(using logger: Logger[IO]): IO[Unit] =
+    process.stdout
+      .through(fs2.text.utf8.decode)
+      .through(fs2.text.lines)
+      .zipWithIndex
+      .evalMap { case (line, idx) =>
+        JsonParser.parseJsonLineWithContext(line, idx.toInt + 1, logger)
+      }
+      .evalMap {
+        case Left(err)        => IO.raiseError(err)
+        case Right(None)      => IO.pure(None: Option[Message])
+        case Right(Some(msg)) =>
+          msg match
+            case result: ResultMessage =>
+              sessionIdRef.set(result.sessionId).as(Some(msg): Option[Message])
+            case _ => IO.pure(Some(msg): Option[Message])
+      }
+      .unNone
+      .evalMap(msg => messageQueue.offer(Some(msg)))
+      .compile
+      .drain
+      .guarantee(messageQueue.offer(None))
+
+  private val InitReadTimeout =
+    scala.concurrent.duration.FiniteDuration(1000, "ms")
+
+  /** Waits for the first message from the stdout reader and checks if it's the
+    * init SystemMessage. If so, extracts the session ID. Otherwise, re-enqueues
+    * the message so it appears in the user's stream.
+    *
+    * Waits up to InitReadTimeout. If no message arrives within the timeout, the
+    * session ID stays "pending" (the init message either was not emitted or has
+    * not yet been buffered by the stdout reader fiber).
+    */
+  private def readInitMessage(
+      messageQueue: Queue[IO, Option[Message]],
+      sessionIdRef: Ref[IO, String]
+  )(using logger: Logger[IO]): IO[Unit] =
+    // Wait for the first message with a timeout using race
+    IO.race(
+      messageQueue.take,
+      IO.sleep(InitReadTimeout)
+    ).flatMap {
+      case Left(None) =>
+        // Stdout closed before any message
+        messageQueue.offer(None)
+      case Left(Some(SystemMessage("init", data))) =>
+        data.get("session_id").map(_.toString) match
+          case Some(id) =>
+            logger.info(s"Session ID extracted from init message: $id") *>
+              sessionIdRef.set(id)
+          case None => IO.unit
+      case Left(Some(msg)) =>
+        // Non-init message; put it back for the user's stream
+        messageQueue.offer(Some(msg))
+      case Right(()) =>
+        // Timeout: no message arrived — session ID stays "pending"
+        IO.unit
+    }
+
+  private def captureStderr(
+      process: fs2.io.process.Process[IO]
+  )(using logger: Logger[IO]): IO[Unit] =
+    process.stderr
+      .through(fs2.text.utf8.decode)
+      .through(fs2.text.lines)
+      .evalMap(line => logger.debug(s"session stderr: $line"))
+      .compile
+      .drain
+
+/** Internal Session implementation that writes to a stdin queue and reads from
+  * a shared message queue.
+  */
+private class SessionImpl(
+    stdinQueue: Queue[IO, Option[Chunk[Byte]]],
+    sessionIdRef: Ref[IO, String],
+    messageQueue: Queue[IO, Option[Message]]
+)(using logger: Logger[IO])
+    extends Session:
+
+  def sessionId: IO[String] = sessionIdRef.get
+
+  def send(prompt: String): IO[Unit] =
+    sessionIdRef.get.flatMap { currentId =>
+      val msg = SDKUserMessage(content = prompt, sessionId = currentId)
+      val json = msg.asJson.noSpaces + "\n"
+      logger.debug(
+        s"Writing SDKUserMessage to stdin: ${msg.asJson.noSpaces}"
+      ) *>
+        stdinQueue.offer(
+          Some(
+            Chunk.array(json.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          )
+        )
+    }
+
+  /** Reads messages from the shared queue until (and including) a
+    * ResultMessage, then stops.
+    */
+  def stream: Stream[IO, Message] =
+    Stream.eval(messageQueue.take).flatMap {
+      case None =>
+        // Stdout closed — no more messages
+        Stream.empty
+      case Some(msg) =>
+        msg match
+          case _: ResultMessage =>
+            Stream.emit(msg)
+          case _ =>
+            Stream.emit(msg) ++ stream
+    }

--- a/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+++ b/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
@@ -1,10 +1,11 @@
 // PURPOSE: Resource-based effectful Session implementation backed by a long-lived CLI process
-// PURPOSE: Manages stdin writing, stdout streaming via Queue, stderr capture, and process lifecycle
+// PURPOSE: Handles session startup, multi-turn message routing, and deterministic process cleanup
 package works.iterative.claude.effectful.internal.cli
 
 import cats.effect.{IO, Ref, Resource}
 import cats.effect.std.Queue
 import fs2.{Chunk, Stream}
+import scala.concurrent.duration.*
 import fs2.io.process.ProcessBuilder
 import fs2.io.file.Path
 import io.circe.syntax.*
@@ -111,8 +112,7 @@ object SessionProcess:
       .drain
       .guarantee(messageQueue.offer(None))
 
-  private val InitReadTimeout =
-    scala.concurrent.duration.FiniteDuration(1000, "ms")
+  private val InitReadTimeout = 1.second
 
   /** Waits for the first message from the stdout reader and checks if it's the
     * init SystemMessage. If so, extracts the session ID. Otherwise, re-enqueues
@@ -188,14 +188,6 @@ private class SessionImpl(
     * ResultMessage, then stops.
     */
   def stream: Stream[IO, Message] =
-    Stream.eval(messageQueue.take).flatMap {
-      case None =>
-        // Stdout closed — no more messages
-        Stream.empty
-      case Some(msg) =>
-        msg match
-          case _: ResultMessage =>
-            Stream.emit(msg)
-          case _ =>
-            Stream.emit(msg) ++ stream
-    }
+    Stream
+      .fromQueueNoneTerminated(messageQueue)
+      .takeThrough(!_.isInstanceOf[ResultMessage])

--- a/effectful/src/works/iterative/claude/effectful/package.scala
+++ b/effectful/src/works/iterative/claude/effectful/package.scala
@@ -7,6 +7,8 @@ package object effectful:
   // Type aliases for convenient usage
   type QueryOptions = works.iterative.claude.core.model.QueryOptions
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
+  type SessionOptions = works.iterative.claude.core.model.SessionOptions
+  val SessionOptions = works.iterative.claude.core.model.SessionOptions
 
   // Re-export all model classes that users need
   type Message = works.iterative.claude.core.model.Message

--- a/effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
@@ -12,6 +12,10 @@ class EffectfulPackageReexportTest extends CatsEffectSuite:
     val opts = QueryOptions.simple("hello")
     assertEquals(opts.prompt, "hello")
 
+  test("effectful.* re-exports SessionOptions"):
+    val opts = SessionOptions.defaults
+    assertEquals(opts.cwd, None)
+
   test("effectful.* re-exports UserMessage"):
     val msg: Message = UserMessage("hello")
     assert(msg.isInstanceOf[UserMessage])

--- a/effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
@@ -1,0 +1,112 @@
+// PURPOSE: End-to-end tests for effectful Session using the real Claude Code CLI
+// PURPOSE: Tests are gated on CLI availability and skip gracefully when not present
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+
+class SessionE2ETest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  private def isClaudeCliInstalled(): Boolean =
+    try
+      val process = new ProcessBuilder("claude", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def hasApiKeyOrCredentials(): Boolean =
+    val hasApiKey = sys.env.contains("ANTHROPIC_API_KEY")
+    val homeDir = sys.env.get("HOME").orElse(sys.env.get("USERPROFILE"))
+    val hasCredentials = homeDir.exists { home =>
+      val path = java.nio.file.Paths.get(home, ".claude", ".credentials.json")
+      java.nio.file.Files.exists(path)
+    }
+    hasApiKey || hasCredentials
+
+  private def assumeClaudeAvailable(): Unit =
+    assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+    assume(
+      hasApiKeyOrCredentials(),
+      "Test requires API key or credentials file"
+    )
+
+  // ============================================================
+  // E1: Single-turn session with real CLI
+  // ============================================================
+
+  test("E2E: real CLI session completes a single turn") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("What is 1+1? Reply with just the number.")
+          messages <- session.stream.compile.toList
+        yield
+          assert(messages.nonEmpty, "Expected messages from real CLI session")
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            "Expected AssistantMessage in response"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            "Expected ResultMessage signalling end of turn"
+          )
+      }
+  }
+
+  // ============================================================
+  // E2: Multi-turn with context dependency
+  // ============================================================
+
+  test("E2E: two-turn conversation preserves context across turns") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("Remember the number 42. Reply only with 'OK'.")
+          _ <- session.stream.compile.drain
+          _ <- session.send(
+            "What number did I ask you to remember? Reply with just the number."
+          )
+          secondTurnMessages <- session.stream.compile.toList
+        yield
+          val assistantMessages =
+            secondTurnMessages.collect { case a: AssistantMessage => a }
+          assert(
+            assistantMessages.nonEmpty,
+            "Expected AssistantMessage in second turn"
+          )
+          val responseText = assistantMessages
+            .flatMap(_.content.collect { case TextBlock(t) => t })
+            .mkString
+          assert(
+            responseText.contains("42"),
+            s"Expected second turn to reference '42', got: $responseText"
+          )
+      }
+  }
+
+  // ============================================================
+  // E3: Session ID is valid after real CLI interaction
+  // ============================================================
+
+  test("E2E: session ID is a valid non-pending value after first turn") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("What is 1+1? Reply with just the number.")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+        yield
+          assert(
+            id != "pending",
+            s"Expected a real session ID after first turn, got: $id"
+          )
+          assert(
+            id.nonEmpty,
+            "Session ID should not be empty after first turn"
+          )
+      }
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
@@ -1,0 +1,458 @@
+// PURPOSE: Integration tests for effectful Session using mock CLI scripts
+// PURPOSE: Verifies full session lifecycle, Resource cleanup, stdin JSON format, and ClaudeCode factory
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import io.circe.parser
+import java.nio.file.Files
+
+class SessionIntegrationTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // IT1: Full single-turn session lifecycle
+  // ============================================================
+
+  test("full single-turn session lifecycle with mock CLI") {
+    val sessionId = "integ-session-001"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "The answer is 42"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("What is the answer?")
+          messages <- session.stream.compile.toList
+        yield
+          assertEquals(messages.length, 2)
+          messages.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("The answer is 42")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          messages.last match
+            case r: ResultMessage =>
+              assertEquals(r.subtype, "conversation_result")
+              assertEquals(r.isError, false)
+              assertEquals(r.sessionId, sessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT2: Resource cleanup on normal exit
+  // ============================================================
+
+  test("Resource cleanup terminates process on normal exit") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(SessionMockCliScript.CommonResponses.resultMessage())
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    // Track whether cleanup ran (we verify indirectly by checking that
+    // the Resource.use block completes without hanging)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.send("test") *> session.stream.compile.drain
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT3: Resource cleanup on error
+  // ============================================================
+
+  test("Resource cleanup terminates process when exception occurs inside use") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = Nil
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { _ =>
+        IO.raiseError(new RuntimeException("deliberate test error"))
+      }
+      .attempt
+      .map {
+        case Left(e: RuntimeException) =>
+          assertEquals(e.getMessage, "deliberate test error")
+        case Left(other) =>
+          fail(
+            s"Expected RuntimeException, got: ${other.getClass.getSimpleName}"
+          )
+        case Right(_) =>
+          fail("Expected exception to propagate through Resource.use")
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT4: Stdin JSON verification
+  // ============================================================
+
+  test("stdin carries correct SDKUserMessage JSON") {
+    val captureFile = Files.createTempFile("stdin-integ-", ".jsonl")
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(SessionMockCliScript.CommonResponses.resultMessage())
+        )
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.send(
+          "Hello from integration test"
+        ) *> session.stream.compile.drain
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+      .flatMap { _ =>
+        IO {
+          val lines = Files.readAllLines(captureFile)
+          assert(lines.size >= 1, "Expected at least one stdin line")
+          val json = parser
+            .parse(lines.get(0))
+            .toOption
+            .getOrElse(fail(s"stdin not valid JSON: ${lines.get(0)}"))
+          val cursor = json.hcursor
+          assertEquals(
+            cursor.downField("type").as[String].toOption,
+            Some("user")
+          )
+          assertEquals(
+            cursor
+              .downField("message")
+              .downField("content")
+              .as[String]
+              .toOption,
+            Some("Hello from integration test")
+          )
+          Files.delete(captureFile)
+        }
+      }
+  }
+
+  // ============================================================
+  // IT5: Session ID from init message
+  // ============================================================
+
+  test("session ID is set from mock init message during acquire") {
+    val expectedSessionId = "integ-init-session-999"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              expectedSessionId
+            )
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, expectedSessionId)
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT6: Two-turn lifecycle
+  // ============================================================
+
+  test("two-turn lifecycle returns correct responses per turn") {
+    val initSessionId = "two-turn-init-001"
+    val turn1SessionId = "two-turn-result-001"
+    val turn2SessionId = "two-turn-result-002"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "First turn answer"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+          )
+        ),
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Second turn answer"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(turn2SessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          initId <- session.sessionId
+          _ = assertEquals(initId, initSessionId)
+          _ <- session.send("First question")
+          turn1 <- session.stream.compile.toList
+          _ = assertEquals(turn1.length, 2)
+          _ = turn1.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("First turn answer")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          _ = turn1.last match
+            case r: ResultMessage => assertEquals(r.sessionId, turn1SessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+          id1 <- session.sessionId
+          _ = assertEquals(id1, turn1SessionId)
+          _ <- session.send("Second question")
+          turn2 <- session.stream.compile.toList
+          _ = assertEquals(turn2.length, 2)
+          _ = turn2.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("Second turn answer")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          _ = turn2.last match
+            case r: ResultMessage => assertEquals(r.sessionId, turn2SessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+          id2 <- session.sessionId
+          _ = assertEquals(id2, turn2SessionId)
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT7: Session ID progression across turns
+  // ============================================================
+
+  test("stdin capture shows correct session ID progression across turns") {
+    val initSessionId = "progression-init-001"
+    val turn1SessionId = "progression-turn-001"
+    val captureFile = Files.createTempFile("stdin-progression-integ-", ".jsonl")
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+          )
+        ),
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              "progression-turn-002"
+            )
+          )
+        )
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("Prompt one")
+          _ <- session.stream.compile.drain
+          _ <- session.send("Prompt two")
+          _ <- session.stream.compile.drain
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+      .flatMap { _ =>
+        IO {
+          val lines = Files.readAllLines(captureFile)
+          assert(
+            lines.size >= 2,
+            s"Expected at least 2 stdin lines, got ${lines.size}"
+          )
+
+          val firstJson = parser
+            .parse(lines.get(0))
+            .toOption
+            .getOrElse(fail(s"First stdin line not valid JSON"))
+          assertEquals(
+            firstJson.hcursor.downField("session_id").as[String].toOption,
+            Some(initSessionId),
+            "First send should carry init session ID"
+          )
+
+          val secondJson = parser
+            .parse(lines.get(1))
+            .toOption
+            .getOrElse(fail(s"Second stdin line not valid JSON"))
+          assertEquals(
+            secondJson.hcursor.downField("session_id").as[String].toOption,
+            Some(turn1SessionId),
+            "Second send should carry session ID from first turn's ResultMessage"
+          )
+          Files.delete(captureFile)
+        }
+      }
+  }
+
+  // ============================================================
+  // IT8: Variable message counts per turn
+  // ============================================================
+
+  test("turns with different message counts emit exactly the right messages") {
+    val sessionId = "msg-count-session"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        // Turn 1: assistant + result (2 messages)
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage("Short"),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        ),
+        // Turn 2: keepalive + stream_event + assistant + result (4 messages)
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.keepAliveMessage,
+            SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+            SessionMockCliScript.CommonResponses.assistantMessage("Verbose"),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("Short turn")
+          turn1 <- session.stream.compile.toList
+          _ = assertEquals(
+            turn1.length,
+            2,
+            s"Turn 1 should have 2 messages, got: $turn1"
+          )
+          _ = assert(
+            turn1.exists(_.isInstanceOf[AssistantMessage]),
+            "Turn 1 must have AssistantMessage"
+          )
+          _ = assert(
+            turn1.exists(_.isInstanceOf[ResultMessage]),
+            "Turn 1 must have ResultMessage"
+          )
+          _ = assert(
+            !turn1.exists(_ == KeepAliveMessage),
+            "Turn 1 must not have KeepAliveMessage"
+          )
+          _ <- session.send("Verbose turn")
+          turn2 <- session.stream.compile.toList
+          _ = assertEquals(
+            turn2.length,
+            4,
+            s"Turn 2 should have 4 messages, got: $turn2"
+          )
+          _ = assert(
+            turn2(0) == KeepAliveMessage,
+            s"Turn 2[0] should be KeepAliveMessage"
+          )
+          _ = assert(
+            turn2(1).isInstanceOf[StreamEventMessage],
+            s"Turn 2[1] should be StreamEventMessage"
+          )
+          _ = assert(
+            turn2(2).isInstanceOf[AssistantMessage],
+            s"Turn 2[2] should be AssistantMessage"
+          )
+          _ = assert(
+            turn2(3).isInstanceOf[ResultMessage],
+            s"Turn 2[3] should be ResultMessage"
+          )
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT9: ClaudeCode.session factory
+  // ============================================================
+
+  test("ClaudeCode.session factory produces a working session Resource") {
+    val sessionId = "factory-session-002"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Factory response"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("factory test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            "Expected AssistantMessage"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            "Expected ResultMessage"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
@@ -26,21 +26,19 @@ class SessionTest extends CatsEffectSuite:
     val parsed = parser.parse(json).toOption.get
     val cursor = parsed.hcursor
 
-    IO {
-      assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
-      assertEquals(
-        cursor.downField("message").downField("role").as[String].toOption,
-        Some("user")
-      )
-      assertEquals(
-        cursor.downField("message").downField("content").as[String].toOption,
-        Some("Hello, Claude!")
-      )
-      assertEquals(
-        cursor.downField("session_id").as[String].toOption,
-        Some("sess-42")
-      )
-    }
+    assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
+    assertEquals(
+      cursor.downField("message").downField("role").as[String].toOption,
+      Some("user")
+    )
+    assertEquals(
+      cursor.downField("message").downField("content").as[String].toOption,
+      Some("Hello, Claude!")
+    )
+    assertEquals(
+      cursor.downField("session_id").as[String].toOption,
+      Some("sess-42")
+    )
   }
 
   // ============================================================

--- a/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
@@ -1,0 +1,387 @@
+// PURPOSE: Unit tests for effectful Session trait and SessionProcess implementation
+// PURPOSE: Verifies session lifecycle, message flow, and session ID extraction using cats-effect IO
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import io.circe.parser
+import java.nio.file.Files
+
+class SessionTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // T1: SDKUserMessage encoding test
+  // ============================================================
+
+  test("SDKUserMessage is correctly encoded for stdin") {
+    import io.circe.syntax.*
+    val msg = SDKUserMessage(content = "Hello, Claude!", sessionId = "sess-42")
+    val json = msg.asJson.noSpaces
+    val parsed = parser.parse(json).toOption.get
+    val cursor = parsed.hcursor
+
+    IO {
+      assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
+      assertEquals(
+        cursor.downField("message").downField("role").as[String].toOption,
+        Some("user")
+      )
+      assertEquals(
+        cursor.downField("message").downField("content").as[String].toOption,
+        Some("Hello, Claude!")
+      )
+      assertEquals(
+        cursor.downField("session_id").as[String].toOption,
+        Some("sess-42")
+      )
+    }
+  }
+
+  // ============================================================
+  // T2: Session ID defaults to "pending"
+  // ============================================================
+
+  test("session ID defaults to 'pending' before any send") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = Nil
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, "pending")
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T3: Session ID extracted from init SystemMessage
+  // ============================================================
+
+  test(
+    "session ID is extracted from init SystemMessage during Resource acquire"
+  ) {
+    val expectedSessionId = "init-extracted-001"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              expectedSessionId
+            )
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, expectedSessionId)
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T4: Session ID updated from ResultMessage
+  // ============================================================
+
+  test("session ID is updated from ResultMessage after stream completes") {
+    val updatedSessionId = "updated-session-id-456"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$updatedSessionId"}"""
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+        yield assertEquals(id, updatedSessionId)
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T5: stream returns messages up to and including ResultMessage
+  // ============================================================
+
+  test("stream completes after emitting ResultMessage") {
+    val sessionId = "sess-flow-test"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            """{"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}""",
+            s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$sessionId"}"""
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          val resultMessages = messages.collect { case r: ResultMessage => r }
+          assertEquals(resultMessages.length, 1)
+          val assistantMessages = messages.collect { case a: AssistantMessage =>
+            a
+          }
+          assertEquals(assistantMessages.length, 1)
+          assertEquals(messages.length, 2)
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T6: KeepAlive and StreamEvent pass through
+  // ============================================================
+
+  test("KeepAlive and StreamEvent messages pass through the stream") {
+    val sessionId = "keepalive-stream-session"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.keepAliveMessage,
+            SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Answer with events"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_ == KeepAliveMessage),
+            s"Expected KeepAliveMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[StreamEventMessage]),
+            s"Expected StreamEventMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            s"Expected AssistantMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            s"Expected ResultMessage in stream: $messages"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T7: Two sequential sends return isolated streams
+  // ============================================================
+
+  test("two sequential sends return isolated message streams") {
+    val turn1Response =
+      """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 1 response"}]}}"""
+    val turn1Result =
+      """{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"session-turn-1"}"""
+    val turn2Response =
+      """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 2 response"}]}}"""
+    val turn2Result =
+      """{"type":"result","subtype":"conversation_result","duration_ms":150,"duration_api_ms":60,"is_error":false,"num_turns":2,"session_id":"session-turn-2"}"""
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(List(turn1Response, turn1Result)),
+        SessionMockCliScript.TurnResponse(List(turn2Response, turn2Result))
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("First prompt")
+          turn1Messages <- session.stream.compile.toList
+          _ <- session.send("Second prompt")
+          turn2Messages <- session.stream.compile.toList
+        yield
+          assertEquals(turn1Messages.length, 2)
+          val turn1Assistants = turn1Messages.collect {
+            case a: AssistantMessage => a
+          }
+          assertEquals(turn1Assistants.length, 1)
+
+          assertEquals(turn2Messages.length, 2)
+          val turn2Assistants = turn2Messages.collect {
+            case a: AssistantMessage => a
+          }
+          assertEquals(turn2Assistants.length, 1)
+
+          val turn1Texts = turn1Assistants.flatMap(_.content.collect {
+            case TextBlock(t) => t
+          })
+          assert(
+            turn1Texts.exists(_.contains("Turn 1")),
+            s"Expected 'Turn 1' text: $turn1Texts"
+          )
+
+          val turn2Texts = turn2Assistants.flatMap(_.content.collect {
+            case TextBlock(t) => t
+          })
+          assert(
+            turn2Texts.exists(_.contains("Turn 2")),
+            s"Expected 'Turn 2' text: $turn2Texts"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T8: Session ID propagates from first turn to second send
+  // ============================================================
+
+  test("session ID propagates from first turn ResultMessage to second send") {
+    val firstTurnSessionId = "session-after-turn-1"
+    val captureFile = Files.createTempFile("stdin-capture-effectful-", ".jsonl")
+    val turn1Result =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$firstTurnSessionId"}"""
+    val turn2Result =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":120,"duration_api_ms":55,"is_error":false,"num_turns":2,"session_id":"session-after-turn-2"}"""
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(List(turn1Result)),
+        SessionMockCliScript.TurnResponse(List(turn2Result))
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    val test = ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("First prompt")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+          _ = assertEquals(id, firstTurnSessionId)
+          _ <- session.send("Second prompt")
+          _ <- session.stream.compile.drain
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+
+    test.flatMap { _ =>
+      IO {
+        val lines = Files.readAllLines(captureFile)
+        assert(
+          lines.size >= 2,
+          s"Expected at least 2 stdin lines, got ${lines.size}"
+        )
+
+        val secondLine = lines.get(1)
+        val secondJson = parser
+          .parse(secondLine)
+          .toOption
+          .getOrElse(fail(s"Second stdin line not valid JSON: $secondLine"))
+        assertEquals(
+          secondJson.hcursor.downField("session_id").as[String].toOption,
+          Some(firstTurnSessionId)
+        )
+        Files.delete(captureFile)
+      }
+    }
+  }
+
+  // ============================================================
+  // T9: Three-turn cycling
+  // ============================================================
+
+  test("three sequential sends each return only their own turn's messages") {
+    val turns = (1 to 3).map { i =>
+      SessionMockCliScript.TurnResponse(
+        List(
+          s"""{"type":"assistant","message":{"content":[{"type":"text","text":"Response $i"}]}}""",
+          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":$i,"session_id":"session-turn-$i"}"""
+        )
+      )
+    }.toList
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = turns
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        def runTurn(i: Int): IO[List[Message]] =
+          session.send(s"Prompt $i") *> session.stream.compile.toList
+
+        for
+          t1 <- runTurn(1)
+          t2 <- runTurn(2)
+          t3 <- runTurn(3)
+        yield List(t1, t2, t3).zipWithIndex.foreach { case (msgs, idx) =>
+          val i = idx + 1
+          assertEquals(
+            msgs.length,
+            2,
+            s"Turn $i: expected 2 messages, got ${msgs.length}"
+          )
+          assert(
+            msgs.head.isInstanceOf[AssistantMessage],
+            s"Turn $i: first should be AssistantMessage"
+          )
+          assert(
+            msgs.last.isInstanceOf[ResultMessage],
+            s"Turn $i: last should be ResultMessage"
+          )
+          val resultMsg = msgs.last.asInstanceOf[ResultMessage]
+          assertEquals(
+            resultMsg.sessionId,
+            s"session-turn-$i",
+            s"Turn $i: wrong session ID"
+          )
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -197,3 +197,46 @@ M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
 ```
 
 ---
+
+### Refactoring R1: Split Session.send into send + stream (CQS) (2026-04-05)
+
+**Trigger:** Comparison with the V2 Claude Agent SDK revealed our `send()` combines a command (write prompt to stdin) and a query (read response stream) in one method, violating command-query separation. The V2 SDK separates these as `send()` (void) and `stream()` (async generator).
+
+**What changed:**
+- `direct/src/.../Session.scala` — trait split: `send(prompt: String): Flow[Message]` → `send(prompt: String): Unit` + `stream(): Flow[Message]`
+- `direct/src/.../internal/cli/SessionProcess.scala` — implementation split: stdin write separated from stdout reading loop
+- `direct/test/src/.../SessionTest.scala` — all call sites updated from `session.send(x).runToList()` to `session.send(x); session.stream().runToList()`
+- `direct/test/src/.../SessionIntegrationTest.scala` — same call site pattern update
+- `direct/test/src/.../SessionE2ETest.scala` — same call site pattern update
+
+**Before → After:**
+- `session.send("prompt").forEach(...)` → `session.send("prompt"); session.stream().forEach(...)`
+- `send` no longer returns a value; `stream` is a separate query method
+- Internal mechanics unchanged: stdin writing, stdout reading, session ID updates, stderr capture all preserved
+
+**Patterns applied:**
+- Command-Query Separation (CQS): `send` is a command (side effect, returns Unit), `stream` is a query (returns data, no side effect beyond reading)
+
+**Testing:**
+- Tests updated: 15 call sites across 3 test files
+- All 193 direct tests passing, no regressions
+- No new tests added (mechanical refactoring — same assertions, different call patterns)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-refactor-05-R1-20260405-144725.md
+- Skills applied: style, testing, scala3, composition
+- Composition reviewer raised design concern about CQS split breaking composability — triaged as deliberate decision aligning with V2 SDK direction
+- Warnings addressed: duplicate Scaladoc removed, dead `caught != null` assertion removed, PURPOSE comment updated
+- Deferred to Phase 6: `stream()` without `send()` guard, `close()` without consuming stream test
+
+**Files changed:**
+```
+M  direct/src/works/iterative/claude/direct/Session.scala
+M  direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+M  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -240,3 +240,57 @@ M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
 ```
 
 ---
+
+## Phase 5: Effectful API - Session lifecycle with Resource (2026-04-05)
+
+**What was built:**
+- `effectful/src/.../effectful/Session.scala` — Session trait with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, `sessionId: IO[String]`
+- `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]` with three background fibers (stdin writer, stdout reader, stderr capture), stdin `Queue` to keep pipe open across turns, `IO.race` for init message extraction
+- `effectful/src/.../effectful/ClaudeCode.scala` — Added `session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method and shared `resolveExecutable` helper
+- `effectful/src/.../effectful/package.scala` — Added `SessionOptions` type and value re-exports
+
+**Decisions made:**
+- Used a `Queue[IO, Option[Chunk[Byte]]]` for stdin: fs2 process stdin pipe closes after first stream completes, so a background fiber drains the queue into stdin keeping it open across multiple `send` calls
+- Used `IO.race` between `messageQueue.take` and `IO.sleep(1.second)` for init message extraction: more reliable than polling or timeout-cancellation
+- Reused `SessionMockCliScript` from `direct.internal.testing` rather than duplicating: cross-module test dependency accepted for now, extraction to shared module deferred
+- No `close()` method on effectful Session: Resource finalizer handles cleanup, matching cats-effect idioms
+
+**Patterns applied:**
+- Resource-based lifecycle: `Resource[IO, Session]` for deterministic cleanup on normal exit and error
+- Queue-based stdin bridge: `Queue.unbounded[IO, Option[Chunk[Byte]]]` with `None` as close signal
+- `Stream.fromQueueNoneTerminated` + `takeThrough` for constant-space message consumption (fixed from recursive `++ stream` during code review)
+- Shared executable discovery: extracted `resolveExecutable` helper used by both `session` and `query` paths
+
+**Testing:**
+- Unit tests: 9 tests in SessionTest.scala (encoding, session ID lifecycle, stream termination, multi-turn isolation, three-turn cycling)
+- Integration tests: 9 tests in SessionIntegrationTest.scala (full lifecycle, Resource cleanup, stdin verification, session ID progression, variable message counts, factory method)
+- E2E tests: 3 tests in SessionE2ETest.scala (single-turn, multi-turn context dependency, session ID validation — gated on CLI availability)
+- Re-export test: 1 test added to EffectfulPackageReexportTest.scala
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-05-20260405-152422.md
+- Skills applied: style, testing, scala3, composition, architecture
+- Critical findings: 2 (recursive stream, duplicated executable discovery) — both fixed
+- Warnings addressed: 3 (FiniteDuration string constructor, PURPOSE comment, pure test in IO)
+- Deferred: cross-module test dependency, unbounded queues, `"pending"` sentinel
+
+**For next phases:**
+- Effectful `Session` API is complete and mirrors the direct API with cats-effect idioms
+- `ClaudeCode.session` factory follows the same pattern as `query`/`querySync`/`queryResult`
+- Error handling (Phase 6) can add process liveness checks, typed errors for process crashes, and malformed JSON handling in the continuous-reading context
+- `SessionMockCliScript` should eventually be extracted to shared test-support module
+
+**Files changed:**
+```
+M  effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+A  effectful/src/works/iterative/claude/effectful/Session.scala
+A  effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+M  effectful/src/works/iterative/claude/effectful/package.scala
+M  effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+```
+
+---

--- a/project-management/issues/CC-15/phase-05-context.md
+++ b/project-management/issues/CC-15/phase-05-context.md
@@ -1,0 +1,196 @@
+# Phase 05: Effectful API - Session lifecycle with Resource
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 8-12 hours
+**Status:** Not started
+
+## Goals
+
+1. Expose an effectful `Session` trait where `send` returns `Stream[IO, Message]` and the session is acquired as `Resource[IO, Session]`
+2. Implement session process management using `fs2.io.process.ProcessBuilder.spawn` with Resource-based cleanup
+3. Add `ClaudeCode.session(SessionOptions): Resource[IO, Session]` factory to the effectful API
+4. Re-export `SessionOptions` in the effectful package object
+5. Validate multi-turn conversation support from the start (lessons from Phase 4)
+6. Provide full test coverage: unit, integration, and E2E
+
+## Scope
+
+### In scope
+
+- `Session` trait in `effectful` package with `send(prompt: String): Stream[IO, Message]` and `sessionId: IO[String]`
+- Internal `SessionProcess` implementation using `fs2.io.process.Process[IO]` from `ProcessBuilder.spawn`
+- `Resource[IO, Session]` lifecycle: process start in acquire, process kill + stdin close in release
+- Stdin writing via `process.stdin` pipe (write SDKUserMessage JSON, flush)
+- Stdout reading via `process.stdout` pipe, parsed line-by-line through the effectful `JsonParser`, terminated at `ResultMessage`
+- Stderr capture as a background fiber (matching the existing effectful `ProcessManager` pattern)
+- Session ID extraction from init `SystemMessage` and update from each `ResultMessage`
+- Multi-turn support: sequential `send` calls reuse the same process, each returning its own `Stream[IO, Message]`
+- `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method
+- `SessionOptions` re-export in `effectful/package.scala`
+
+### Out of scope
+
+- Concurrent `send` calls (per RESOLVED decision: no client-side enforcement, CLI handles queueing)
+- Turn-level timeouts (can be composed by caller via `stream.timeout`)
+- Error handling for process crashes mid-conversation (Phase 06)
+- `--continue` / `--resume` validation for session mode
+- Control messages (`control_request` / `control_response`)
+
+## Dependencies
+
+**Prior phases delivered:**
+
+- **Phase 01:** `SDKUserMessage` with circe `Encoder` in `core/src/.../model/SDKUserMessage.scala` -- ready for stdin writing. `KeepAliveMessage`, `StreamEventMessage` types and parser branches in core `JsonParser`. `ResultMessage` confirmed as end-of-turn delimiter.
+- **Phase 02:** `SessionOptions` in `core/src/.../model/SessionOptions.scala` with fluent builders. `CLIArgumentBuilder.buildSessionArgs` producing `--print --input-format stream-json --output-format stream-json` plus all option flags.
+- **Phase 03:** Direct `Session` trait and `SessionProcess` implementation -- reference for session lifecycle, init message reading, stdin/stdout protocol, stderr capture, close semantics.
+- **Phase 04:** Multi-turn test patterns -- `SessionMockCliScript` with `TurnResponse` cycling, stdin capture verification, context-dependent E2E tests. Key lesson: the infrastructure from Phase 3 handled multi-turn correctly without code changes; thorough testing is what matters.
+
+**Existing effectful patterns to follow:**
+
+- `effectful/src/.../ClaudeCode.scala` -- query methods returning `Stream[IO, Message]`, CLI discovery, argument building, configuration validation
+- `effectful/src/.../internal/cli/ProcessManager.scala` -- `ProcessBuilder.spawn[IO]` as `Resource`, stderr capture via fiber, stdout line parsing through effectful `JsonParser`
+- `effectful/src/.../internal/parsing/JsonParser.scala` -- wraps core `JsonParser` with IO effects and logging
+- `effectful/src/.../package.scala` -- type/value re-exports for single-import usage
+- `effectful/test/.../internal/testing/MockScriptResource.scala` -- classpath-based mock script extraction
+
+## Approach
+
+### 1. Create the effectful Session trait
+
+Define `Session` in `effectful/src/works/iterative/claude/effectful/Session.scala`:
+
+```scala
+trait Session:
+  def send(prompt: String): Stream[IO, Message]
+  def sessionId: IO[String]
+```
+
+Key differences from the direct `Session`:
+- `send` returns `Stream[IO, Message]` instead of `Flow[Message]`
+- `sessionId` returns `IO[String]` instead of `String` (since reading a `Ref` is an effect)
+- No `close()` method -- cleanup is handled by the `Resource` finalizer
+
+### 2. Implement SessionProcess
+
+Create `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala`:
+
+- Use `ProcessBuilder(executablePath, args).spawn[IO]` to get `Resource[IO, Process[IO]]`
+- In the Resource acquire phase:
+  1. Spawn the process
+  2. Start a background fiber for stderr capture (same pattern as existing `ProcessManager.captureStderr`)
+  3. Read init messages from stdout to extract session ID into a `Ref[IO, String]`
+  4. Return the `Session` instance
+- In the Resource release phase:
+  1. Write EOF to stdin (close the stdin pipe)
+  2. Wait briefly for process exit
+  3. Cancel the stderr fiber
+- `send` implementation:
+  1. Encode `SDKUserMessage` to JSON using circe
+  2. Write JSON + newline to `process.stdin` via `Stream.emit(bytes).through(process.stdin).compile.drain`
+  3. Return a `Stream` that reads `process.stdout`, decodes UTF-8, splits lines, parses via effectful `JsonParser`, and completes when a `ResultMessage` is emitted (using `takeThrough` or similar)
+  4. Update the session ID `Ref` when `ResultMessage` is encountered
+
+Key implementation detail: stdout must be read as a continuous stream across turns. The `send` method should not re-create the stdout stream each time. Instead, use a shared `Queue[IO, Option[String]]` or similar mechanism where a single background fiber reads stdout lines into the queue, and each `send` call pulls from the queue until it sees a `ResultMessage`. Alternatively, use `fs2.concurrent.Topic` or simply rely on the process stdout pipe being consumed incrementally across `send` calls.
+
+The simplest approach: keep a `Ref` to the current state of the stdout byte stream. Each `send` call reads lines from it until `ResultMessage`. Since sends are sequential, there is no contention.
+
+### 3. Add factory method to ClaudeCode
+
+Add to `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala`:
+
+```scala
+def session(options: SessionOptions)(using logger: Logger[IO]): Resource[IO, Session] =
+  // validate config, discover executable, build args, delegate to SessionProcess
+```
+
+Follow the same pattern as `query`: validate configuration, discover executable path, build CLI arguments, then delegate to `SessionProcess.start`.
+
+### 4. Update package re-exports
+
+Add `SessionOptions` type and value aliases to `effectful/package.scala`, matching the existing re-export pattern.
+
+### 5. Create mock session script infrastructure for effectful tests
+
+Port or share `SessionMockCliScript` from the direct module. Since the script generation is pure (it creates bash scripts on disk), consider either:
+- Extracting `SessionMockCliScript` to a shared test-support location, or
+- Creating a thin effectful wrapper that creates scripts as `Resource[IO, Path]` for automatic cleanup
+
+### 6. Write tests at all three levels
+
+Follow the test patterns established in Phases 3-4, adapted for cats-effect and fs2.
+
+## Files to Modify/Create
+
+### New files
+
+- `effectful/src/works/iterative/claude/effectful/Session.scala` -- Session trait
+- `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` -- Process-backed implementation
+- `effectful/test/src/works/iterative/claude/effectful/SessionTest.scala` -- Unit tests
+- `effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala` -- Integration tests with mock scripts
+- `effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala` -- E2E tests with real CLI
+- `effectful/test/src/works/iterative/claude/effectful/internal/testing/SessionMockCliScript.scala` -- Mock script utilities (or shared from direct module)
+
+### Files to modify
+
+- `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` -- add `session` factory method
+- `effectful/src/works/iterative/claude/effectful/package.scala` -- add `SessionOptions` re-export
+
+### Reference files (no changes)
+
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` -- session configuration
+- `core/src/works/iterative/claude/core/model/SDKUserMessage.scala` -- stdin message type with Encoder
+- `core/src/works/iterative/claude/core/model/Message.scala` -- message hierarchy including ResultMessage, KeepAliveMessage, StreamEventMessage
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` -- `buildSessionArgs` for CLI flags
+- `core/src/works/iterative/claude/core/parsing/JsonParser.scala` -- core pure parsing logic
+- `effectful/src/works/iterative/claude/effectful/internal/parsing/JsonParser.scala` -- effectful parsing wrapper
+- `effectful/src/works/iterative/claude/effectful/internal/cli/ProcessManager.scala` -- reference for fs2 process patterns
+- `effectful/src/works/iterative/claude/effectful/internal/cli/CLIDiscovery.scala` -- executable path resolution
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` -- reference implementation for session protocol
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` -- reference for mock script generation
+
+## Testing Strategy
+
+### Unit tests (`SessionTest.scala`)
+
+1. **SDKUserMessage encoding for send** -- verify the JSON written to stdin matches the protocol format
+2. **Session ID defaults to "pending"** -- verify initial session ID before any send
+3. **Session ID extracted from init message** -- verify session ID updates from init SystemMessage
+4. **Session ID updates from ResultMessage** -- verify session ID updates after send completes
+5. **send returns messages up to and including ResultMessage** -- verify stream terminates correctly at end-of-turn
+6. **KeepAlive and StreamEvent pass through** -- verify non-terminal message types are emitted
+7. **Two sequential sends return isolated streams** -- verify messages from turn 1 do not bleed into turn 2
+8. **Session ID propagates from first turn to second send** -- verify the second SDKUserMessage uses the updated session ID
+9. **Three-turn cycling** -- verify three sequential sends work correctly
+
+### Integration tests (`SessionIntegrationTest.scala`)
+
+1. **Full session lifecycle with Resource** -- acquire session, send one message, verify response, release (process cleanup)
+2. **Resource cleanup on normal exit** -- verify process is terminated after Resource.use completes
+3. **Resource cleanup on error** -- verify process is terminated when an exception occurs inside Resource.use
+4. **Stdin JSON verification** -- use captureStdinFile to verify SDKUserMessage JSON format
+5. **Session ID from init message** -- verify session ID is set from the mock init message
+6. **Two-turn lifecycle** -- send two prompts with different configured responses, verify correct mapping
+7. **Session ID progression across turns** -- verify stdin capture shows correct session ID in each SDKUserMessage
+8. **Variable message counts per turn** -- turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
+9. **ClaudeCode.session factory** -- verify the factory method produces a working session Resource
+
+### E2E tests (`SessionE2ETest.scala`)
+
+1. **Single-turn session with real CLI** -- gated on CLI availability; open session, send one prompt, verify AssistantMessage and ResultMessage in response stream, verify Resource cleanup
+2. **Multi-turn with context dependency** -- send "Remember the number 42" then "What number did I ask you to remember?", verify the second response references 42
+3. **Session ID is valid after real CLI interaction** -- verify session ID is non-empty and not "pending" after a send
+
+## Acceptance Criteria
+
+1. `Session` trait exists in `effectful` package with `send(prompt: String): Stream[IO, Message]` and `sessionId: IO[String]`
+2. `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method works
+3. Resource acquire starts the CLI process; Resource release terminates it
+4. Process cleanup happens on both normal exit and error (Resource finalizer)
+5. `send` returns a `Stream[IO, Message]` that completes after the turn's `ResultMessage`
+6. Multiple sequential `send` calls within one session each return their own complete stream
+7. Session ID is extracted from init message and updated from each ResultMessage
+8. Messages from one turn do not appear in another turn's stream
+9. `SessionOptions` is re-exported in the effectful package object
+10. All unit, integration, and E2E tests pass with no compilation warnings
+11. All existing effectful query tests continue to pass (no regressions)
+12. All existing direct session tests continue to pass (no regressions)

--- a/project-management/issues/CC-15/phase-05-context.md
+++ b/project-management/issues/CC-15/phase-05-context.md
@@ -6,7 +6,7 @@
 
 ## Goals
 
-1. Expose an effectful `Session` trait where `send` returns `Stream[IO, Message]` and the session is acquired as `Resource[IO, Session]`
+1. Expose an effectful `Session` trait with `send(prompt): IO[Unit]` (command) and `stream: Stream[IO, Message]` (query), acquired as `Resource[IO, Session]`
 2. Implement session process management using `fs2.io.process.ProcessBuilder.spawn` with Resource-based cleanup
 3. Add `ClaudeCode.session(SessionOptions): Resource[IO, Session]` factory to the effectful API
 4. Re-export `SessionOptions` in the effectful package object
@@ -17,7 +17,7 @@
 
 ### In scope
 
-- `Session` trait in `effectful` package with `send(prompt: String): Stream[IO, Message]` and `sessionId: IO[String]`
+- `Session` trait in `effectful` package with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
 - Internal `SessionProcess` implementation using `fs2.io.process.Process[IO]` from `ProcessBuilder.spawn`
 - `Resource[IO, Session]` lifecycle: process start in acquire, process kill + stdin close in release
 - Stdin writing via `process.stdin` pipe (write SDKUserMessage JSON, flush)
@@ -61,14 +61,18 @@ Define `Session` in `effectful/src/works/iterative/claude/effectful/Session.scal
 
 ```scala
 trait Session:
-  def send(prompt: String): Stream[IO, Message]
+  def send(prompt: String): IO[Unit]
+  def stream: Stream[IO, Message]
   def sessionId: IO[String]
 ```
 
 Key differences from the direct `Session`:
-- `send` returns `Stream[IO, Message]` instead of `Flow[Message]`
+- `send` returns `IO[Unit]` instead of `Unit` (effectful command)
+- `stream` returns `Stream[IO, Message]` instead of `Flow[Message]`
 - `sessionId` returns `IO[String]` instead of `String` (since reading a `Ref` is an effect)
 - No `close()` method -- cleanup is handled by the `Resource` finalizer
+
+Note: The direct `Session` trait is being refactored as part of R1 (see Refactoring Decisions) to match this same send/stream separation pattern.
 
 ### 2. Implement SessionProcess
 
@@ -182,7 +186,7 @@ Follow the test patterns established in Phases 3-4, adapted for cats-effect and 
 
 ## Acceptance Criteria
 
-1. `Session` trait exists in `effectful` package with `send(prompt: String): Stream[IO, Message]` and `sessionId: IO[String]`
+1. `Session` trait exists in `effectful` package with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
 2. `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method works
 3. Resource acquire starts the CLI process; Resource release terminates it
 4. Process cleanup happens on both normal exit and error (Resource finalizer)
@@ -194,3 +198,19 @@ Follow the test patterns established in Phases 3-4, adapted for cats-effect and 
 10. All unit, integration, and E2E tests pass with no compilation warnings
 11. All existing effectful query tests continue to pass (no regressions)
 12. All existing direct session tests continue to pass (no regressions)
+
+## Refactoring Decisions
+
+### R1: Split Session.send into send + stream (CQS) (2026-04-05)
+
+**Trigger:** Comparison with the V2 Claude Agent SDK revealed our `send()` combines a command (write prompt to stdin) and a query (read response stream) in one method, violating command-query separation. The V2 SDK separates these as `send()` → `Promise<void>` and `stream()` → `AsyncGenerator<SDKMessage>`.
+**Decision:** Split `Session.send(prompt): Flow[Message]` into two methods:
+- `send(prompt: String): Unit` — command: writes SDKUserMessage JSON to stdin
+- `stream(): Flow[Message]` — query: reads stdout until ResultMessage
+
+This applies to both the direct Session (refactoring existing code) and the effectful Session (new code, designed this way from the start).
+**Scope:**
+- Files affected: `Session.scala` (trait), `SessionProcess.scala` (impl), `SessionTest.scala`, `SessionIntegrationTest.scala`, `SessionE2ETest.scala`
+- Components: direct Session trait, SessionProcess implementation, all session tests
+- Boundaries: do NOT touch core model types, CLIArgumentBuilder, effectful module, ClaudeCode factory methods
+**Approach:** Mechanical split — extract stdin-write from `send` into a void method, create `stream()` from the stdout-reading portion, update all test call sites from `session.send(x).forEach(...)` to `session.send(x); session.stream().forEach(...)`

--- a/project-management/issues/CC-15/phase-05-tasks.md
+++ b/project-management/issues/CC-15/phase-05-tasks.md
@@ -6,51 +6,51 @@
 
 ## Setup
 
-- [ ] [impl] Create effectful `Session` trait in `effectful/src/.../effectful/Session.scala` with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
-- [ ] [impl] Add `SessionOptions` re-export to `effectful/src/.../effectful/package.scala` (type alias + value alias, matching existing re-export pattern)
+- [x] [impl] Create effectful `Session` trait in `effectful/src/.../effectful/Session.scala` with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
+- [x] [impl] Add `SessionOptions` re-export to `effectful/src/.../effectful/package.scala` (type alias + value alias, matching existing re-export pattern)
 
 ## Tests
 
 ### Unit tests (SessionTest.scala)
 
-- [ ] [test] SDKUserMessage encoding for send — verify the JSON written to a mock stdin pipe matches the protocol format (`type`, `message.role`, `message.content`, `session_id`)
-- [ ] [test] Session ID defaults to "pending" — verify `sessionId` returns IO("pending") before any send
-- [ ] [test] Session ID extracted from init SystemMessage — verify sessionId updates from init message during Resource acquire
-- [ ] [test] Session ID updates from ResultMessage — verify sessionId reflects the session_id from each ResultMessage after stream completes
-- [ ] [test] stream returns messages up to and including ResultMessage — verify the stream terminates correctly at end-of-turn
-- [ ] [test] KeepAlive and StreamEvent pass through — verify non-terminal message types are emitted in the stream
-- [ ] [test] Two sequential sends return isolated streams — configure mock with two turns, verify each stream returns only its own turn's messages
-- [ ] [test] Session ID propagates from first turn to second send — verify the second SDKUserMessage uses the updated session ID from the first turn's ResultMessage
-- [ ] [test] Three-turn cycling — verify three sequential send/stream cycles work correctly
+- [x] [test] SDKUserMessage encoding for send — verify the JSON written to a mock stdin pipe matches the protocol format (`type`, `message.role`, `message.content`, `session_id`)
+- [x] [test] Session ID defaults to "pending" — verify `sessionId` returns IO("pending") before any send
+- [x] [test] Session ID extracted from init SystemMessage — verify sessionId updates from init message during Resource acquire
+- [x] [test] Session ID updates from ResultMessage — verify sessionId reflects the session_id from each ResultMessage after stream completes
+- [x] [test] stream returns messages up to and including ResultMessage — verify the stream terminates correctly at end-of-turn
+- [x] [test] KeepAlive and StreamEvent pass through — verify non-terminal message types are emitted in the stream
+- [x] [test] Two sequential sends return isolated streams — configure mock with two turns, verify each stream returns only its own turn's messages
+- [x] [test] Session ID propagates from first turn to second send — verify the second SDKUserMessage uses the updated session ID from the first turn's ResultMessage
+- [x] [test] Three-turn cycling — verify three sequential send/stream cycles work correctly
 
 ### Integration tests (SessionIntegrationTest.scala)
 
-- [ ] [test] Full session lifecycle with Resource — acquire session, send one message, consume stream, verify response, release (process cleanup)
-- [ ] [test] Resource cleanup on normal exit — verify process is terminated after Resource.use completes
-- [ ] [test] Resource cleanup on error — verify process is terminated when an exception occurs inside Resource.use
-- [ ] [test] Stdin JSON verification — use captureStdinFile in mock script to verify SDKUserMessage JSON format
-- [ ] [test] Session ID from init message — verify session ID is set from the mock init message during acquire
-- [ ] [test] Two-turn lifecycle — send two prompts with different configured responses, verify correct mapping
-- [ ] [test] Session ID progression across turns — verify stdin capture shows correct session ID in each SDKUserMessage
-- [ ] [test] Variable message counts per turn — turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
-- [ ] [test] ClaudeCode.session factory — verify the factory method produces a working session Resource
+- [x] [test] Full session lifecycle with Resource — acquire session, send one message, consume stream, verify response, release (process cleanup)
+- [x] [test] Resource cleanup on normal exit — verify process is terminated after Resource.use completes
+- [x] [test] Resource cleanup on error — verify process is terminated when an exception occurs inside Resource.use
+- [x] [test] Stdin JSON verification — use captureStdinFile in mock script to verify SDKUserMessage JSON format
+- [x] [test] Session ID from init message — verify session ID is set from the mock init message during acquire
+- [x] [test] Two-turn lifecycle — send two prompts with different configured responses, verify correct mapping
+- [x] [test] Session ID progression across turns — verify stdin capture shows correct session ID in each SDKUserMessage
+- [x] [test] Variable message counts per turn — turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
+- [x] [test] ClaudeCode.session factory — verify the factory method produces a working session Resource
 
 ### E2E tests (SessionE2ETest.scala)
 
-- [ ] [test] Single-turn session with real CLI — gated on CLI availability; open session Resource, send one prompt, verify AssistantMessage and ResultMessage in stream, verify Resource cleanup
-- [ ] [test] Multi-turn with context dependency — send "Remember the number 42" then "What number did I ask you to remember?", verify second response references 42
-- [ ] [test] Session ID is valid after real CLI interaction — verify session ID is non-empty and not "pending" after a send
+- [x] [test] Single-turn session with real CLI — gated on CLI availability; open session Resource, send one prompt, verify AssistantMessage and ResultMessage in stream, verify Resource cleanup
+- [x] [test] Multi-turn with context dependency — send "Remember the number 42" then "What number did I ask you to remember?", verify second response references 42
+- [x] [test] Session ID is valid after real CLI interaction — verify session ID is non-empty and not "pending" after a send
 
 ## Implementation
 
-- [ ] [impl] Create `SessionProcess` in `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]`, background stderr fiber, shared stdout stream, stdin writing via process.stdin pipe
-- [ ] [impl] Add `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method to `effectful/src/.../effectful/ClaudeCode.scala`
-- [ ] [impl] Create mock script infrastructure for effectful tests — `SessionMockCliScript.scala` in effectful test internal/testing (Resource[IO, Path] wrapper or shared from direct module)
+- [x] [impl] Create `SessionProcess` in `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]`, background stderr fiber, shared stdout stream, stdin writing via process.stdin pipe
+- [x] [impl] Add `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method to `effectful/src/.../effectful/ClaudeCode.scala`
+- [x] [impl] Create mock script infrastructure for effectful tests — `SessionMockCliScript.scala` in effectful test internal/testing (Resource[IO, Path] wrapper or shared from direct module)
 
 ## Integration
 
-- [ ] [integration] Verify all new effectful session tests pass (`./mill effectful.test`)
-- [ ] [integration] Verify no regressions in existing effectful query tests
-- [ ] [integration] Verify no regressions in direct module tests (`./mill direct.test`)
-- [ ] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
-**Phase Status:** Not started
+- [x] [integration] Verify all new effectful session tests pass (`./mill effectful.test`)
+- [x] [integration] Verify no regressions in existing effectful query tests
+- [x] [integration] Verify no regressions in direct module tests (`./mill direct.test`)
+- [x] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-05-tasks.md
+++ b/project-management/issues/CC-15/phase-05-tasks.md
@@ -1,0 +1,56 @@
+# Phase 05 Tasks: Effectful API - Session lifecycle with Resource
+
+## Refactoring
+
+- [ ] [impl] Refactoring R1: Split direct Session.send into send + stream (CQS) — see `refactor-phase-05-R1.md`
+
+## Setup
+
+- [ ] [impl] Create effectful `Session` trait in `effectful/src/.../effectful/Session.scala` with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
+- [ ] [impl] Add `SessionOptions` re-export to `effectful/src/.../effectful/package.scala` (type alias + value alias, matching existing re-export pattern)
+
+## Tests
+
+### Unit tests (SessionTest.scala)
+
+- [ ] [test] SDKUserMessage encoding for send — verify the JSON written to a mock stdin pipe matches the protocol format (`type`, `message.role`, `message.content`, `session_id`)
+- [ ] [test] Session ID defaults to "pending" — verify `sessionId` returns IO("pending") before any send
+- [ ] [test] Session ID extracted from init SystemMessage — verify sessionId updates from init message during Resource acquire
+- [ ] [test] Session ID updates from ResultMessage — verify sessionId reflects the session_id from each ResultMessage after stream completes
+- [ ] [test] stream returns messages up to and including ResultMessage — verify the stream terminates correctly at end-of-turn
+- [ ] [test] KeepAlive and StreamEvent pass through — verify non-terminal message types are emitted in the stream
+- [ ] [test] Two sequential sends return isolated streams — configure mock with two turns, verify each stream returns only its own turn's messages
+- [ ] [test] Session ID propagates from first turn to second send — verify the second SDKUserMessage uses the updated session ID from the first turn's ResultMessage
+- [ ] [test] Three-turn cycling — verify three sequential send/stream cycles work correctly
+
+### Integration tests (SessionIntegrationTest.scala)
+
+- [ ] [test] Full session lifecycle with Resource — acquire session, send one message, consume stream, verify response, release (process cleanup)
+- [ ] [test] Resource cleanup on normal exit — verify process is terminated after Resource.use completes
+- [ ] [test] Resource cleanup on error — verify process is terminated when an exception occurs inside Resource.use
+- [ ] [test] Stdin JSON verification — use captureStdinFile in mock script to verify SDKUserMessage JSON format
+- [ ] [test] Session ID from init message — verify session ID is set from the mock init message during acquire
+- [ ] [test] Two-turn lifecycle — send two prompts with different configured responses, verify correct mapping
+- [ ] [test] Session ID progression across turns — verify stdin capture shows correct session ID in each SDKUserMessage
+- [ ] [test] Variable message counts per turn — turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
+- [ ] [test] ClaudeCode.session factory — verify the factory method produces a working session Resource
+
+### E2E tests (SessionE2ETest.scala)
+
+- [ ] [test] Single-turn session with real CLI — gated on CLI availability; open session Resource, send one prompt, verify AssistantMessage and ResultMessage in stream, verify Resource cleanup
+- [ ] [test] Multi-turn with context dependency — send "Remember the number 42" then "What number did I ask you to remember?", verify second response references 42
+- [ ] [test] Session ID is valid after real CLI interaction — verify session ID is non-empty and not "pending" after a send
+
+## Implementation
+
+- [ ] [impl] Create `SessionProcess` in `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]`, background stderr fiber, shared stdout stream, stdin writing via process.stdin pipe
+- [ ] [impl] Add `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method to `effectful/src/.../effectful/ClaudeCode.scala`
+- [ ] [impl] Create mock script infrastructure for effectful tests — `SessionMockCliScript.scala` in effectful test internal/testing (Resource[IO, Path] wrapper or shared from direct module)
+
+## Integration
+
+- [ ] [integration] Verify all new effectful session tests pass (`./mill effectful.test`)
+- [ ] [integration] Verify no regressions in existing effectful query tests
+- [ ] [integration] Verify no regressions in direct module tests (`./mill direct.test`)
+- [ ] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
+**Phase Status:** Not started

--- a/project-management/issues/CC-15/phase-05-tasks.md
+++ b/project-management/issues/CC-15/phase-05-tasks.md
@@ -2,7 +2,7 @@
 
 ## Refactoring
 
-- [ ] [impl] Refactoring R1: Split direct Session.send into send + stream (CQS) — see `refactor-phase-05-R1.md`
+- [x] [impl] Refactoring R1: Split direct Session.send into send + stream (CQS) — see `refactor-phase-05-R1.md`
 
 ## Setup
 

--- a/project-management/issues/CC-15/refactor-phase-05-R1.md
+++ b/project-management/issues/CC-15/refactor-phase-05-R1.md
@@ -2,7 +2,7 @@
 
 **Phase:** 5
 **Created:** 2026-04-05
-**Status:** Planned
+**Status:** Complete
 
 ## Decision Summary
 
@@ -49,19 +49,19 @@ Test usage becomes `session.send("..."); session.stream().forEach(...)`.
 
 ## Tasks
 
-- [ ] [impl] [Analysis] Review all usages of `Session.send` in tests to confirm scope
-- [ ] [impl] [Refactor] Split `Session` trait: `send(prompt: String): Unit` + `stream(): Flow[Message]`
-- [ ] [impl] [Refactor] Split `SessionProcess.send` into `send` (stdin write) and `stream` (stdout read + emit)
-- [ ] [impl] [Test] Update `SessionTest.scala` call sites: `send` then `stream`
-- [ ] [impl] [Test] Update `SessionIntegrationTest.scala` call sites
-- [ ] [impl] [Test] Update `SessionE2ETest.scala` call sites
-- [ ] [impl] [Verify] Run all tests (`./mill __.test`), ensure nothing broke
-- [ ] [impl] [Cleanup] Remove any dead code from the split
+- [x] [impl] [Analysis] Review all usages of `Session.send` in tests to confirm scope
+- [x] [impl] [Refactor] Split `Session` trait: `send(prompt: String): Unit` + `stream(): Flow[Message]`
+- [x] [impl] [Refactor] Split `SessionProcess.send` into `send` (stdin write) and `stream` (stdout read + emit)
+- [x] [impl] [Test] Update `SessionTest.scala` call sites: `send` then `stream`
+- [x] [impl] [Test] Update `SessionIntegrationTest.scala` call sites
+- [x] [impl] [Test] Update `SessionE2ETest.scala` call sites
+- [x] [impl] [Verify] Run all tests (`./mill __.test`), ensure nothing broke
+- [x] [impl] [Cleanup] Remove any dead code from the split
 
 ## Verification
 
-- [ ] All existing tests pass
-- [ ] `Session` trait has separate `send` and `stream` methods
-- [ ] `send` returns `Unit`, `stream` returns `Flow[Message]`
-- [ ] No regressions in functionality
+- [x] All existing tests pass
+- [x] `Session` trait has separate `send` and `stream` methods
+- [x] `send` returns `Unit`, `stream` returns `Flow[Message]`
+- [x] No regressions in functionality
 - [ ] Direct API ClaudeCode.session factory still works

--- a/project-management/issues/CC-15/refactor-phase-05-R1.md
+++ b/project-management/issues/CC-15/refactor-phase-05-R1.md
@@ -1,0 +1,67 @@
+# Refactoring R1: Split Session.send into send + stream (CQS)
+
+**Phase:** 5
+**Created:** 2026-04-05
+**Status:** Planned
+
+## Decision Summary
+
+Our `Session.send(prompt)` combines a command (write prompt to stdin) and a query (return response stream) in one method, violating command-query separation. The V2 Claude Agent SDK separates these as `send()` (void) and `stream()` (async generator). Splitting them makes the API cleaner, aligns with the official SDK direction, and makes the turn lifecycle explicit.
+
+## Current State
+
+Direct `Session` trait (`direct/src/works/iterative/claude/direct/Session.scala`):
+
+```scala
+trait Session:
+  def send(prompt: String): Flow[Message]  // combined command+query
+  def close(): Unit
+  def sessionId: String
+```
+
+`SessionProcess.send()` eagerly writes to stdin, then returns a `Flow` that reads stdout until `ResultMessage`.
+
+All tests use `session.send("...").forEach(...)` or `session.send("...").toList()`.
+
+## Target State
+
+Direct `Session` trait:
+
+```scala
+trait Session:
+  def send(prompt: String): Unit      // command: write SDKUserMessage to stdin
+  def stream(): Flow[Message]         // query: read stdout until ResultMessage
+  def close(): Unit
+  def sessionId: String
+```
+
+Test usage becomes `session.send("..."); session.stream().forEach(...)`.
+
+## Constraints
+
+- PRESERVE: All existing test assertions and coverage — only call sites change, not what's being tested
+- PRESERVE: `SessionProcess` internal mechanics (stdin writing, stdout reading, session ID update, stderr capture)
+- PRESERVE: `ClaudeCode.session()` factory methods — no signature changes
+- DO NOT TOUCH: Core model types (Message, SDKUserMessage, SessionOptions)
+- DO NOT TOUCH: CLIArgumentBuilder
+- DO NOT TOUCH: Effectful module (it will be built with the new pattern from scratch)
+- DO NOT TOUCH: `SessionMockCliScript` or `MockLogger`
+
+## Tasks
+
+- [ ] [impl] [Analysis] Review all usages of `Session.send` in tests to confirm scope
+- [ ] [impl] [Refactor] Split `Session` trait: `send(prompt: String): Unit` + `stream(): Flow[Message]`
+- [ ] [impl] [Refactor] Split `SessionProcess.send` into `send` (stdin write) and `stream` (stdout read + emit)
+- [ ] [impl] [Test] Update `SessionTest.scala` call sites: `send` then `stream`
+- [ ] [impl] [Test] Update `SessionIntegrationTest.scala` call sites
+- [ ] [impl] [Test] Update `SessionE2ETest.scala` call sites
+- [ ] [impl] [Verify] Run all tests (`./mill __.test`), ensure nothing broke
+- [ ] [impl] [Cleanup] Remove any dead code from the split
+
+## Verification
+
+- [ ] All existing tests pass
+- [ ] `Session` trait has separate `send` and `stream` methods
+- [ ] `send` returns `Unit`, `stream` returns `Flow[Message]`
+- [ ] No regressions in functionality
+- [ ] Direct API ClaudeCode.session factory still works

--- a/project-management/issues/CC-15/review-packet-phase-05.md
+++ b/project-management/issues/CC-15/review-packet-phase-05.md
@@ -1,0 +1,209 @@
+---
+generated_from: 6a4f4725166cf9b629b144aad531c87e38815cb9
+generated_at: 2026-04-05T13:24:39Z
+branch: CC-15-phase-05
+issue_id: CC-15
+phase: 5
+files_analyzed:
+  - effectful/src/works/iterative/claude/effectful/Session.scala
+  - effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+  - effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+  - effectful/src/works/iterative/claude/effectful/package.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+  - effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+---
+
+# Review Packet: Phase 5 - Effectful API - Session lifecycle with Resource
+
+## Goals
+
+This phase delivers the cats-effect session API, enabling persistent multi-turn conversations with a single long-lived Claude Code CLI process through a `Resource[IO, Session]` lifecycle.
+
+Key objectives:
+
+- Expose a `Session` trait in the `effectful` package with CQS-split methods: `send(prompt): IO[Unit]` (writes stdin) and `stream: Stream[IO, Message]` (reads stdout until `ResultMessage`)
+- Implement `SessionProcess`, a `Resource`-based process manager that spawns the CLI once and keeps it alive across turns, using background fibers for stdin writing, stdout reading, and stderr capture
+- Add `ClaudeCode.session(SessionOptions): Resource[IO, Session]` factory to the effectful API entry point
+- Re-export `SessionOptions` in the effectful package object for single-import usage
+- Apply the CQS refactoring (R1) to the direct `Session` trait and tests to match this phase's design
+
+This phase is the effectful counterpart to the direct API session work delivered in Phases 3-4, adapted for cats-effect idioms with `Resource`, `fs2.Stream`, `IO`, `Ref`, `Queue`, and background fibers.
+
+## Scenarios
+
+- [ ] A session can be opened, a prompt sent, and a streaming response received within `Resource.use`
+- [ ] The CLI process starts once on Resource acquire and stays alive across multiple `send` / `stream` cycles
+- [ ] The process is terminated cleanly when the `Resource.use` block exits normally
+- [ ] The process is terminated cleanly when an exception is thrown inside `Resource.use`
+- [ ] `sessionId` returns `"pending"` before the CLI emits an init message
+- [ ] `sessionId` is updated from the init `SystemMessage` during Resource acquire
+- [ ] `sessionId` is updated from each turn's `ResultMessage` after `stream` completes
+- [ ] Each turn's `stream` emits exactly its own messages and terminates after `ResultMessage`
+- [ ] Messages from one turn do not bleed into the next turn's stream
+- [ ] Multiple sequential `send` / `stream` pairs work correctly within one session
+- [ ] The second `send` carries the session ID from the first turn's `ResultMessage` in its `SDKUserMessage` JSON
+- [ ] `KeepAliveMessage` and `StreamEventMessage` pass through the stream
+- [ ] `SessionOptions` is accessible via a single `effectful.*` import
+- [ ] All existing effectful query tests and direct session tests continue to pass
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `effectful/src/works/iterative/claude/effectful/Session.scala` | `Session` trait | Public API contract: defines `send`, `stream`, `sessionId` |
+| `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` | `ClaudeCode.session()` | Factory method: the user-facing entry point that returns `Resource[IO, Session]` |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `SessionProcess.start()` | Core implementation: process spawn, fiber management, queue wiring |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `SessionImpl` | Session implementation: `send` writes to stdinQueue, `stream` reads from messageQueue |
+| `effectful/src/works/iterative/claude/effectful/package.scala` | package object | Re-export: confirms `SessionOptions` is accessible from a single import |
+
+## Diagrams
+
+### Component Architecture
+
+```
+effectful package
+┌─────────────────────────────────────────────────────────┐
+│  ClaudeCode.session(SessionOptions)                      │
+│      │                                                   │
+│      └─► SessionProcess.start(executablePath, options)   │
+│              │                                           │
+│              └─► Resource[IO, Session]                   │
+│                      acquire: spawn process + fibers     │
+│                      release: cancel fibers + close stdin│
+└─────────────────────────────────────────────────────────┘
+
+SessionProcess internals
+┌──────────────────────────────────────────────────────────────────┐
+│  ProcessBuilder.spawn[IO]  ──► fs2.io.process.Process[IO]        │
+│                                                                   │
+│  Queue[IO, Option[Chunk[Byte]]]  stdinQueue                      │
+│      ▲                  │                                        │
+│  SessionImpl.send()     └──► fiber: stdinQueue → process.stdin  │
+│                                                                   │
+│  Queue[IO, Option[Message]]  messageQueue                        │
+│      │                  ▲                                        │
+│  SessionImpl.stream()   └──── fiber: process.stdout → parser     │
+│                                         → sessionIdRef update    │
+│                                         → messageQueue           │
+│                                                                   │
+│  Ref[IO, String]  sessionIdRef  ◄── init message + ResultMessage │
+│                                                                   │
+│  fiber: process.stderr → logger.debug                            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Session Lifecycle Flow
+
+```
+Resource.use { session =>
+    session.send("prompt")          // IO[Unit]
+    │  └─ encode SDKUserMessage JSON
+    │  └─ stdinQueue.offer(Some(chunk))
+    │
+    session.stream.compile.toList   // Stream[IO, Message]
+       └─ messageQueue.take (loop until ResultMessage)
+       └─ emits all messages including ResultMessage
+       └─ sessionIdRef updated by background stdout reader on ResultMessage
+}
+│
+│  acquire:
+│    spawn process
+│    start stdinWriter fiber (drains stdinQueue → process.stdin)
+│    start stdoutReader fiber (process.stdout → messageQueue, updates sessionIdRef)
+│    start stderrCapture fiber (process.stderr → logger.debug)
+│    readInitMessage (peek messageQueue, extract session_id if SystemMessage("init"))
+│
+│  release:
+│    cancel all fibers
+│    stdinQueue.offer(None) → closes process.stdin → process exits
+```
+
+### Turn Sequence (Multi-turn)
+
+```
+Turn 1:
+  send("Q1")   →  stdinQueue ← SDKUserMessage(session_id="pending")
+  stream        →  [AssistantMessage, ResultMessage(session_id="s1")]
+                   sessionIdRef updated to "s1"
+
+Turn 2:
+  send("Q2")   →  stdinQueue ← SDKUserMessage(session_id="s1")
+  stream        →  [KeepAliveMessage, AssistantMessage, ResultMessage(session_id="s2")]
+                   sessionIdRef updated to "s2"
+```
+
+## Test Summary
+
+### Unit Tests (`SessionTest.scala`) — 9 tests
+
+| # | Test | Type | Notes |
+|---|------|------|-------|
+| T1 | SDKUserMessage is correctly encoded for stdin | Unit | Verifies JSON fields: `type`, `message.role`, `message.content`, `session_id` |
+| T2 | Session ID defaults to `"pending"` before any send | Unit | Uses minimal mock script with no init message |
+| T3 | Session ID extracted from init SystemMessage during Resource acquire | Unit | Mock emits `SystemMessage("init", {"session_id": "..."})` before any send |
+| T4 | Session ID updated from ResultMessage after stream completes | Unit | Checks `sessionId` after `stream.compile.drain` |
+| T5 | `stream` completes after emitting ResultMessage | Unit | Verifies exactly 1 AssistantMessage + 1 ResultMessage, then stream ends |
+| T6 | KeepAlive and StreamEvent messages pass through | Unit | All four message types present in stream |
+| T7 | Two sequential sends return isolated streams | Unit | Turn 1 messages not in turn 2, and vice versa |
+| T8 | Session ID propagates from first turn to second send | Unit | Reads stdin capture file; second JSON line has `session_id` from turn 1 ResultMessage |
+| T9 | Three sequential send/stream cycles work correctly | Unit | Each turn has correct messages and session ID |
+
+All unit tests use `SessionMockCliScript` from the direct module (reused across modules).
+
+### Integration Tests (`SessionIntegrationTest.scala`) — 9 tests
+
+| # | Test | Notes |
+|---|------|-------|
+| IT1 | Full single-turn lifecycle with mock CLI | Verifies AssistantMessage content and ResultMessage fields |
+| IT2 | Resource cleanup on normal exit | Verifies `Resource.use` completes without hanging |
+| IT3 | Resource cleanup on error | `IO.raiseError` inside `use`; checks exception propagates and process is cleaned up |
+| IT4 | Stdin carries correct SDKUserMessage JSON | Reads captured stdin file; checks `type` and `message.content` |
+| IT5 | Session ID from init message during acquire | Checks `sessionId` before any `send` |
+| IT6 | Two-turn lifecycle | Verifies init ID, turn 1 response + ID, turn 2 response + ID |
+| IT7 | Stdin shows correct session ID progression | First send uses init ID; second send uses turn 1 ResultMessage ID |
+| IT8 | Variable message counts per turn | Turn 1: 2 messages; turn 2: 4 messages (keepalive, stream_event, assistant, result) |
+| IT9 | `ClaudeCode.session` factory produces working session | End-to-end factory method test with mock script |
+
+### E2E Tests (`SessionE2ETest.scala`) — 3 tests
+
+| # | Test | Gate |
+|---|------|------|
+| E1 | Single-turn session with real CLI | `assume` on `claude --version` exit code = 0 and API key / credentials file |
+| E2 | Two-turn context dependency (`"Remember 42"` → `"What number?"`) | Same gate |
+| E3 | Session ID is non-empty and not `"pending"` after first turn | Same gate |
+
+E2E tests skip gracefully when the CLI is not installed or credentials are absent.
+
+### Regression Test
+
+| File | Purpose |
+|------|---------|
+| `EffectfulPackageReexportTest.scala` | Confirms `SessionOptions` is accessible as `effectful.SessionOptions` (new assertion added alongside existing re-export tests) |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `effectful/src/works/iterative/claude/effectful/Session.scala` | **New** — `Session` trait with `send`, `stream`, `sessionId` |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | **New** — `SessionProcess.start` (Resource factory) and `SessionImpl` (queue-based implementation) |
+| `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` | **Modified** — added `session(SessionOptions)` factory and `discoverExecutableForSession` helper |
+| `effectful/src/works/iterative/claude/effectful/package.scala` | **Modified** — added `SessionOptions` type and value re-exports |
+| `effectful/test/src/works/iterative/claude/effectful/SessionTest.scala` | **New** — 9 unit tests |
+| `effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala` | **New** — 9 integration tests |
+| `effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala` | **New** — 3 E2E tests |
+| `effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala` | **Modified** — added `SessionOptions` re-export assertion |
+
+<details>
+<summary>Key design notes for reviewers</summary>
+
+**Shared stdout reader approach:** The stdout fiber continuously reads lines from the process into `messageQueue`. Each `stream` call pulls from that same queue until it sees a `ResultMessage`. This works without contention because `send` / `stream` calls are sequential — the design does not enforce this but documents that concurrent sends are delegated to the CLI's own queueing (per the resolved architectural decision).
+
+**Init message peeling:** `readInitMessage` races a `messageQueue.take` against a 1-second timeout. If the first message is a `SystemMessage("init", ...)`, the session ID is extracted and the message is consumed (not re-enqueued). If it is any other message type, it is put back into the queue so it appears in the user's first `stream`. If the timeout fires first, `sessionId` stays `"pending"`.
+
+**Stdin queue closure:** On Resource release, the fibers are cancelled and `None` is offered to `stdinQueue`. The stdin writer fiber, which uses `Stream.fromQueueNoneTerminated`, sees the `None` sentinel, terminates, and the process stdin pipe closes — causing the CLI process to exit cleanly.
+
+**Mock script reuse:** `SessionMockCliScript` lives in the `direct` test module and is reused directly by the effectful tests. This avoids duplicating test infrastructure. If the modules are published separately, this dependency will need to be revisited.
+
+</details>

--- a/project-management/issues/CC-15/review-phase-05-20260405-152422.md
+++ b/project-management/issues/CC-15/review-phase-05-20260405-152422.md
@@ -1,0 +1,57 @@
+# Code Review Results
+
+**Review Context:** Phase 5: Effectful API - Session lifecycle with Resource for issue CC-15 (Iteration 1/3)
+**Files Reviewed:** 8
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition, code-review-architecture
+**Timestamp:** 2026-04-05T15:24:22
+**Git Context:** git diff 16f38ed126cdd86d438472db9a336e85fbf230a5
+
+---
+
+## Critical Issues (2 — both fixed)
+
+### 1. Recursive stream accumulates stack (composition)
+**Location:** SessionProcess.scala — `SessionImpl.stream`
+**Problem:** `Stream.emit(msg) ++ stream` builds unbounded chain of continuations.
+**Fix:** Replaced with `Stream.fromQueueNoneTerminated(messageQueue).takeThrough(!_.isInstanceOf[ResultMessage])`.
+
+### 2. Duplicated executable discovery (composition, architecture)
+**Location:** ClaudeCode.scala — `discoverExecutableForSession` and `discoverExecutablePath`
+**Problem:** Identical CLI discovery logic in two methods with different wrapper types.
+**Fix:** Extracted shared `resolveExecutable(path: Option[String]): IO[String]` helper.
+
+---
+
+## Warnings Addressed (3)
+
+- **FiniteDuration string constructor:** `FiniteDuration(1000, "ms")` → `1.second`
+- **PURPOSE comment:** Removed implementation details, now describes responsibility
+- **T1 pure test in IO:** Removed unnecessary `IO { ... }` wrapper for pure assertions
+
+---
+
+## Warnings Deferred
+
+- **Cross-module test dependency** (`direct.internal.testing.SessionMockCliScript`): Would require build restructuring; acceptable for now, consider extracting to shared test-support module later
+- **Unbounded queues:** Back-pressure not needed for sequential CLI protocol; bounded queue is an optimization that can be added if memory issues arise
+- **`"pending"` sentinel vs Option[String]:** Matches direct API convention; changing to `Option` would be a cross-module API change
+- **IT9 duplicates IT1:** Minor maintenance cost; both tests document different concerns (factory vs lifecycle)
+- **Temp file cleanup not fully effect-safe:** Minor; files cleaned in guarantee block for scripts, capture files are small
+
+---
+
+## Suggestions Noted
+
+- Section divider comments in test files (visual noise)
+- Inline comments on queue semantics (redundant for fs2 idiom)
+- `package object` vs top-level definitions (pre-existing pattern)
+- `CLIDiscovery.findClaude` could use `using` for logger
+- `SessionImpl` could take `writeLine: String => IO[Unit]` instead of `Queue`
+
+---
+
+## Summary
+
+- **Critical Issues:** 2 (both fixed)
+- **Warnings:** 8 (3 fixed, 5 deferred with rationale)
+- **Suggestions:** 5 (noted, not blocking)

--- a/project-management/issues/CC-15/review-refactor-05-R1-20260405-144725.md
+++ b/project-management/issues/CC-15/review-refactor-05-R1-20260405-144725.md
@@ -1,0 +1,27 @@
+# Code Review Results
+
+**Review Context:** Phase 5: Effectful API - Session lifecycle with Resource for issue CC-15 - Refactoring R1 (Iteration 1/3)
+**Files Reviewed:** 5
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-04-05T14:47:25
+**Git Context:** git diff f9a14123514bd8e6101ad7a8e853f29a57a924c2
+
+---
+
+## Summary
+
+- **Critical Issues:** 3 (all triaged as out-of-scope or deliberate decisions)
+  - Composition: CQS split breaks composition → deliberate design decision per refactor-phase-05-R1.md, aligning with V2 SDK
+  - Testing: `stream()` without `send()` untested → new edge case, Phase 6 scope (error handling)
+  - Testing: `close()` without consuming stream untested → new edge case, Phase 6 scope
+- **Warnings:** 5 (3 addressed, 2 deferred)
+  - Duplicate Scaladoc on `readInitMessages` → **fixed**
+  - `caught != null` dead assertion in T7 → **fixed**
+  - PURPOSE comment stale → **fixed**
+  - `stream()` doc doesn't document violation behavior → deferred to Phase 6
+  - No guard on `stream()` without `send()` → deferred to Phase 6
+- **Suggestions:** 6 (all noted, none blocking)
+
+## Disposition
+
+No blocking critical issues. Three warnings addressed. Refactoring passes review.

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -54,14 +54,22 @@
     {
       "label": "Phase 5 Tasks",
       "path": "project-management/issues/CC-15/phase-05-tasks.md"
+    },
+    {
+      "label": "Review Packet Phase 5",
+      "path": "project-management/issues/CC-15/review-packet-phase-05.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-15/implementation-log.md"
     }
   ],
-  "last_updated": "2026-04-05T12:45:00.000000000Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-05T15:35:00.000000000Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 5: Tasks Ready",
+    "text": "Phase 5: Awaiting Review",
     "subtext": "Effectful API - Session lifecycle with Resource",
-    "type": "success"
+    "type": "warning"
   },
   "badges": [
     {
@@ -69,19 +77,20 @@
       "type": "info"
     },
     {
-      "label": "In Progress",
-      "type": "info"
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 5 tasks ready",
+  "message": "Phase 5 implementation complete - PR awaiting review",
   "available_actions": [
     {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
-  "git_sha": "5a0ab5c",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/27",
+  "git_sha": "5aaabb3",
   "phase_checkpoints": {
     "4": {
       "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
@@ -90,6 +99,6 @@
       "context_sha": "879e48a"
     }
   },
-  "needs_attention": false,
+  "needs_attention": true,
   "activity": "waiting"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -46,14 +46,18 @@
     {
       "label": "Phase 4 Tasks",
       "path": "project-management/issues/CC-15/phase-04-tasks.md"
+    },
+    {
+      "label": "Phase 5 Context",
+      "path": "project-management/issues/CC-15/phase-05-context.md"
     }
   ],
-  "last_updated": "2026-04-05T09:06:52.864139249Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-05T10:30:00.000000000Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 04: Awaiting Review",
-    "subtext": "Direct API - Multi-turn conversation",
-    "type": "warning"
+    "text": "Phase 5: Context Ready",
+    "subtext": "Effectful API - Session lifecycle with Resource",
+    "type": "info"
   },
   "badges": [
     {
@@ -63,59 +67,25 @@
     {
       "label": "In Progress",
       "type": "info"
-    },
-    {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
-      "label": "Review Needed",
-      "type": "warning"
-    },
-    {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
-      "label": "Review Needed",
-      "type": "warning"
     }
   ],
-  "message": "Phase 04 implementation started",
+  "message": "Phase 5 context ready for review",
   "available_actions": [
     {
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
-    },
-    {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
-      "id": "view-pr",
-      "label": "View Pull Request",
-      "skill": "external-link"
-    },
-    {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
-      "id": "view-pr",
-      "label": "View Pull Request",
-      "skill": "external-link"
     }
   ],
-  "git_sha": "84ba56e",
+  "git_sha": "879e48a",
   "phase_checkpoints": {
     "4": {
       "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
+    },
+    "5": {
+      "context_sha": "879e48a"
     }
   },
-  "needs_attention": true,
-  "activity": "waiting",
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/26"
+  "needs_attention": false,
+  "activity": "working"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -50,14 +50,18 @@
     {
       "label": "Phase 5 Context",
       "path": "project-management/issues/CC-15/phase-05-context.md"
+    },
+    {
+      "label": "Phase 5 Tasks",
+      "path": "project-management/issues/CC-15/phase-05-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T10:30:00.000000000Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-05T12:45:00.000000000Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 5: Context Ready",
+    "text": "Phase 5: Tasks Ready",
     "subtext": "Effectful API - Session lifecycle with Resource",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -69,7 +73,7 @@
       "type": "info"
     }
   ],
-  "message": "Phase 5 context ready for review",
+  "message": "Phase 5 tasks ready",
   "available_actions": [
     {
       "id": "implement",
@@ -77,7 +81,7 @@
       "skill": "ag-implement"
     }
   ],
-  "git_sha": "879e48a",
+  "git_sha": "5a0ab5c",
   "phase_checkpoints": {
     "4": {
       "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
@@ -87,5 +91,5 @@
     }
   },
   "needs_attention": false,
-  "activity": "working"
+  "activity": "waiting"
 }


### PR DESCRIPTION
## Summary

- Effectful `Session` trait with `send(prompt): IO[Unit]`, `stream: Stream[IO, Message]`, `sessionId: IO[String]`
- `SessionProcess`: Resource-based implementation using `ProcessBuilder.spawn[IO]`, Queue-based stdin bridge, background fibers for stdout/stderr
- `ClaudeCode.session(SessionOptions)`: Factory method returning `Resource[IO, Session]`
- `SessionOptions` re-exported in effectful package
- R1 refactoring: direct `Session.send` split into `send` + `stream` (CQS) to align with V2 SDK

## Test plan

- [x] 9 unit tests (encoding, session ID lifecycle, stream termination, multi-turn, three-turn)
- [x] 9 integration tests (lifecycle, Resource cleanup, stdin verification, ID progression, factory)
- [x] 3 E2E tests (single-turn, context-dependent multi-turn, session ID validation)
- [x] All 397+ existing tests pass — no regressions
- [x] Code review: 2 critical issues found and fixed (recursive stream, duplicated discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)