### PR TITLE
feat(CC-15): Persistent two-way conversation sessions

### DIFF
--- a/core/src/works/iterative/claude/core/CLIError.scala
+++ b/core/src/works/iterative/claude/core/CLIError.scala
@@ -49,3 +49,15 @@ case class EnvironmentValidationError(
 ) extends CLIError:
   val message =
     s"Invalid environment variable names: ${invalidVariables.mkString(", ")}. $reason"
+
+case class SessionProcessDied(
+    exitCode: Option[Int],
+    stderr: String
+) extends CLIError:
+  val message = exitCode match
+    case Some(code) =>
+      s"Session process exited unexpectedly with code $code. $stderr"
+    case None => s"Session process is not alive. $stderr"
+
+case class SessionClosedError(sessionId: String) extends CLIError:
+  val message = s"Cannot send to closed session '$sessionId'"

--- a/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+++ b/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
@@ -3,7 +3,11 @@
 
 package works.iterative.claude.core.cli
 
-import works.iterative.claude.core.model.{QueryOptions, PermissionMode}
+import works.iterative.claude.core.model.{
+  QueryOptions,
+  SessionOptions,
+  PermissionMode
+}
 
 object CLIArgumentBuilder:
   /** Converts QueryOptions into list of CLI arguments for Claude Code
@@ -55,6 +59,76 @@ object CLIArgumentBuilder:
       case None         => List.empty
 
     List(
+      maxTurnsArgs,
+      modelArgs,
+      allowedToolsArgs,
+      disallowedToolsArgs,
+      systemPromptArgs,
+      appendSystemPromptArgs,
+      continueConversationArgs,
+      resumeArgs,
+      permissionModeArgs,
+      maxThinkingTokensArgs
+    ).flatten
+
+  /** Converts SessionOptions into list of CLI arguments for a Claude Code
+    * streaming session subprocess. Always prepends the required streaming
+    * flags: --print, --input-format stream-json, --output-format stream-json.
+    * Does not append a trailing prompt argument.
+    */
+  def buildSessionArgs(options: SessionOptions): List[String] =
+    val maxTurnsArgs = options.maxTurns match
+      case Some(turns) => List("--max-turns", turns.toString)
+      case None        => List.empty
+
+    val modelArgs = options.model match
+      case Some(model) => List("--model", model)
+      case None        => List.empty
+
+    val allowedToolsArgs = options.allowedTools match
+      case Some(tools) => List("--allowedTools", tools.mkString(","))
+      case None        => List.empty
+
+    val disallowedToolsArgs = options.disallowedTools match
+      case Some(tools) => List("--disallowedTools", tools.mkString(","))
+      case None        => List.empty
+
+    val systemPromptArgs = options.systemPrompt match
+      case Some(prompt) => List("--system-prompt", prompt)
+      case None         => List.empty
+
+    val appendSystemPromptArgs = options.appendSystemPrompt match
+      case Some(prompt) => List("--append-system-prompt", prompt)
+      case None         => List.empty
+
+    val continueConversationArgs = options.continueConversation match
+      case Some(true) => List("--continue")
+      case _          => List.empty
+
+    val resumeArgs = options.resume match
+      case Some(conversationId) => List("--resume", conversationId)
+      case None                 => List.empty
+
+    val permissionModeArgs = options.permissionMode match
+      case Some(PermissionMode.Default) => List("--permission-mode", "default")
+      case Some(PermissionMode.AcceptEdits) =>
+        List("--permission-mode", "acceptEdits")
+      case Some(PermissionMode.BypassPermissions) =>
+        List("--permission-mode", "bypassPermissions")
+      case None => List.empty
+
+    val maxThinkingTokensArgs = options.maxThinkingTokens match
+      case Some(tokens) => List("--max-thinking-tokens", tokens.toString)
+      case None         => List.empty
+
+    List(
+      List(
+        "--print",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json"
+      ),
       maxTurnsArgs,
       modelArgs,
       allowedToolsArgs,

--- a/core/src/works/iterative/claude/core/model/Message.scala
+++ b/core/src/works/iterative/claude/core/model/Message.scala
@@ -26,3 +26,7 @@ case class ResultMessage(
     usage: Option[Map[String, Any]] = None,
     result: Option[String] = None
 ) extends Message
+
+case object KeepAliveMessage extends Message
+
+case class StreamEventMessage(data: Map[String, Any]) extends Message

--- a/core/src/works/iterative/claude/core/model/SDKUserMessage.scala
+++ b/core/src/works/iterative/claude/core/model/SDKUserMessage.scala
@@ -1,0 +1,27 @@
+// PURPOSE: Represents a user message written to Claude Code CLI stdin in stream-json mode
+// PURPOSE: Provides circe Encoder producing the exact JSON shape the CLI protocol expects
+
+package works.iterative.claude.core.model
+
+import io.circe.{Encoder, Json}
+
+case class SDKUserMessage(
+    content: String,
+    sessionId: String,
+    parentToolUseId: Option[String] = None
+)
+
+object SDKUserMessage:
+  given Encoder[SDKUserMessage] = Encoder.instance { msg =>
+    Json.obj(
+      "type" -> Json.fromString("user"),
+      "message" -> Json.obj(
+        "role" -> Json.fromString("user"),
+        "content" -> Json.fromString(msg.content)
+      ),
+      "parent_tool_use_id" -> msg.parentToolUseId.fold(Json.Null)(
+        Json.fromString
+      ),
+      "session_id" -> Json.fromString(msg.sessionId)
+    )
+  }

--- a/core/src/works/iterative/claude/core/model/SessionOptions.scala
+++ b/core/src/works/iterative/claude/core/model/SessionOptions.scala
@@ -1,0 +1,111 @@
+// PURPOSE: Configuration options for Claude Code streaming sessions, mapping to CLI arguments
+// PURPOSE: Provides all session startup parameters except the prompt, which arrives per-turn
+
+package works.iterative.claude.core.model
+
+/** Configuration options for a Claude Code streaming session.
+  *
+  * Contains all fields from QueryOptions except prompt, which is sent per-turn
+  * during the session. Fields that are process-level configuration (timeout,
+  * inheritEnvironment, environmentVariables, executable, executableArgs,
+  * pathToClaudeCodeExecutable) are consumed by the session runner and not
+  * translated to CLI flags.
+  */
+case class SessionOptions(
+    /** Working directory for the Claude Code CLI process */
+    cwd: Option[String] = None,
+
+    /** Which JavaScript runtime to use (node/bun) - for internal SDK use */
+    executable: Option[String] = None,
+
+    /** Arguments to pass to the JavaScript runtime - for internal SDK use */
+    executableArgs: Option[List[String]] = None,
+
+    /** Path to the Claude Code executable (overrides default bundled CLI) */
+    pathToClaudeCodeExecutable: Option[String] = None,
+
+    /** Maximum number of conversation turns (--max-turns) */
+    maxTurns: Option[Int] = None,
+
+    /** List of tools Claude is allowed to use (--allowedTools) */
+    allowedTools: Option[List[String]] = None,
+
+    /** List of tools Claude is NOT allowed to use (--disallowedTools) */
+    disallowedTools: Option[List[String]] = None,
+
+    /** Custom system prompt to override Claude's default behavior
+      * (--system-prompt)
+      */
+    systemPrompt: Option[String] = None,
+
+    /** Additional instructions to append to the default system prompt
+      * (--append-system-prompt)
+      */
+    appendSystemPrompt: Option[String] = None,
+
+    /** List of MCP (Model Context Protocol) tools to enable */
+    mcpTools: Option[List[String]] = None,
+
+    /** How to handle tool permission prompts (--permission-mode) */
+    permissionMode: Option[PermissionMode] = None,
+
+    /** Whether to continue from the most recent conversation (--continue) */
+    continueConversation: Option[Boolean] = None,
+
+    /** Session ID to resume a specific conversation (--resume) */
+    resume: Option[String] = None,
+
+    /** Specific Claude model to use (--model) */
+    model: Option[String] = None,
+
+    /** Maximum tokens for Claude's internal reasoning/thinking */
+    maxThinkingTokens: Option[Int] = None,
+
+    /** Timeout for the Claude Code CLI process execution */
+    timeout: Option[scala.concurrent.duration.FiniteDuration] = None,
+
+    /** Whether to inherit the parent process environment variables */
+    inheritEnvironment: Option[Boolean] = None,
+
+    /** Additional environment variables to set for the Claude Code CLI process
+      */
+    environmentVariables: Option[Map[String, String]] = None
+):
+  def withCwd(cwd: String): SessionOptions = copy(cwd = Some(cwd))
+  def withExecutable(executable: String): SessionOptions =
+    copy(executable = Some(executable))
+  def withExecutableArgs(args: List[String]): SessionOptions =
+    copy(executableArgs = Some(args))
+  def withClaudeExecutable(path: String): SessionOptions =
+    copy(pathToClaudeCodeExecutable = Some(path))
+  def withMaxTurns(turns: Int): SessionOptions = copy(maxTurns = Some(turns))
+  def withAllowedTools(tools: List[String]): SessionOptions =
+    copy(allowedTools = Some(tools))
+  def withDisallowedTools(tools: List[String]): SessionOptions =
+    copy(disallowedTools = Some(tools))
+  def withSystemPrompt(prompt: String): SessionOptions =
+    copy(systemPrompt = Some(prompt))
+  def withAppendSystemPrompt(prompt: String): SessionOptions =
+    copy(appendSystemPrompt = Some(prompt))
+  def withMcpTools(tools: List[String]): SessionOptions =
+    copy(mcpTools = Some(tools))
+  def withPermissionMode(mode: PermissionMode): SessionOptions =
+    copy(permissionMode = Some(mode))
+  def withContinueConversation(continue: Boolean): SessionOptions =
+    copy(continueConversation = Some(continue))
+  def withResume(sessionId: String): SessionOptions =
+    copy(resume = Some(sessionId))
+  def withModel(model: String): SessionOptions = copy(model = Some(model))
+  def withMaxThinkingTokens(tokens: Int): SessionOptions =
+    copy(maxThinkingTokens = Some(tokens))
+  def withTimeout(
+      timeout: scala.concurrent.duration.FiniteDuration
+  ): SessionOptions = copy(timeout = Some(timeout))
+  def withInheritEnvironment(inherit: Boolean): SessionOptions =
+    copy(inheritEnvironment = Some(inherit))
+  def withEnvironmentVariables(vars: Map[String, String]): SessionOptions =
+    copy(environmentVariables = Some(vars))
+
+object SessionOptions:
+  /** Create SessionOptions with all defaults */
+  val defaults: SessionOptions = SessionOptions()

--- a/core/src/works/iterative/claude/core/parsing/JsonParser.scala
+++ b/core/src/works/iterative/claude/core/parsing/JsonParser.scala
@@ -22,11 +22,13 @@ object JsonParser:
       .get[String]("type")
       .toOption
       .flatMap:
-        case "user"      => parseUserMessage(cursor)
-        case "assistant" => parseAssistantMessage(cursor)
-        case "system"    => parseSystemMessage(json, cursor)
-        case "result"    => parseResultMessage(cursor)
-        case _           => None
+        case "user"         => parseUserMessage(cursor)
+        case "assistant"    => parseAssistantMessage(cursor)
+        case "system"       => parseSystemMessage(json, cursor)
+        case "result"       => parseResultMessage(cursor)
+        case "keep_alive"   => Some(KeepAliveMessage)
+        case "stream_event" => parseStreamEventMessage(json)
+        case _              => None
 
   // Message type parsers - handle specific message formats
   private def parseUserMessage(cursor: io.circe.HCursor): Option[UserMessage] =
@@ -52,6 +54,14 @@ object JsonParser:
       jsonObj <- json.asObject
       data = extractSystemMessageData(jsonObj)
     yield SystemMessage(subtype, data)
+
+  private def parseStreamEventMessage(json: Json): Option[StreamEventMessage] =
+    json.asObject.map { jsonObj =>
+      val data = jsonObj.toMap
+        .filter { case (key, _) => key != "type" }
+        .map { case (key, value) => key -> extractJsonValue(value) }
+      StreamEventMessage(data)
+    }
 
   // Data extraction utilities - low-level JSON value extraction
   private def extractSystemMessageData(

--- a/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+++ b/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
@@ -1,0 +1,143 @@
+// PURPOSE: Tests buildSessionArgs mapping from SessionOptions to Claude Code CLI arguments
+// PURPOSE: Ensures required streaming flags are always present and all options map correctly
+
+package works.iterative.claude.core.cli
+
+import munit.CatsEffectSuite
+import works.iterative.claude.core.model.{SessionOptions, PermissionMode}
+
+class SessionOptionsArgsTest extends CatsEffectSuite:
+
+  private val requiredFlags =
+    List(
+      "--print",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json"
+    )
+
+  test("default options produce only the three required session flags"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assertEquals(args, requiredFlags)
+
+  test("required session flags appear at the start of the argument list"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withModel("claude-opus-4-5")
+    )
+    assertEquals(args.take(requiredFlags.length), requiredFlags)
+
+  test("no trailing prompt argument"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assertEquals(args.length, requiredFlags.length)
+
+  test("maxTurns maps to --max-turns"):
+    val args =
+      CLIArgumentBuilder.buildSessionArgs(SessionOptions().withMaxTurns(5))
+    assert(args.contains("--max-turns"))
+    assert(args.contains("5"))
+
+  test("model maps to --model"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withModel("claude-opus-4-5")
+    )
+    assert(args.contains("--model"))
+    assert(args.contains("claude-opus-4-5"))
+
+  test("allowedTools maps to --allowedTools with comma-joined value"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withAllowedTools(List("Read", "Write", "Bash"))
+    )
+    assert(args.contains("--allowedTools"))
+    assert(args.contains("Read,Write,Bash"))
+
+  test("disallowedTools maps to --disallowedTools with comma-joined value"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withDisallowedTools(List("Bash", "Write"))
+    )
+    assert(args.contains("--disallowedTools"))
+    assert(args.contains("Bash,Write"))
+
+  test("systemPrompt maps to --system-prompt"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withSystemPrompt("You are a code reviewer.")
+    )
+    assert(args.contains("--system-prompt"))
+    assert(args.contains("You are a code reviewer."))
+
+  test("appendSystemPrompt maps to --append-system-prompt"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withAppendSystemPrompt("Be concise.")
+    )
+    assert(args.contains("--append-system-prompt"))
+    assert(args.contains("Be concise."))
+
+  test(
+    "continueConversation Some(true) maps to --continue, Some(false) produces no flag"
+  ):
+    val argsTrue = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withContinueConversation(true)
+    )
+    assert(argsTrue.contains("--continue"))
+
+    val argsFalse = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withContinueConversation(false)
+    )
+    assert(!argsFalse.contains("--continue"))
+
+  test("resume maps to --resume"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withResume("session-id-xyz")
+    )
+    assert(args.contains("--resume"))
+    assert(args.contains("session-id-xyz"))
+
+  test("permissionMode maps to --permission-mode for all three enum values"):
+    val defaultArgs = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withPermissionMode(PermissionMode.Default)
+    )
+    assert(defaultArgs.contains("--permission-mode"))
+    assert(defaultArgs.contains("default"))
+
+    val acceptEditsArgs = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withPermissionMode(PermissionMode.AcceptEdits)
+    )
+    assert(acceptEditsArgs.contains("--permission-mode"))
+    assert(acceptEditsArgs.contains("acceptEdits"))
+
+    val bypassArgs = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withPermissionMode(PermissionMode.BypassPermissions)
+    )
+    assert(bypassArgs.contains("--permission-mode"))
+    assert(bypassArgs.contains("bypassPermissions"))
+
+  test("maxThinkingTokens maps to --max-thinking-tokens"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withMaxThinkingTokens(8000)
+    )
+    assert(args.contains("--max-thinking-tokens"))
+    assert(args.contains("8000"))
+
+  test("None values produce no extra args beyond the required flags"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assertEquals(args, requiredFlags)
+
+  test("multiple options combine correctly"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions()
+        .withModel("claude-opus-4-5")
+        .withSystemPrompt("You are a code reviewer")
+        .withMaxTurns(3)
+        .withPermissionMode(PermissionMode.AcceptEdits)
+    )
+    // Required flags come first
+    assertEquals(args.take(requiredFlags.length), requiredFlags)
+    // All option flags are present
+    assert(args.contains("--model"))
+    assert(args.contains("claude-opus-4-5"))
+    assert(args.contains("--system-prompt"))
+    assert(args.contains("You are a code reviewer"))
+    assert(args.contains("--max-turns"))
+    assert(args.contains("3"))
+    assert(args.contains("--permission-mode"))
+    assert(args.contains("acceptEdits"))

--- a/core/test/src/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala
+++ b/core/test/src/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala
@@ -1,0 +1,52 @@
+// PURPOSE: End-to-end test validating SDKUserMessage format against the real Claude Code CLI
+// PURPOSE: Gated on CLI availability to skip gracefully in environments without the CLI
+
+package works.iterative.claude.core.model
+
+import munit.FunSuite
+import io.circe.syntax.*
+import scala.util.Try
+
+class SDKUserMessageE2ETest extends FunSuite:
+
+  private def assumeCommand(command: String): Unit =
+    val available = Try {
+      new ProcessBuilder("which", command).start().waitFor() == 0
+    }.getOrElse(false)
+    assume(available, s"Command '$command' not found in PATH")
+
+  test(
+    "Real CLI accepts SDKUserMessage JSON format via stream-json stdin"
+  ):
+    // Skips automatically when `claude` CLI is not available
+    assumeCommand("claude")
+
+    val msg = SDKUserMessage("What is 1+1?", "pending", None)
+    val jsonLine = msg.asJson.noSpaces
+
+    val process = new ProcessBuilder(
+      "claude",
+      "--print",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json"
+    ).redirectErrorStream(false).start()
+
+    val writer = process.getOutputStream
+    writer.write((jsonLine + "\n").getBytes)
+    writer.flush()
+    writer.close()
+
+    val exitCode = process.waitFor()
+    val stderr =
+      scala.io.Source.fromInputStream(process.getErrorStream).mkString
+    val stdout =
+      scala.io.Source.fromInputStream(process.getInputStream).mkString
+
+    // The CLI should not crash with a format error
+    assert(
+      exitCode == 0,
+      s"CLI should accept the message format. Exit: $exitCode, stderr: $stderr"
+    )

--- a/core/test/src/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala
+++ b/core/test/src/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala
@@ -1,0 +1,150 @@
+// PURPOSE: Integration test for SDKUserMessage round-trip through a mock CLI process
+// PURPOSE: Validates the JSON format works end-to-end with stdin/stdout piping
+
+package works.iterative.claude.core.model
+
+import munit.FunSuite
+import io.circe.syntax.*
+import works.iterative.claude.core.parsing.JsonParser
+
+class SDKUserMessageRoundTripTest extends FunSuite:
+
+  private def assumeUnixSystem(): Unit =
+    val osName = System.getProperty("os.name").toLowerCase
+    assume(
+      !osName.contains("windows"),
+      s"Test requires Unix-like system, but running on: $osName"
+    )
+
+  test("Round-trip: encode SDKUserMessage, mock CLI echoes response, parse it"):
+    assumeUnixSystem()
+
+    val msg = SDKUserMessage("What is 2+2?", "session-abc", None)
+    val jsonLine = msg.asJson.noSpaces
+
+    // Mock script reads stdin line, then writes an assistant message and result
+    val script =
+      s"""#!/bin/bash
+         |read INPUT_LINE
+         |echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The answer is 4."}]}}'
+         |echo '{"type":"result","subtype":"success","duration_ms":100,"duration_api_ms":80,"is_error":false,"num_turns":1,"session_id":"session-abc","result":"The answer is 4."}'
+         |""".stripMargin
+
+    val scriptFile =
+      java.nio.file.Files.createTempFile("mock-cli-", ".sh")
+    java.nio.file.Files.write(scriptFile, script.getBytes)
+    java.nio.file.Files.setPosixFilePermissions(
+      scriptFile,
+      java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x")
+    )
+
+    try
+      val process = new ProcessBuilder(scriptFile.toString)
+        .redirectErrorStream(false)
+        .start()
+
+      // Write the SDKUserMessage JSON to stdin
+      val writer = process.getOutputStream
+      writer.write((jsonLine + "\n").getBytes)
+      writer.flush()
+      writer.close()
+
+      // Read stdout lines
+      val reader = scala.io.Source.fromInputStream(process.getInputStream)
+      val lines = reader.getLines().toList
+      reader.close()
+
+      process.waitFor()
+
+      assertEquals(lines.length, 2, s"Expected 2 output lines, got: $lines")
+
+      val parsed = lines.flatMap(JsonParser.parseJsonLine)
+      assertEquals(parsed.length, 2)
+
+      parsed(0) match
+        case AssistantMessage(content) =>
+          assertEquals(content.length, 1)
+          content.head match
+            case TextBlock(text) => assertEquals(text, "The answer is 4.")
+            case other           => fail(s"Expected TextBlock, got $other")
+        case other => fail(s"Expected AssistantMessage, got $other")
+
+      parsed(1) match
+        case rm: ResultMessage =>
+          assertEquals(rm.subtype, "success")
+          assertEquals(rm.sessionId, "session-abc")
+          assertEquals(rm.result, Some("The answer is 4."))
+        case other => fail(s"Expected ResultMessage, got $other")
+    finally java.nio.file.Files.deleteIfExists(scriptFile): Unit
+
+  test(
+    "Mock session protocol: init message, stdin write, assistant + result response"
+  ):
+    assumeUnixSystem()
+
+    val msg = SDKUserMessage("Hello", "pending", None)
+    val jsonLine = msg.asJson.noSpaces
+
+    // Mock script: outputs init, reads stdin, then responds
+    val script =
+      s"""#!/bin/bash
+         |echo '{"type":"system","subtype":"init","session_id":"real-session-42","model":"claude-sonnet","tools":[]}'
+         |read INPUT_LINE
+         |echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi there!"}]}}'
+         |echo '{"type":"result","subtype":"success","duration_ms":200,"duration_api_ms":150,"is_error":false,"num_turns":1,"session_id":"real-session-42"}'
+         |""".stripMargin
+
+    val scriptFile =
+      java.nio.file.Files.createTempFile("mock-session-", ".sh")
+    java.nio.file.Files.write(scriptFile, script.getBytes)
+    java.nio.file.Files.setPosixFilePermissions(
+      scriptFile,
+      java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x")
+    )
+
+    try
+      val process = new ProcessBuilder(scriptFile.toString)
+        .redirectErrorStream(false)
+        .start()
+
+      // Read the init message first (it's written before reading stdin)
+      val inputStream = process.getInputStream
+      val bufferedReader =
+        new java.io.BufferedReader(new java.io.InputStreamReader(inputStream))
+
+      val initLine = bufferedReader.readLine()
+      assertNotEquals(initLine, null, "Expected init message")
+      val initMsg = JsonParser.parseJsonLine(initLine)
+      initMsg match
+        case Some(SystemMessage(subtype, data)) =>
+          assertEquals(subtype, "init")
+          assertEquals(data("session_id"), "real-session-42")
+        case other => fail(s"Expected SystemMessage, got $other")
+
+      // Write our SDKUserMessage
+      val writer = process.getOutputStream
+      writer.write((jsonLine + "\n").getBytes)
+      writer.flush()
+      writer.close()
+
+      // Read the response
+      val assistantLine = bufferedReader.readLine()
+      val resultLine = bufferedReader.readLine()
+      bufferedReader.close()
+
+      process.waitFor()
+
+      val assistantMsg = JsonParser.parseJsonLine(assistantLine)
+      assistantMsg match
+        case Some(AssistantMessage(content)) =>
+          content.head match
+            case TextBlock(text) => assertEquals(text, "Hi there!")
+            case other           => fail(s"Expected TextBlock, got $other")
+        case other => fail(s"Expected AssistantMessage, got $other")
+
+      val resultMsg = JsonParser.parseJsonLine(resultLine)
+      resultMsg match
+        case Some(rm: ResultMessage) =>
+          assertEquals(rm.sessionId, "real-session-42")
+        case other => fail(s"Expected ResultMessage, got $other")
+    finally java.nio.file.Files.deleteIfExists(scriptFile): Unit

--- a/core/test/src/works/iterative/claude/core/model/SDKUserMessageTest.scala
+++ b/core/test/src/works/iterative/claude/core/model/SDKUserMessageTest.scala
@@ -1,0 +1,52 @@
+// PURPOSE: Unit tests for SDKUserMessage circe Encoder
+// PURPOSE: Verifies the exact JSON shape required by the Claude Code stdin protocol
+
+package works.iterative.claude.core.model
+
+import munit.FunSuite
+import io.circe.syntax.*
+import io.circe.Json
+
+class SDKUserMessageTest extends FunSuite:
+
+  test("Encoder produces correct JSON structure"):
+    val msg = SDKUserMessage("hello", "session-1", None)
+    val json = msg.asJson
+
+    assertEquals(json.hcursor.get[String]("type").toOption, Some("user"))
+    assertEquals(
+      json.hcursor.get[String]("session_id").toOption,
+      Some("session-1")
+    )
+    assert(json.hcursor.downField("parent_tool_use_id").focus.exists(_.isNull))
+
+    val message = json.hcursor.downField("message")
+    assertEquals(message.get[String]("role").toOption, Some("user"))
+    assertEquals(message.get[String]("content").toOption, Some("hello"))
+
+  test("Encoder produces string value for Some(parentToolUseId)"):
+    val msg = SDKUserMessage("hello", "s1", Some("tool-123"))
+    val json = msg.asJson
+
+    assertEquals(
+      json.hcursor.get[String]("parent_tool_use_id").toOption,
+      Some("tool-123")
+    )
+
+  test("Encoder accepts pending as session_id"):
+    val msg = SDKUserMessage("hello", "pending", None)
+    val json = msg.asJson
+
+    assertEquals(
+      json.hcursor.get[String]("session_id").toOption,
+      Some("pending")
+    )
+
+  test("Encoded JSON contains no embedded newlines"):
+    val msg = SDKUserMessage("hello world", "session-1", None)
+    val jsonStr = msg.asJson.noSpaces
+
+    assert(
+      !jsonStr.contains('\n'),
+      s"JSON should not contain newlines: $jsonStr"
+    )

--- a/core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala
+++ b/core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala
@@ -1,0 +1,104 @@
+// PURPOSE: Tests SessionOptions construction, defaults, and fluent builder methods
+// PURPOSE: Ensures each with* builder sets only its targeted field and leaves others unchanged
+
+package works.iterative.claude.core.model
+
+import munit.CatsEffectSuite
+import scala.concurrent.duration.*
+
+class SessionOptionsTest extends CatsEffectSuite:
+
+  test("SessionOptions() has all None fields"):
+    val opts = SessionOptions()
+    assertEquals(opts.cwd, None)
+    assertEquals(opts.executable, None)
+    assertEquals(opts.executableArgs, None)
+    assertEquals(opts.pathToClaudeCodeExecutable, None)
+    assertEquals(opts.maxTurns, None)
+    assertEquals(opts.allowedTools, None)
+    assertEquals(opts.disallowedTools, None)
+    assertEquals(opts.systemPrompt, None)
+    assertEquals(opts.appendSystemPrompt, None)
+    assertEquals(opts.mcpTools, None)
+    assertEquals(opts.permissionMode, None)
+    assertEquals(opts.continueConversation, None)
+    assertEquals(opts.resume, None)
+    assertEquals(opts.model, None)
+    assertEquals(opts.maxThinkingTokens, None)
+    assertEquals(opts.timeout, None)
+    assertEquals(opts.inheritEnvironment, None)
+    assertEquals(opts.environmentVariables, None)
+
+  test("SessionOptions.defaults equals SessionOptions()"):
+    assertEquals(SessionOptions.defaults, SessionOptions())
+
+  // SessionOptions has no prompt field — enforced at compile time by the type definition
+  test("each with* builder sets only its field"):
+    val base = SessionOptions()
+
+    assertEquals(base.withCwd("/tmp"), base.copy(cwd = Some("/tmp")))
+    assertEquals(
+      base.withExecutable("bun"),
+      base.copy(executable = Some("bun"))
+    )
+    assertEquals(
+      base.withExecutableArgs(List("--arg1")),
+      base.copy(executableArgs = Some(List("--arg1")))
+    )
+    assertEquals(
+      base.withClaudeExecutable("/usr/local/bin/claude"),
+      base.copy(pathToClaudeCodeExecutable = Some("/usr/local/bin/claude"))
+    )
+    assertEquals(base.withMaxTurns(10), base.copy(maxTurns = Some(10)))
+    assertEquals(
+      base.withAllowedTools(List("Read", "Write")),
+      base.copy(allowedTools = Some(List("Read", "Write")))
+    )
+    assertEquals(
+      base.withDisallowedTools(List("Bash")),
+      base.copy(disallowedTools = Some(List("Bash")))
+    )
+    assertEquals(
+      base.withSystemPrompt("You are helpful."),
+      base.copy(systemPrompt = Some("You are helpful."))
+    )
+    assertEquals(
+      base.withAppendSystemPrompt("Be concise."),
+      base.copy(appendSystemPrompt = Some("Be concise."))
+    )
+    assertEquals(
+      base.withMcpTools(List("mcp__fs__read")),
+      base.copy(mcpTools = Some(List("mcp__fs__read")))
+    )
+    assertEquals(
+      base.withPermissionMode(PermissionMode.AcceptEdits),
+      base.copy(permissionMode = Some(PermissionMode.AcceptEdits))
+    )
+    assertEquals(
+      base.withContinueConversation(true),
+      base.copy(continueConversation = Some(true))
+    )
+    assertEquals(
+      base.withResume("session-id-abc"),
+      base.copy(resume = Some("session-id-abc"))
+    )
+    assertEquals(
+      base.withModel("claude-opus-4-5"),
+      base.copy(model = Some("claude-opus-4-5"))
+    )
+    assertEquals(
+      base.withMaxThinkingTokens(8000),
+      base.copy(maxThinkingTokens = Some(8000))
+    )
+    assertEquals(
+      base.withTimeout(30.seconds),
+      base.copy(timeout = Some(30.seconds))
+    )
+    assertEquals(
+      base.withInheritEnvironment(false),
+      base.copy(inheritEnvironment = Some(false))
+    )
+    assertEquals(
+      base.withEnvironmentVariables(Map("KEY" -> "value")),
+      base.copy(environmentVariables = Some(Map("KEY" -> "value")))
+    )

--- a/core/test/src/works/iterative/claude/core/parsing/JsonParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/parsing/JsonParserTest.scala
@@ -140,3 +140,76 @@ class JsonParserTest extends FunSuite:
     val whitespaceLine = "   \t  \n  "
     val result = JsonParser.parseJsonLine(whitespaceLine)
     assertEquals(result, None, "Whitespace-only line should return None")
+
+  test("parseMessage parses keep_alive into KeepAliveMessage"):
+    val keepAliveStr = """{"type":"keep_alive"}"""
+    val json =
+      parser.parse(keepAliveStr).getOrElse(fail("Failed to parse JSON"))
+    val result = JsonParser.parseMessage(json)
+
+    result match
+      case Some(KeepAliveMessage) => () // success
+      case Some(other)            =>
+        fail(s"Expected KeepAliveMessage, got: ${other.getClass.getSimpleName}")
+      case None => fail("Expected KeepAliveMessage, got None")
+
+  test("parseMessage parses stream_event into StreamEventMessage"):
+    val streamEventStr = """{
+      "type": "stream_event",
+      "event": "content_block_delta",
+      "data": {"type": "text_delta", "text": "Hello"}
+    }"""
+
+    val json =
+      parser.parse(streamEventStr).getOrElse(fail("Failed to parse JSON"))
+    val result = JsonParser.parseMessage(json)
+
+    result match
+      case Some(StreamEventMessage(data)) =>
+        assert(data.contains("event"))
+        assertEquals(data("event"), "content_block_delta")
+        assert(data.contains("data"))
+        val nestedData = data("data").asInstanceOf[Map[String, Any]]
+        assertEquals(nestedData("type"), "text_delta")
+        assertEquals(nestedData("text"), "Hello")
+      case Some(other) =>
+        fail(
+          s"Expected StreamEventMessage, got: ${other.getClass.getSimpleName}"
+        )
+      case None => fail("Expected StreamEventMessage, got None")
+
+  test("ResultMessage parses realistic stream-json end-of-turn"):
+    val resultJsonStr = """{
+      "type": "result",
+      "subtype": "success",
+      "duration_ms": 3200,
+      "duration_api_ms": 2800,
+      "is_error": false,
+      "num_turns": 3,
+      "result": "Here is the final answer to your question.",
+      "session_id": "abc-def-123-456",
+      "total_cost_usd": 0.0042,
+      "usage": {"input_tokens": 1500, "output_tokens": 350}
+    }"""
+
+    val json =
+      parser.parse(resultJsonStr).getOrElse(fail("Failed to parse JSON"))
+    val result = JsonParser.parseMessage(json)
+
+    result match
+      case Some(rm: ResultMessage) =>
+        assertEquals(rm.subtype, "success")
+        assertEquals(rm.durationMs, 3200)
+        assertEquals(rm.durationApiMs, 2800)
+        assertEquals(rm.isError, false)
+        assertEquals(rm.numTurns, 3)
+        assertEquals(rm.sessionId, "abc-def-123-456")
+        assertEquals(rm.totalCostUsd, Some(0.0042))
+        assert(rm.usage.isDefined)
+        assertEquals(
+          rm.result,
+          Some("Here is the final answer to your question.")
+        )
+      case Some(other) =>
+        fail(s"Expected ResultMessage, got: ${other.getClass.getSimpleName}")
+      case None => fail("Expected ResultMessage, got None")

--- a/direct/src/works/iterative/claude/direct/ClaudeCode.scala
+++ b/direct/src/works/iterative/claude/direct/ClaudeCode.scala
@@ -6,10 +6,12 @@ import ox.*
 import ox.flow.Flow
 import works.iterative.claude.core.cli.CLIArgumentBuilder
 import works.iterative.claude.core.ConfigurationError
+import works.iterative.claude.core.model.SessionOptions
 import works.iterative.claude.direct.internal.cli.{
   ProcessManager,
   CLIDiscovery,
-  FileSystemOps
+  FileSystemOps,
+  SessionProcess
 }
 import works.iterative.claude.direct.Logger
 
@@ -47,6 +49,13 @@ class ClaudeCode(using logger: Logger, ox: Ox):
   def queryResult(options: QueryOptions): String =
     val messages = executeQuery(options)
     ClaudeCode.extractAssistantTextContent(messages)
+
+  /** Starts a long-lived CLI process and returns a Session for multi-turn
+    * conversations. The process stays alive until `Session.close()` is called.
+    * Background forks for stderr capture run within the provided Ox scope.
+    */
+  def session(options: SessionOptions): Session =
+    ClaudeCode.createSession(options)
 
   private def executeQuery(options: QueryOptions): List[Message] =
     ClaudeCode.executeQuery(options)
@@ -88,6 +97,14 @@ object ClaudeCode:
     */
   def concurrent(using Logger, Ox): ClaudeCode = new ClaudeCode()
 
+  /** Starts a long-lived CLI session and returns it for multi-turn
+    * conversations. The caller must provide an Ox scope for background forks
+    * (stderr capture). The session remains open until `Session.close()` is
+    * called.
+    */
+  def session(options: SessionOptions)(using Logger, Ox): Session =
+    createSession(options)
+
   // ==== MAIN EXECUTION LOGIC ====
 
   private def executeQuery(
@@ -103,7 +120,9 @@ object ClaudeCode:
 
   private def resolveClaudeExecutablePath(options: QueryOptions): String =
     options.pathToClaudeCodeExecutable.getOrElse {
-      discoverClaudeExecutablePath(options)
+      // For testing, if executableArgs is provided, use /bin/echo to simulate the CLI
+      if options.executableArgs.isDefined then "/bin/echo"
+      else resolveExecutablePath(None)
     }
 
   private def buildCliArguments(options: QueryOptions): List[String] =
@@ -125,14 +144,15 @@ object ClaudeCode:
         )
     }
 
-  private def discoverClaudeExecutablePath(options: QueryOptions): String =
-    // For testing purposes with T6.2, if executableArgs is provided, use /bin/echo
-    // This allows the test to pass by using echo to simulate the CLI
-    if options.executableArgs.isDefined then "/bin/echo"
-    else
+  /** Resolves the Claude CLI executable path from an explicit override or CLI
+    * discovery.
+    */
+  private def resolveExecutablePath(explicit: Option[String]): String =
+    explicit.getOrElse {
       CLIDiscovery.findClaude match
         case Right(path) => path
         case Left(error) => throw new RuntimeException(error.message)
+    }
 
   private def extractAssistantTextContent(messages: List[Message]): String =
     messages
@@ -147,3 +167,13 @@ object ClaudeCode:
         textBlock.text
       }
       .getOrElse("")
+
+  private[direct] def createSession(
+      options: SessionOptions
+  )(using logger: Logger, ox: Ox): Session =
+    validateWorkingDirectory(options.cwd)
+    val executablePath = resolveSessionExecutablePath(options)
+    SessionProcess.start(executablePath, options)
+
+  private def resolveSessionExecutablePath(options: SessionOptions): String =
+    resolveExecutablePath(options.pathToClaudeCodeExecutable)

--- a/direct/src/works/iterative/claude/direct/Session.scala
+++ b/direct/src/works/iterative/claude/direct/Session.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Trait representing an active conversational session with the Claude Code CLI
-// PURPOSE: Provides send/close interface for multi-turn conversations over a persistent process
+// PURPOSE: Provides send/stream/close interface for multi-turn conversations over a persistent process
 package works.iterative.claude.direct
 
 import ox.flow.Flow
@@ -8,19 +8,21 @@ import works.iterative.claude.core.model.Message
 /** An active Claude Code session backed by a long-lived CLI process.
   *
   * Each session maintains a single CLI process whose stdin is kept open for
-  * multi-turn conversation. Prompts are submitted via `send`, which writes an
-  * SDKUserMessage to stdin and streams stdout messages back as a Flow until a
-  * ResultMessage signals end-of-turn. Call `close` to shut down the process
-  * cleanly when the session is no longer needed.
+  * multi-turn conversation. Each turn is initiated with `send` (which writes
+  * the prompt to stdin) and then consumed via `stream` (which reads stdout
+  * until the ResultMessage signals end-of-turn). Call `close` to shut down the
+  * process cleanly when the session is no longer needed.
   */
 trait Session:
-  /** Sends a prompt to the session and streams the response.
+  /** Writes a prompt to the session's stdin as an SDKUserMessage JSON line. */
+  def send(prompt: String): Unit
+
+  /** Reads stdout messages for the current turn until a ResultMessage.
     *
-    * Writes an SDKUserMessage JSON line to the process stdin, then returns a
-    * Flow of messages read from stdout. The Flow completes after emitting the
-    * ResultMessage that terminates the current turn.
+    * Returns a Flow of messages that completes after emitting the ResultMessage
+    * that terminates the current turn. Must be called after `send`.
     */
-  def send(prompt: String): Flow[Message]
+  def stream(): Flow[Message]
 
   /** Shuts down the underlying CLI process.
     *
@@ -32,7 +34,7 @@ trait Session:
   /** The session ID assigned by the CLI.
     *
     * Returns "pending" until the CLI emits an init SystemMessage or until the
-    * first send completes (at which point the ResultMessage session ID is
+    * first turn completes (at which point the ResultMessage session ID is
     * used).
     */
   def sessionId: String

--- a/direct/src/works/iterative/claude/direct/Session.scala
+++ b/direct/src/works/iterative/claude/direct/Session.scala
@@ -1,0 +1,38 @@
+// PURPOSE: Trait representing an active conversational session with the Claude Code CLI
+// PURPOSE: Provides send/close interface for multi-turn conversations over a persistent process
+package works.iterative.claude.direct
+
+import ox.flow.Flow
+import works.iterative.claude.core.model.Message
+
+/** An active Claude Code session backed by a long-lived CLI process.
+  *
+  * Each session maintains a single CLI process whose stdin is kept open for
+  * multi-turn conversation. Prompts are submitted via `send`, which writes an
+  * SDKUserMessage to stdin and streams stdout messages back as a Flow until a
+  * ResultMessage signals end-of-turn. Call `close` to shut down the process
+  * cleanly when the session is no longer needed.
+  */
+trait Session:
+  /** Sends a prompt to the session and streams the response.
+    *
+    * Writes an SDKUserMessage JSON line to the process stdin, then returns a
+    * Flow of messages read from stdout. The Flow completes after emitting the
+    * ResultMessage that terminates the current turn.
+    */
+  def send(prompt: String): Flow[Message]
+
+  /** Shuts down the underlying CLI process.
+    *
+    * Closes stdin, waits briefly for the process to exit, and forcibly destroys
+    * it if it does not exit in time.
+    */
+  def close(): Unit
+
+  /** The session ID assigned by the CLI.
+    *
+    * Returns "pending" until the CLI emits an init SystemMessage or until the
+    * first send completes (at which point the ResultMessage session ID is
+    * used).
+    */
+  def sessionId: String

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -1,0 +1,231 @@
+// PURPOSE: Internal implementation of Session backed by a long-lived CLI process
+// PURPOSE: Manages stdin writing, stdout streaming, stderr capture, and process lifecycle
+package works.iterative.claude.direct.internal.cli
+
+import ox.*
+import ox.flow.Flow
+import works.iterative.claude.core.model.*
+import works.iterative.claude.core.cli.CLIArgumentBuilder
+import works.iterative.claude.direct.{Logger, Session}
+import works.iterative.claude.direct.internal.parsing.JsonParser
+import io.circe.syntax.*
+import java.io.{
+  BufferedReader,
+  BufferedWriter,
+  InputStreamReader,
+  OutputStreamWriter
+}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import scala.jdk.CollectionConverters.*
+
+/** Session implementation backed by a long-lived CLI process.
+  *
+  * The process is started in the factory method and stays alive across multiple
+  * `send` calls. A background fork captures stderr for diagnostics. The session
+  * ID is extracted from the CLI's initial SystemMessage(subtype="init") if it
+  * arrives before the first send; otherwise "pending" is used until the first
+  * ResultMessage updates it.
+  */
+private[direct] class SessionProcess(
+    process: Process,
+    stdinWriter: BufferedWriter,
+    stdoutReader: BufferedReader
+)(using logger: Logger)
+    extends Session:
+
+  private val currentSessionId = new AtomicReference[String]("pending")
+
+  def sessionId: String = currentSessionId.get()
+
+  def send(prompt: String): Flow[Message] =
+    val msg =
+      SDKUserMessage(content = prompt, sessionId = currentSessionId.get())
+    val json = msg.asJson.noSpaces
+    logger.debug(s"Writing SDKUserMessage to stdin: $json")
+    stdinWriter.write(json)
+    stdinWriter.newLine()
+    stdinWriter.flush()
+
+    Flow.usingEmit { emit =>
+      var done = false
+      var lineNumber = 0
+      while !done do
+        val line = stdoutReader.readLine()
+        if line == null then
+          logger.debug("stdout EOF reached during send")
+          done = true
+        else
+          lineNumber += 1
+          JsonParser.parseJsonLineWithContextWithLogging(line, lineNumber) match
+            case Right(Some(message)) =>
+              logger.debug(
+                s"Emitting message: ${message.getClass.getSimpleName}"
+              )
+              emit(message)
+              message match
+                case result: ResultMessage =>
+                  currentSessionId.set(result.sessionId)
+                  done = true
+                case _ => ()
+            case Right(None) => ()
+            case Left(error) =>
+              logger.error(s"JSON parsing failed: ${error.message}")
+    }
+
+  def close(): Unit =
+    logger.debug("Closing session process")
+    try stdinWriter.close()
+    catch case _: Exception => ()
+    try
+      val exited = process.waitFor(5, TimeUnit.SECONDS)
+      if !exited then
+        logger.debug("Process did not exit in time, destroying forcibly")
+        process.destroyForcibly(): Unit
+    catch
+      case _: InterruptedException =>
+        process.destroyForcibly(): Unit
+    try stdoutReader.close()
+    catch case _: Exception => ()
+
+object SessionProcess:
+
+  /** Starts a CLI process for the given options and returns a ready Session.
+    *
+    * The factory:
+    *   1. Builds CLI args from SessionOptions
+    *   2. Starts the process with stdin/stdout pipes
+    *   3. Forks stderr capture in the background
+    *   4. Reads initial stdout lines to extract the session_id from the init
+    *      SystemMessage (up to a reasonable number of lines)
+    *   5. Returns the constructed SessionProcess
+    */
+  def start(
+      executablePath: String,
+      options: SessionOptions
+  )(using logger: Logger, ox: Ox): Session =
+    // --verbose is required for stream-json output format but is not part of
+    // the core SessionOptions CLI flags (which focus on session configuration).
+    // It is added here at the process boundary, consistent with how query mode
+    // adds --verbose in ClaudeCode.buildCliArguments.
+    val args = "--verbose" :: CLIArgumentBuilder.buildSessionArgs(options)
+    logger.info(
+      s"Starting session process: $executablePath ${args.mkString(" ")}"
+    )
+
+    val processBuilder = configureSessionProcess(executablePath, args, options)
+    val process = processBuilder.start()
+
+    val stdinWriter = new BufferedWriter(
+      new OutputStreamWriter(process.getOutputStream)
+    )
+    val stdoutReader = new BufferedReader(
+      new InputStreamReader(process.getInputStream)
+    )
+
+    val _ = fork {
+      captureStderr(process)
+    }
+
+    val session = new SessionProcess(process, stdinWriter, stdoutReader)
+
+    // Attempt to read the init message from stdout to extract the session ID.
+    // If the process is a long-lived session process, it will emit the init
+    // message before waiting for stdin. If no init message arrives (or the
+    // process exits quickly), session ID stays "pending".
+    readInitMessages(process, stdoutReader).foreach { id =>
+      session.currentSessionId.set(id)
+    }
+
+    session
+
+  private val MaxInitLines = 20
+  private val InitReadTimeoutMs = 500L // Wait up to 500ms for init message
+  private val InitReadRetryDelayMs = 10L // Sleep between ready() checks
+
+  /** Reads from stdout to extract the session_id from the CLI's init message.
+    *
+    * Waits up to InitReadTimeoutMs for the process to emit an init message.
+    * Only reads if the process is still alive (to avoid consuming messages from
+    * quick-exit mock scripts used in tests). Stops as soon as the init message
+    * is found, a non-init message is encountered, or the timeout expires.
+    *
+    * If no init message is found, the session ID remains "pending" and will be
+    * updated from the first ResultMessage when `send` is called.
+    */
+  /** Reads from stdout to find the session_id in the CLI's init message.
+    *
+    * Returns the extracted session ID if an init message is found within the
+    * timeout, or None if the timeout expires, the process exits, or a non-init
+    * message is encountered first.
+    */
+  private def readInitMessages(
+      process: Process,
+      reader: BufferedReader
+  )(using logger: Logger): Option[String] =
+    val deadline = System.currentTimeMillis() + InitReadTimeoutMs
+    var linesRead = 0
+    var done = false
+    var result: Option[String] = None
+    while !done && linesRead < MaxInitLines && System
+        .currentTimeMillis() < deadline
+    do
+      if reader.ready() then
+        val line = reader.readLine()
+        if line != null then
+          linesRead += 1
+          JsonParser.parseJsonLineWithContext(line, linesRead) match
+            case Right(Some(SystemMessage("init", data))) =>
+              result = data.get("session_id").map(_.toString)
+              result.foreach { id =>
+                logger.info(s"Session ID extracted from init message: $id")
+              }
+              done = true
+            case Right(Some(_)) =>
+              // Non-init message found before init — stop (init won't come later)
+              done = true
+            case _ =>
+              () // Empty/unparseable line — continue reading
+        else done = true // EOF — process exited
+      else if !process.isAlive() then
+        done = true // Process already exited — don't wait for init
+      else Thread.sleep(InitReadRetryDelayMs) // Wait briefly for init message
+    result
+
+  private def configureSessionProcess(
+      executablePath: String,
+      args: List[String],
+      options: SessionOptions
+  ): ProcessBuilder =
+    val pb = new ProcessBuilder((executablePath :: args).asJava)
+    options.cwd.foreach { cwdPath =>
+      pb.directory(new java.io.File(cwdPath))
+    }
+    val environment = pb.environment()
+    options.inheritEnvironment match
+      case Some(false) => environment.clear()
+      case _           => ()
+    options.environmentVariables.foreach { envVars =>
+      envVars.foreach { case (k, v) => environment.put(k, v) }
+    }
+    pb
+
+  private def captureStderr(process: Process)(using
+      logger: Logger
+  ): Unit =
+    val reader =
+      new BufferedReader(new InputStreamReader(process.getErrorStream))
+    try
+      var line: String = null
+      while { line = reader.readLine(); line != null } do
+        logger.debug(s"session stderr: $line")
+    catch
+      case _: InterruptedException =>
+        // Interrupted by scope cancellation — kill the process to release the pipe
+        logger.debug("Stderr capture interrupted — destroying process")
+        process.destroyForcibly(): Unit
+      case _: Exception =>
+        logger.debug("Session stderr stream closed")
+    finally
+      try reader.close()
+      catch case _: Exception => ()

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -38,7 +38,7 @@ private[direct] class SessionProcess(
 
   def sessionId: String = currentSessionId.get()
 
-  def send(prompt: String): Flow[Message] =
+  def send(prompt: String): Unit =
     val msg =
       SDKUserMessage(content = prompt, sessionId = currentSessionId.get())
     val json = msg.asJson.noSpaces
@@ -47,13 +47,14 @@ private[direct] class SessionProcess(
     stdinWriter.newLine()
     stdinWriter.flush()
 
+  def stream(): Flow[Message] =
     Flow.usingEmit { emit =>
       var done = false
       var lineNumber = 0
       while !done do
         val line = stdoutReader.readLine()
         if line == null then
-          logger.debug("stdout EOF reached during send")
+          logger.debug("stdout EOF reached during stream")
           done = true
         else
           lineNumber += 1
@@ -143,16 +144,6 @@ object SessionProcess:
   private val InitReadTimeoutMs = 500L // Wait up to 500ms for init message
   private val InitReadRetryDelayMs = 10L // Sleep between ready() checks
 
-  /** Reads from stdout to extract the session_id from the CLI's init message.
-    *
-    * Waits up to InitReadTimeoutMs for the process to emit an init message.
-    * Only reads if the process is still alive (to avoid consuming messages from
-    * quick-exit mock scripts used in tests). Stops as soon as the init message
-    * is found, a non-init message is encountered, or the timeout expires.
-    *
-    * If no init message is found, the session ID remains "pending" and will be
-    * updated from the first ResultMessage when `send` is called.
-    */
   /** Reads from stdout to find the session_id in the CLI's init message.
     *
     * Returns the extracted session ID if an init message is found within the

--- a/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+++ b/direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
@@ -6,6 +6,7 @@ import ox.*
 import ox.flow.Flow
 import works.iterative.claude.core.model.*
 import works.iterative.claude.core.cli.CLIArgumentBuilder
+import works.iterative.claude.core.{SessionClosedError, SessionProcessDied}
 import works.iterative.claude.direct.{Logger, Session}
 import works.iterative.claude.direct.internal.parsing.JsonParser
 import io.circe.syntax.*
@@ -16,7 +17,7 @@ import java.io.{
   OutputStreamWriter
 }
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.jdk.CollectionConverters.*
 
 /** Session implementation backed by a long-lived CLI process.
@@ -34,28 +35,49 @@ private[direct] class SessionProcess(
 )(using logger: Logger)
     extends Session:
 
+  private[direct] def underlyingProcess: Process = process
+
   private val currentSessionId = new AtomicReference[String]("pending")
+  private val alive = new AtomicBoolean(true)
+
+  private def safeExitCode(): Option[Int] =
+    try Some(process.exitValue())
+    catch case _: Exception => None
 
   def sessionId: String = currentSessionId.get()
 
   def send(prompt: String): Unit =
+    if !alive.get() then throw SessionClosedError(currentSessionId.get())
+    if !process.isAlive then
+      alive.set(false)
+      throw SessionProcessDied(safeExitCode(), captureRemainingStderr())
     val msg =
       SDKUserMessage(content = prompt, sessionId = currentSessionId.get())
     val json = msg.asJson.noSpaces
     logger.debug(s"Writing SDKUserMessage to stdin: $json")
-    stdinWriter.write(json)
-    stdinWriter.newLine()
-    stdinWriter.flush()
+    try
+      stdinWriter.write(json)
+      stdinWriter.newLine()
+      stdinWriter.flush()
+    catch
+      case e: java.io.IOException =>
+        alive.set(false)
+        throw SessionProcessDied(safeExitCode(), e.getMessage)
 
   def stream(): Flow[Message] =
     Flow.usingEmit { emit =>
       var done = false
       var lineNumber = 0
+      var resultSeen = false
       while !done do
         val line = stdoutReader.readLine()
         if line == null then
           logger.debug("stdout EOF reached during stream")
           done = true
+          if !resultSeen then
+            // Unexpected EOF before ResultMessage — process died mid-turn
+            alive.set(false)
+            throw SessionProcessDied(safeExitCode(), captureRemainingStderr())
         else
           lineNumber += 1
           JsonParser.parseJsonLineWithContextWithLogging(line, lineNumber) match
@@ -67,6 +89,7 @@ private[direct] class SessionProcess(
               message match
                 case result: ResultMessage =>
                   currentSessionId.set(result.sessionId)
+                  resultSeen = true
                   done = true
                 case _ => ()
             case Right(None) => ()
@@ -75,19 +98,41 @@ private[direct] class SessionProcess(
     }
 
   def close(): Unit =
-    logger.debug("Closing session process")
-    try stdinWriter.close()
-    catch case _: Exception => ()
+    if alive.compareAndSet(true, false) then
+      logger.debug("Closing session process")
+      try stdinWriter.close()
+      catch case _: Exception => ()
+      try
+        val exited = process.waitFor(5, TimeUnit.SECONDS)
+        if !exited then
+          logger.debug("Process did not exit in time, destroying forcibly")
+          process.destroyForcibly(): Unit
+      catch
+        case _: InterruptedException =>
+          process.destroyForcibly(): Unit
+      try stdoutReader.close()
+      catch case _: Exception => ()
+    else logger.debug("close() called on already-closed session — ignoring")
+
+  /** Attempt to drain any remaining stderr for error context. Returns empty
+    * string if nothing is available.
+    */
+  private def captureRemainingStderr(): String =
+    val stderrReader =
+      new BufferedReader(new InputStreamReader(process.getErrorStream))
     try
-      val exited = process.waitFor(5, TimeUnit.SECONDS)
-      if !exited then
-        logger.debug("Process did not exit in time, destroying forcibly")
-        process.destroyForcibly(): Unit
-    catch
-      case _: InterruptedException =>
-        process.destroyForcibly(): Unit
-    try stdoutReader.close()
-    catch case _: Exception => ()
+      val sb = new StringBuilder
+      var line: String = null
+      while stderrReader.ready() && {
+          line = stderrReader.readLine(); line != null
+        }
+      do
+        val _ = sb.append(line).append("\n")
+      sb.toString().trim
+    catch case _: Exception => ""
+    finally
+      try stderrReader.close()
+      catch case _: Exception => ()
 
 object SessionProcess:
 

--- a/direct/src/works/iterative/claude/direct/internal/parsing/JsonParser.scala
+++ b/direct/src/works/iterative/claude/direct/internal/parsing/JsonParser.scala
@@ -8,7 +8,9 @@ import works.iterative.claude.core.model.{
   UserMessage,
   AssistantMessage,
   SystemMessage,
-  ResultMessage
+  ResultMessage,
+  KeepAliveMessage,
+  StreamEventMessage
 }
 import works.iterative.claude.core.parsing.{JsonParser as CoreJsonParser}
 import works.iterative.claude.direct.Logger
@@ -109,7 +111,9 @@ object JsonParser:
   /** Extract message type for logging purposes */
   private def extractMessageType(message: Message): String =
     message match
-      case _: UserMessage      => "user"
-      case _: AssistantMessage => "assistant"
-      case _: SystemMessage    => "system"
-      case _: ResultMessage    => "result"
+      case _: UserMessage        => "user"
+      case _: AssistantMessage   => "assistant"
+      case _: SystemMessage      => "system"
+      case _: ResultMessage      => "result"
+      case KeepAliveMessage      => "keep_alive"
+      case _: StreamEventMessage => "stream_event"

--- a/direct/src/works/iterative/claude/direct/package.scala
+++ b/direct/src/works/iterative/claude/direct/package.scala
@@ -7,6 +7,8 @@ package object direct:
   // Type aliases for convenient usage
   type QueryOptions = works.iterative.claude.core.model.QueryOptions
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
+  type SessionOptions = works.iterative.claude.core.model.SessionOptions
+  val SessionOptions = works.iterative.claude.core.model.SessionOptions
 
   // Re-export all model classes that users need
   type Message = works.iterative.claude.core.model.Message

--- a/direct/test/src/works/iterative/claude/direct/ClaudeCodeIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/ClaudeCodeIntegrationTest.scala
@@ -236,7 +236,6 @@ class ClaudeCodeIntegrationTest extends munit.FunSuite:
 
       // Explicit environmental assumptions - fail fast if prerequisites aren't met
       assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
-      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
       assume(
         hasApiKeyOrMockSetup(),
         "Test requires API key configuration or mock setup"
@@ -283,16 +282,6 @@ class ClaudeCodeIntegrationTest extends munit.FunSuite:
   private def isClaudeCliInstalled(): Boolean = {
     try {
       val process = ProcessBuilder("claude", "--version").start()
-      val exitCode = process.waitFor()
-      exitCode == 0
-    } catch {
-      case _: Exception => false
-    }
-  }
-
-  private def isNodeJsAvailable(): Boolean = {
-    try {
-      val process = ProcessBuilder("node", "--version").start()
       val exitCode = process.waitFor()
       exitCode == 0
     } catch {

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -14,12 +14,6 @@ class SessionE2ETest extends munit.FunSuite:
       process.waitFor() == 0
     catch case _: Exception => false
 
-  private def isNodeJsAvailable(): Boolean =
-    try
-      val process = ProcessBuilder("node", "--version").start()
-      process.waitFor() == 0
-    catch case _: Exception => false
-
   private def hasApiKeyOrCredentials(): Boolean =
     val hasApiKey = sys.env.contains("ANTHROPIC_API_KEY")
     val homeDir = sys.env.get("HOME").orElse(sys.env.get("USERPROFILE"))
@@ -29,15 +23,17 @@ class SessionE2ETest extends munit.FunSuite:
     }
     hasApiKey || hasCredentials
 
+  private def assumeClaudeAvailable(): Unit =
+    assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+    assume(
+      hasApiKeyOrCredentials(),
+      "Test requires API key or credentials file"
+    )
+
   test("E2E: real CLI session completes a single turn") {
     given logger: MockLogger = MockLogger()
     supervised {
-      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
-      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
-      assume(
-        hasApiKeyOrCredentials(),
-        "Test requires API key or credentials file"
-      )
+      assumeClaudeAvailable()
 
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
@@ -58,15 +54,48 @@ class SessionE2ETest extends munit.FunSuite:
     }
   }
 
+  test("E2E: two-turn conversation preserves context across turns") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assumeClaudeAvailable()
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val _ =
+          session
+            .send("Remember the number 42. Reply only with 'OK'.")
+            .runToList()
+
+        val secondTurnMessages =
+          session
+            .send(
+              "What number did I ask you to remember? Reply with just the number."
+            )
+            .runToList()
+
+        val assistantMessages =
+          secondTurnMessages.collect { case a: AssistantMessage => a }
+        assert(
+          assistantMessages.nonEmpty,
+          "Expected AssistantMessage in second turn"
+        )
+
+        val responseText = assistantMessages
+          .flatMap(_.content.collect { case TextBlock(t) => t })
+          .mkString
+        assert(
+          responseText.contains("42"),
+          s"Expected second turn to reference '42', got: $responseText"
+        )
+      finally session.close()
+    }
+  }
+
   test("E2E: session ID is a valid non-pending value after first turn") {
     given logger: MockLogger = MockLogger()
     supervised {
-      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
-      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
-      assume(
-        hasApiKeyOrCredentials(),
-        "Test requires API key or credentials file"
-      )
+      assumeClaudeAvailable()
 
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
@@ -81,6 +110,49 @@ class SessionE2ETest extends munit.FunSuite:
         assert(
           session.sessionId.nonEmpty,
           "Session ID should not be empty after first turn"
+        )
+      finally session.close()
+    }
+  }
+
+  test(
+    "E2E: session ID remains valid and non-pending across multiple turns"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assumeClaudeAvailable()
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val _ =
+          session.send("What is 1+1? Reply with just the number.").runToList()
+        val afterFirstTurn = session.sessionId
+
+        val _ =
+          session.send("What is 2+2? Reply with just the number.").runToList()
+        val afterSecondTurn = session.sessionId
+
+        assert(
+          afterFirstTurn != "pending",
+          s"Session ID should be non-pending after first turn, got: $afterFirstTurn"
+        )
+        assert(
+          afterFirstTurn.nonEmpty,
+          "Session ID should not be empty after first turn"
+        )
+        assert(
+          afterSecondTurn != "pending",
+          s"Session ID should be non-pending after second turn, got: $afterSecondTurn"
+        )
+        assert(
+          afterSecondTurn.nonEmpty,
+          "Session ID should not be empty after second turn"
+        )
+        assertEquals(
+          afterFirstTurn,
+          afterSecondTurn,
+          "Session ID should remain stable across turns in the same session"
         )
       finally session.close()
     }

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -38,8 +38,8 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val messages =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val messages = session.stream().runToList()
 
         assert(messages.nonEmpty, "Expected messages from real CLI session")
         assert(
@@ -62,17 +62,13 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session
-            .send("Remember the number 42. Reply only with 'OK'.")
-            .runToList()
+        session.send("Remember the number 42. Reply only with 'OK'.")
+        val _ = session.stream().runToList()
 
-        val secondTurnMessages =
-          session
-            .send(
-              "What number did I ask you to remember? Reply with just the number."
-            )
-            .runToList()
+        session.send(
+          "What number did I ask you to remember? Reply with just the number."
+        )
+        val secondTurnMessages = session.stream().runToList()
 
         val assistantMessages =
           secondTurnMessages.collect { case a: AssistantMessage => a }
@@ -100,8 +96,8 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val _ = session.stream().runToList()
 
         assert(
           session.sessionId != "pending",
@@ -125,12 +121,12 @@ class SessionE2ETest extends munit.FunSuite:
       val options = SessionOptions()
       val session = ClaudeCode.session(options)
       try
-        val _ =
-          session.send("What is 1+1? Reply with just the number.").runToList()
+        session.send("What is 1+1? Reply with just the number.")
+        val _ = session.stream().runToList()
         val afterFirstTurn = session.sessionId
 
-        val _ =
-          session.send("What is 2+2? Reply with just the number.").runToList()
+        session.send("What is 2+2? Reply with just the number.")
+        val _ = session.stream().runToList()
         val afterSecondTurn = session.sessionId
 
         assert(

--- a/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
@@ -1,0 +1,87 @@
+// PURPOSE: End-to-end tests for Session using the real Claude Code CLI
+// PURPOSE: Tests are gated on CLI availability and skip gracefully when not present
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.MockLogger
+
+class SessionE2ETest extends munit.FunSuite:
+
+  private def isClaudeCliInstalled(): Boolean =
+    try
+      val process = ProcessBuilder("claude", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def isNodeJsAvailable(): Boolean =
+    try
+      val process = ProcessBuilder("node", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def hasApiKeyOrCredentials(): Boolean =
+    val hasApiKey = sys.env.contains("ANTHROPIC_API_KEY")
+    val homeDir = sys.env.get("HOME").orElse(sys.env.get("USERPROFILE"))
+    val hasCredentials = homeDir.exists { home =>
+      val path = java.nio.file.Paths.get(home, ".claude", ".credentials.json")
+      java.nio.file.Files.exists(path)
+    }
+    hasApiKey || hasCredentials
+
+  test("E2E: real CLI session completes a single turn") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
+      assume(
+        hasApiKeyOrCredentials(),
+        "Test requires API key or credentials file"
+      )
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val messages =
+          session.send("What is 1+1? Reply with just the number.").runToList()
+
+        assert(messages.nonEmpty, "Expected messages from real CLI session")
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          "Expected AssistantMessage in response"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          "Expected ResultMessage signalling end of turn"
+        )
+      finally session.close()
+    }
+  }
+
+  test("E2E: session ID is a valid non-pending value after first turn") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+      assume(isNodeJsAvailable(), "Test requires Node.js to be available")
+      assume(
+        hasApiKeyOrCredentials(),
+        "Test requires API key or credentials file"
+      )
+
+      val options = SessionOptions()
+      val session = ClaudeCode.session(options)
+      try
+        val _ =
+          session.send("What is 1+1? Reply with just the number.").runToList()
+
+        assert(
+          session.sessionId != "pending",
+          s"Expected a real session ID after first turn, got: ${session.sessionId}"
+        )
+        assert(
+          session.sessionId.nonEmpty,
+          "Session ID should not be empty after first turn"
+        )
+      finally session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala
@@ -1,0 +1,187 @@
+// PURPOSE: Integration tests for direct Session error handling with mock CLI scripts
+// PURPOSE: Verifies process crash, between-turn crash, and malformed JSON resilience
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.SessionProcessDied
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.{
+  MockLogger,
+  SessionMockCliScript
+}
+import java.nio.file.Path
+
+class SessionErrorIntegrationTest extends munit.FunSuite:
+
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach { path =>
+      val _ = SessionMockCliScript.cleanup(path)
+    }
+    createdScripts.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // I1: Process crash mid-turn surfaces SessionProcessDied with exit code
+  // ============================================================
+
+  test(
+    "process crash mid-turn: stream() raises SessionProcessDied with exit code"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val exitCode = 42
+      val script = SessionMockCliScript.createCrashMidTurnScript(exitCode)
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      session.send("trigger partial response then crash")
+
+      val caught = intercept[SessionProcessDied] {
+        session.stream().runToList()
+      }
+
+      assertEquals(
+        caught.exitCode,
+        Some(exitCode),
+        s"Expected exit code $exitCode, got: ${caught.exitCode}"
+      )
+
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // I2: Process crash between turns raises SessionProcessDied on next send
+  // ============================================================
+
+  test("process crash between turns: second send raises SessionProcessDied") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script =
+        SessionMockCliScript.createCrashBetweenTurnsScript(exitCode = 1)
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      // First turn should complete normally
+      session.send("First prompt")
+      val turn1Messages = session.stream().runToList()
+      assert(
+        turn1Messages.exists(_.isInstanceOf[ResultMessage]),
+        s"Expected ResultMessage in turn 1: $turn1Messages"
+      )
+
+      // Wait for the process to actually exit (up to 5 seconds)
+      val proc = session
+        .asInstanceOf[
+          works.iterative.claude.direct.internal.cli.SessionProcess
+        ]
+        .underlyingProcess
+      val exited = proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+      assert(exited, "Process should have exited within timeout")
+
+      // Second send or stream should fail because the process exited
+      val caught = intercept[SessionProcessDied] {
+        session.send("Second prompt - process is dead")
+      }
+      assertEquals(
+        caught.exitCode,
+        Some(1),
+        s"Expected exit code 1, got: ${caught.exitCode}"
+      )
+
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // I3: Malformed JSON recovery: valid messages arrive despite bad lines
+  // ============================================================
+
+  test(
+    "malformed JSON recovery: bad JSON line followed by valid messages; valid messages arrive"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createMalformedJsonMidTurnScript()
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      session.send("test")
+      val messages = session.stream().runToList()
+
+      assert(
+        messages.exists(_.isInstanceOf[AssistantMessage]),
+        s"Expected AssistantMessage: $messages"
+      )
+      assert(
+        messages.exists(_.isInstanceOf[ResultMessage]),
+        s"Expected ResultMessage: $messages"
+      )
+
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // I4: Multiple malformed lines do not accumulate errors
+  // ============================================================
+
+  test(
+    "multiple malformed JSON lines do not accumulate errors; all valid messages arrive"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = SessionMockCliScript.CommonResponses.initSessionId
+      // Turn with several bad JSON lines interspersed with valid messages
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(SessionMockCliScript.CommonResponses.initMessage()),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              "{bad json 1}",
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "First valid message"
+              ),
+              "{bad json 2}",
+              "{bad json 3}",
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Second valid message"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      session.send("test")
+      val messages = session.stream().runToList()
+
+      val assistantMessages = messages.collect { case a: AssistantMessage => a }
+      assertEquals(
+        assistantMessages.length,
+        2,
+        s"Expected 2 AssistantMessages, got: $messages"
+      )
+
+      val resultMessages = messages.collect { case r: ResultMessage => r }
+      assertEquals(
+        resultMessages.length,
+        1,
+        s"Expected 1 ResultMessage, got: $messages"
+      )
+
+      session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala
@@ -1,0 +1,159 @@
+// PURPOSE: Tests for session error handling in the direct (Ox) API
+// PURPOSE: Covers process crash, closed session, and malformed JSON scenarios
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.{SessionClosedError, SessionProcessDied}
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.{
+  MockLogger,
+  SessionMockCliScript
+}
+import java.nio.file.Path
+
+class SessionErrorTest extends munit.FunSuite:
+
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach { path =>
+      val _ = SessionMockCliScript.cleanup(path)
+    }
+    createdScripts.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // E1: send after close() throws SessionClosedError
+  // ============================================================
+
+  test("send after close() throws SessionClosedError") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = Nil
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      session.close()
+
+      val caught = intercept[SessionClosedError] {
+        session.send("should fail")
+      }
+      assert(
+        caught.message.contains("closed"),
+        s"Expected 'closed' in message: ${caught.message}"
+      )
+    }
+  }
+
+  // ============================================================
+  // E2: close() is idempotent
+  // ============================================================
+
+  test("close() is idempotent - calling it twice does not throw") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = Nil
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      session.close()
+      session.close() // should not throw
+    }
+  }
+
+  // ============================================================
+  // E3: send to dead process throws SessionProcessDied
+  // ============================================================
+
+  test("send to a dead process throws SessionProcessDied") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      // Script that exits immediately without reading stdin
+      val script = SessionMockCliScript.createImmediateExitScript(exitCode = 1)
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      // Wait for the process to actually exit (up to 5 seconds)
+      val proc = session
+        .asInstanceOf[
+          works.iterative.claude.direct.internal.cli.SessionProcess
+        ]
+        .underlyingProcess
+      val exited = proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+      assert(exited, "Process should have exited within timeout")
+
+      val _ = intercept[SessionProcessDied] {
+        session.send("should fail - process is dead")
+      }
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // E4: stream raises SessionProcessDied when process exits mid-turn
+  // ============================================================
+
+  test(
+    "stream raises SessionProcessDied when process exits mid-turn (before ResultMessage)"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createCrashMidTurnScript(exitCode = 1)
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      session.send("trigger the crash")
+
+      val _ = intercept[SessionProcessDied] {
+        session.stream().runToList()
+      }
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // E5: Malformed JSON line mid-turn is skipped and stream completes normally
+  // ============================================================
+
+  test(
+    "malformed JSON line mid-turn is skipped and stream completes with valid messages"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createMalformedJsonMidTurnScript()
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+
+      session.send("test")
+      val messages = session.stream().runToList()
+
+      // Should have received the valid assistant message + result, not crash on the bad line
+      assert(
+        messages.exists(_.isInstanceOf[AssistantMessage]),
+        s"Expected AssistantMessage in stream: $messages"
+      )
+
+      val resultMessages = messages.collect { case r: ResultMessage => r }
+      assertEquals(
+        resultMessages.length,
+        1,
+        s"Expected exactly 1 ResultMessage, got: $messages"
+      )
+
+      session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -1,0 +1,274 @@
+// PURPOSE: Integration tests for Session using mock CLI scripts that simulate stream-json protocol
+// PURPOSE: Verifies full send/receive lifecycle, stdin JSON format, and session ID extraction
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.{
+  MockLogger,
+  SessionMockCliScript
+}
+import java.nio.file.{Files, Path}
+
+class SessionIntegrationTest extends munit.FunSuite:
+
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+  private val createdFiles = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach(SessionMockCliScript.cleanup)
+    createdFiles.foreach(p => if Files.exists(p) then Files.delete(p))
+    createdScripts.clear()
+    createdFiles.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // IT1: Full single-turn session lifecycle
+  // ============================================================
+
+  test("full single-turn session lifecycle with mock CLI") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "integ-session-001"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "The answer is 42"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("What is the answer?").runToList()
+
+        // Should have assistant + result
+        assertEquals(messages.length, 2)
+
+        messages.head match
+          case AssistantMessage(content) =>
+            val texts = content.collect { case TextBlock(t) => t }
+            assert(texts.exists(_.contains("The answer is 42")))
+          case other => fail(s"Expected AssistantMessage, got: $other")
+
+        messages.last match
+          case ResultMessage(
+                subtype,
+                _,
+                _,
+                isError,
+                _,
+                resultSessionId,
+                _,
+                _,
+                _
+              ) =>
+            assertEquals(subtype, "conversation_result")
+            assertEquals(isError, false)
+            assertEquals(resultSessionId, sessionId)
+          case other => fail(s"Expected ResultMessage, got: $other")
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT2: Mock CLI receives correct stdin JSON
+  // ============================================================
+
+  test("mock CLI receives correct SDKUserMessage JSON on stdin") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val captureFile = Files.createTempFile("stdin-capture-", ".jsonl")
+      createdFiles += captureFile
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage()
+            )
+          )
+        ),
+        captureStdinFile = Some(captureFile)
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val _ = session.send("Hello from test").runToList()
+      finally session.close()
+
+      val capturedLines = Files.readAllLines(captureFile)
+      assert(
+        capturedLines.size >= 1,
+        "Expected at least one stdin line captured"
+      )
+
+      val firstLine = capturedLines.get(0)
+      import io.circe.parser
+      val json = parser
+        .parse(firstLine)
+        .toOption
+        .getOrElse(
+          fail(s"stdin line was not valid JSON: $firstLine")
+        )
+      val cursor = json.hcursor
+      assertEquals(
+        cursor.downField("type").as[String].toOption,
+        Some("user")
+      )
+      assertEquals(
+        cursor
+          .downField("message")
+          .downField("content")
+          .as[String]
+          .toOption,
+        Some("Hello from test")
+      )
+    }
+  }
+
+  // ============================================================
+  // IT3: Session extracts session ID from init message
+  // ============================================================
+
+  test("session extracts session ID from init SystemMessage") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val expectedSessionId = "extracted-from-init-999"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage(
+                expectedSessionId
+              )
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        // Session ID should be extracted from init message before any send
+        assertEquals(session.sessionId, expectedSessionId)
+      finally
+        session.close()
+    }
+  }
+
+  // ============================================================
+  // IT4: KeepAlive and StreamEvent messages emitted in Flow
+  // ============================================================
+
+  test("KeepAlive and StreamEvent messages are emitted in the Flow") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "keepalive-stream-session"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.keepAliveMessage,
+              SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Answer with events"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("test").runToList()
+
+        assert(
+          messages.exists(_ == KeepAliveMessage),
+          s"Expected KeepAliveMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[StreamEventMessage]),
+          s"Expected StreamEventMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          s"Expected AssistantMessage in flow: $messages"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          s"Expected ResultMessage in flow: $messages"
+        )
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT5: ClaudeCode.session factory creates a working session
+  // ============================================================
+
+  test(
+    "ClaudeCode.session factory creates a working session via instance API"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "factory-session-002"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Factory response"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+
+      // Use the instance API (ClaudeCode class)
+      val claude = ClaudeCode.concurrent
+      val session = claude.session(options)
+      try
+        val messages = session.send("factory test").runToList()
+
+        assert(
+          messages.exists(_.isInstanceOf[AssistantMessage]),
+          "Expected AssistantMessage from factory session"
+        )
+        assert(
+          messages.exists(_.isInstanceOf[ResultMessage]),
+          "Expected ResultMessage from factory session"
+        )
+      finally session.close()
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -8,6 +8,7 @@ import works.iterative.claude.direct.internal.testing.{
   MockLogger,
   SessionMockCliScript
 }
+import io.circe.parser
 import java.nio.file.{Files, Path}
 
 class SessionIntegrationTest extends munit.FunSuite:
@@ -117,7 +118,6 @@ class SessionIntegrationTest extends munit.FunSuite:
       )
 
       val firstLine = capturedLines.get(0)
-      import io.circe.parser
       val json = parser
         .parse(firstLine)
         .toOption
@@ -268,6 +268,230 @@ class SessionIntegrationTest extends munit.FunSuite:
         assert(
           messages.exists(_.isInstanceOf[ResultMessage]),
           "Expected ResultMessage from factory session"
+        )
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT6: Full two-turn session lifecycle
+  // ============================================================
+
+  test("full two-turn session lifecycle with mock CLI") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val initSessionId = "two-turn-init-001"
+      val turn1SessionId = "two-turn-result-001"
+      val turn2SessionId = "two-turn-result-002"
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "First turn answer"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+            )
+          ),
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage(
+                "Second turn answer"
+              ),
+              SessionMockCliScript.CommonResponses.resultMessage(turn2SessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        // Init message is consumed before any send
+        assertEquals(session.sessionId, initSessionId)
+
+        val turn1Messages = session.send("First question").runToList()
+        assertEquals(turn1Messages.length, 2)
+        turn1Messages.head match
+          case AssistantMessage(content) =>
+            val texts = content.collect { case TextBlock(t) => t }
+            assert(texts.exists(_.contains("First turn answer")))
+          case other => fail(s"Expected AssistantMessage, got: $other")
+        turn1Messages.last match
+          case r: ResultMessage => assertEquals(r.sessionId, turn1SessionId)
+          case other            => fail(s"Expected ResultMessage, got: $other")
+
+        assertEquals(session.sessionId, turn1SessionId)
+
+        val turn2Messages = session.send("Second question").runToList()
+        assertEquals(turn2Messages.length, 2)
+        turn2Messages.head match
+          case AssistantMessage(content) =>
+            val texts = content.collect { case TextBlock(t) => t }
+            assert(texts.exists(_.contains("Second turn answer")))
+          case other => fail(s"Expected AssistantMessage, got: $other")
+        turn2Messages.last match
+          case r: ResultMessage => assertEquals(r.sessionId, turn2SessionId)
+          case other            => fail(s"Expected ResultMessage, got: $other")
+
+        assertEquals(session.sessionId, turn2SessionId)
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // IT7: Stdin capture shows correct session ID progression
+  // ============================================================
+
+  test("stdin capture shows correct session ID progression across turns") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val initSessionId = "progression-init-001"
+      val turn1SessionId = "progression-turn-001"
+
+      val captureFile = Files.createTempFile("stdin-progression-", ".jsonl")
+      createdFiles += captureFile
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+        ),
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+            )
+          ),
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.resultMessage(
+                "progression-turn-002"
+              )
+            )
+          )
+        ),
+        captureStdinFile = Some(captureFile)
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        assertEquals(session.sessionId, initSessionId)
+        val _ = session.send("Prompt one").runToList()
+        val _ = session.send("Prompt two").runToList()
+      finally session.close()
+
+      val lines = Files.readAllLines(captureFile)
+      assert(
+        lines.size >= 2,
+        s"Expected at least 2 stdin lines, got ${lines.size}"
+      )
+
+      val firstJson = parser
+        .parse(lines.get(0))
+        .toOption
+        .getOrElse(fail(s"First stdin line not valid JSON: ${lines.get(0)}"))
+      assertEquals(
+        firstJson.hcursor.downField("session_id").as[String].toOption,
+        Some(initSessionId),
+        "First send should carry init session ID"
+      )
+
+      val secondJson = parser
+        .parse(lines.get(1))
+        .toOption
+        .getOrElse(fail(s"Second stdin line not valid JSON: ${lines.get(1)}"))
+      assertEquals(
+        secondJson.hcursor.downField("session_id").as[String].toOption,
+        Some(turn1SessionId),
+        "Second send should carry session ID from first turn's ResultMessage"
+      )
+    }
+  }
+
+  // ============================================================
+  // IT8: Turn responses with different message counts
+  // ============================================================
+
+  test("turns with different message counts emit exactly the right messages") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "msg-count-session"
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = List(
+          SessionMockCliScript.CommonResponses.initMessage(sessionId)
+        ),
+        turnResponses = List(
+          // Turn 1: just assistant + result (2 messages)
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.assistantMessage("Short"),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          ),
+          // Turn 2: keepalive + stream_event + assistant + result (4 messages)
+          SessionMockCliScript.TurnResponse(
+            List(
+              SessionMockCliScript.CommonResponses.keepAliveMessage,
+              SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+              SessionMockCliScript.CommonResponses.assistantMessage("Verbose"),
+              SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val turn1Messages = session.send("Short turn").runToList()
+        assertEquals(
+          turn1Messages.length,
+          2,
+          s"Turn 1 should have 2 messages, got: $turn1Messages"
+        )
+        assert(
+          turn1Messages.exists(_.isInstanceOf[AssistantMessage]),
+          "Turn 1 must contain AssistantMessage"
+        )
+        assert(
+          turn1Messages.exists(_.isInstanceOf[ResultMessage]),
+          "Turn 1 must contain ResultMessage"
+        )
+        assert(
+          !turn1Messages.exists(_ == KeepAliveMessage),
+          "Turn 1 must not contain KeepAliveMessage"
+        )
+
+        val turn2Messages = session.send("Verbose turn").runToList()
+        assertEquals(
+          turn2Messages.length,
+          4,
+          s"Turn 2 should have 4 messages, got: $turn2Messages"
+        )
+        // Verify ordering: keepalive, stream_event, assistant, result
+        assert(
+          turn2Messages(0) == KeepAliveMessage,
+          s"Turn 2 message 0 should be KeepAliveMessage, got: ${turn2Messages(0)}"
+        )
+        assert(
+          turn2Messages(1).isInstanceOf[StreamEventMessage],
+          s"Turn 2 message 1 should be StreamEventMessage, got: ${turn2Messages(1)}"
+        )
+        assert(
+          turn2Messages(2).isInstanceOf[AssistantMessage],
+          s"Turn 2 message 2 should be AssistantMessage, got: ${turn2Messages(2)}"
+        )
+        assert(
+          turn2Messages(3).isInstanceOf[ResultMessage],
+          s"Turn 2 message 3 should be ResultMessage, got: ${turn2Messages(3)}"
         )
       finally session.close()
     }

--- a/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
@@ -51,7 +51,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("What is the answer?").runToList()
+        session.send("What is the answer?")
+        val messages = session.stream().runToList()
 
         // Should have assistant + result
         assertEquals(messages.length, 2)
@@ -108,7 +109,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("Hello from test").runToList()
+        session.send("Hello from test")
+        val _ = session.stream().runToList()
       finally session.close()
 
       val capturedLines = Files.readAllLines(captureFile)
@@ -204,7 +206,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("test").runToList()
+        session.send("test")
+        val messages = session.stream().runToList()
 
         assert(
           messages.exists(_ == KeepAliveMessage),
@@ -259,7 +262,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val claude = ClaudeCode.concurrent
       val session = claude.session(options)
       try
-        val messages = session.send("factory test").runToList()
+        session.send("factory test")
+        val messages = session.stream().runToList()
 
         assert(
           messages.exists(_.isInstanceOf[AssistantMessage]),
@@ -315,7 +319,8 @@ class SessionIntegrationTest extends munit.FunSuite:
         // Init message is consumed before any send
         assertEquals(session.sessionId, initSessionId)
 
-        val turn1Messages = session.send("First question").runToList()
+        session.send("First question")
+        val turn1Messages = session.stream().runToList()
         assertEquals(turn1Messages.length, 2)
         turn1Messages.head match
           case AssistantMessage(content) =>
@@ -328,7 +333,8 @@ class SessionIntegrationTest extends munit.FunSuite:
 
         assertEquals(session.sessionId, turn1SessionId)
 
-        val turn2Messages = session.send("Second question").runToList()
+        session.send("Second question")
+        val turn2Messages = session.stream().runToList()
         assertEquals(turn2Messages.length, 2)
         turn2Messages.head match
           case AssistantMessage(content) =>
@@ -383,8 +389,10 @@ class SessionIntegrationTest extends munit.FunSuite:
       val session = ClaudeCode.session(options)
       try
         assertEquals(session.sessionId, initSessionId)
-        val _ = session.send("Prompt one").runToList()
-        val _ = session.send("Prompt two").runToList()
+        session.send("Prompt one")
+        val _ = session.stream().runToList()
+        session.send("Prompt two")
+        val _ = session.stream().runToList()
       finally session.close()
 
       val lines = Files.readAllLines(captureFile)
@@ -451,7 +459,8 @@ class SessionIntegrationTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val turn1Messages = session.send("Short turn").runToList()
+        session.send("Short turn")
+        val turn1Messages = session.stream().runToList()
         assertEquals(
           turn1Messages.length,
           2,
@@ -470,7 +479,8 @@ class SessionIntegrationTest extends munit.FunSuite:
           "Turn 1 must not contain KeepAliveMessage"
         )
 
-        val turn2Messages = session.send("Verbose turn").runToList()
+        session.send("Verbose turn")
+        val turn2Messages = session.stream().runToList()
         assertEquals(
           turn2Messages.length,
           4,

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -11,19 +11,22 @@ import works.iterative.claude.direct.internal.testing.{
 }
 import io.circe.syntax.*
 import io.circe.parser
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 class SessionTest extends munit.FunSuite:
 
   // Track created mock scripts for cleanup
   private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+  private val createdFiles = scala.collection.mutable.ListBuffer[Path]()
 
   override def afterEach(context: AfterEach): Unit =
     createdScripts.foreach { path =>
       val _ = MockCliScript.cleanup(path)
       val _ = SessionMockCliScript.cleanup(path)
     }
+    createdFiles.foreach(p => if Files.exists(p) then Files.delete(p))
     createdScripts.clear()
+    createdFiles.clear()
     super.afterEach(context)
 
   // ============================================================
@@ -193,6 +196,228 @@ class SessionTest extends munit.FunSuite:
 
         // After send completes, session ID should be updated from ResultMessage
         assertEquals(session.sessionId, "updated-session-id-456")
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T8: Two sequential sends return isolated message streams
+  // ============================================================
+
+  test("two sequential sends return isolated message streams") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val turn1Response =
+        """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 1 response"}]}}"""
+      val turn1Result =
+        """{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"session-turn-1"}"""
+      val turn2Response =
+        """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 2 response"}]}}"""
+      val turn2Result =
+        """{"type":"result","subtype":"conversation_result","duration_ms":150,"duration_api_ms":60,"is_error":false,"num_turns":2,"session_id":"session-turn-2"}"""
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(List(turn1Response, turn1Result)),
+          SessionMockCliScript.TurnResponse(List(turn2Response, turn2Result))
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val turn1Messages = session.send("First prompt").runToList()
+        val turn2Messages = session.send("Second prompt").runToList()
+
+        // Turn 1 should have exactly assistant + result
+        assertEquals(turn1Messages.length, 2)
+        val turn1Assistants =
+          turn1Messages.collect { case a: AssistantMessage => a }
+        assertEquals(turn1Assistants.length, 1)
+        val turn1Results = turn1Messages.collect { case r: ResultMessage => r }
+        assertEquals(turn1Results.length, 1)
+
+        // Turn 2 should have exactly assistant + result — no bleed from turn 1
+        assertEquals(turn2Messages.length, 2)
+        val turn2Assistants =
+          turn2Messages.collect { case a: AssistantMessage => a }
+        assertEquals(turn2Assistants.length, 1)
+        val turn2Results = turn2Messages.collect { case r: ResultMessage => r }
+        assertEquals(turn2Results.length, 1)
+
+        // Confirm different content per turn
+        val turn1Texts = turn1Assistants.flatMap(_.content.collect {
+          case TextBlock(t) => t
+        })
+        assert(
+          turn1Texts.exists(_.contains("Turn 1")),
+          s"Expected 'Turn 1' text in turn 1: $turn1Texts"
+        )
+        val turn2Texts = turn2Assistants.flatMap(_.content.collect {
+          case TextBlock(t) => t
+        })
+        assert(
+          turn2Texts.exists(_.contains("Turn 2")),
+          s"Expected 'Turn 2' text in turn 2: $turn2Texts"
+        )
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T9: Session ID propagates from first ResultMessage to second send
+  // ============================================================
+
+  test(
+    "session ID propagates from first turn ResultMessage to second send SDKUserMessage"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val firstTurnSessionId = "session-after-turn-1"
+      val captureFile =
+        Files.createTempFile("stdin-capture-unit-", ".jsonl")
+      createdFiles += captureFile
+
+      val turn1Result =
+        s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$firstTurnSessionId"}"""
+      val turn2Result =
+        s"""{"type":"result","subtype":"conversation_result","duration_ms":120,"duration_api_ms":55,"is_error":false,"num_turns":2,"session_id":"session-after-turn-2"}"""
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(List(turn1Result)),
+          SessionMockCliScript.TurnResponse(List(turn2Result))
+        ),
+        captureStdinFile = Some(captureFile)
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val _ = session.send("First prompt").runToList()
+
+        // After first send, sessionId must be updated from the ResultMessage
+        assertEquals(session.sessionId, firstTurnSessionId)
+
+        val _ = session.send("Second prompt").runToList()
+      finally session.close()
+
+      // Verify the second SDKUserMessage sent to stdin contained the first turn's session ID
+      val lines = Files.readAllLines(captureFile)
+      assert(
+        lines.size >= 2,
+        s"Expected at least 2 stdin lines, got ${lines.size}"
+      )
+
+      val secondLine = lines.get(1)
+      val secondJson = parser
+        .parse(secondLine)
+        .toOption
+        .getOrElse(fail(s"Second stdin line was not valid JSON: $secondLine"))
+      assertEquals(
+        secondJson.hcursor.downField("session_id").as[String].toOption,
+        Some(firstTurnSessionId)
+      )
+    }
+  }
+
+  // ============================================================
+  // T10: Session ID updates after each turn
+  // ============================================================
+
+  test(
+    "session ID is updated after each turn to reflect the most recent ResultMessage"
+  ) {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val turn1SessionId = "session-id-from-turn-1"
+      val turn2SessionId = "session-id-from-turn-2"
+
+      val turn1Result =
+        s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$turn1SessionId"}"""
+      val turn2Result =
+        s"""{"type":"result","subtype":"conversation_result","duration_ms":120,"duration_api_ms":55,"is_error":false,"num_turns":2,"session_id":"$turn2SessionId"}"""
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(List(turn1Result)),
+          SessionMockCliScript.TurnResponse(List(turn2Result))
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val _ = session.send("First prompt").runToList()
+        assertEquals(session.sessionId, turn1SessionId)
+
+        val _ = session.send("Second prompt").runToList()
+        assertEquals(session.sessionId, turn2SessionId)
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T11: Three sequential sends work correctly
+  // ============================================================
+
+  test("three sequential sends each return only their own turn's messages") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val turns = (1 to 3).map { i =>
+        SessionMockCliScript.TurnResponse(
+          List(
+            s"""{"type":"assistant","message":{"content":[{"type":"text","text":"Response $i"}]}}""",
+            s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":$i,"session_id":"session-turn-$i"}"""
+          )
+        )
+      }.toList
+
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = turns
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val results = (1 to 3).map { i =>
+          val messages = session.send(s"Prompt $i").runToList()
+          // Each turn must end with its own ResultMessage
+          val resultMsg = messages
+            .collectFirst { case r: ResultMessage => r }
+            .getOrElse(fail(s"Turn $i: expected ResultMessage"))
+          assertEquals(
+            resultMsg.sessionId,
+            s"session-turn-$i",
+            s"Turn $i: wrong session ID in ResultMessage"
+          )
+          // Each turn must have exactly 2 messages in order: assistant, then result
+          assertEquals(
+            messages.length,
+            2,
+            s"Turn $i: expected 2 messages, got ${messages.length}"
+          )
+          assert(
+            messages.head.isInstanceOf[AssistantMessage],
+            s"Turn $i: first message should be AssistantMessage, got ${messages.head}"
+          )
+          assert(
+            messages.last.isInstanceOf[ResultMessage],
+            s"Turn $i: last message should be ResultMessage, got ${messages.last}"
+          )
+          messages
+        }
+
+        // No bleed: all three turn flows are independent
+        assertEquals(results.length, 3)
       finally session.close()
     }
   }

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -455,10 +455,9 @@ class SessionTest extends munit.FunSuite:
       // after close(), sending should fail because stdin is closed
       session.close()
 
-      // Verify the session is no longer usable — send should throw because
-      // the underlying stdin writer is closed
-      intercept[Exception] {
+      // Verify the session is no longer usable — send should throw SessionClosedError
+      intercept[works.iterative.claude.core.SessionClosedError] {
         session.send("should fail")
-      }
+      }: Unit
     }
   }

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -152,7 +152,8 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val messages = session.send("test").runToList()
+        session.send("test")
+        val messages = session.stream().runToList()
 
         // Should have assistant + result only
         val resultMessages = messages.collect { case r: ResultMessage => r }
@@ -191,10 +192,11 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        // Run the flow to completion
-        val _ = session.send("test").runToList()
+        // Run the stream to completion
+        session.send("test")
+        val _ = session.stream().runToList()
 
-        // After send completes, session ID should be updated from ResultMessage
+        // After stream completes, session ID should be updated from ResultMessage
         assertEquals(session.sessionId, "updated-session-id-456")
       finally session.close()
     }
@@ -228,8 +230,10 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val turn1Messages = session.send("First prompt").runToList()
-        val turn2Messages = session.send("Second prompt").runToList()
+        session.send("First prompt")
+        val turn1Messages = session.stream().runToList()
+        session.send("Second prompt")
+        val turn2Messages = session.stream().runToList()
 
         // Turn 1 should have exactly assistant + result
         assertEquals(turn1Messages.length, 2)
@@ -298,12 +302,14 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("First prompt").runToList()
+        session.send("First prompt")
+        val _ = session.stream().runToList()
 
-        // After first send, sessionId must be updated from the ResultMessage
+        // After first turn, sessionId must be updated from the ResultMessage
         assertEquals(session.sessionId, firstTurnSessionId)
 
-        val _ = session.send("Second prompt").runToList()
+        session.send("Second prompt")
+        val _ = session.stream().runToList()
       finally session.close()
 
       // Verify the second SDKUserMessage sent to stdin contained the first turn's session ID
@@ -354,10 +360,12 @@ class SessionTest extends munit.FunSuite:
       val options = SessionOptions().withClaudeExecutable(script.toString)
       val session = ClaudeCode.session(options)
       try
-        val _ = session.send("First prompt").runToList()
+        session.send("First prompt")
+        val _ = session.stream().runToList()
         assertEquals(session.sessionId, turn1SessionId)
 
-        val _ = session.send("Second prompt").runToList()
+        session.send("Second prompt")
+        val _ = session.stream().runToList()
         assertEquals(session.sessionId, turn2SessionId)
       finally session.close()
     }
@@ -389,7 +397,8 @@ class SessionTest extends munit.FunSuite:
       val session = ClaudeCode.session(options)
       try
         val results = (1 to 3).map { i =>
-          val messages = session.send(s"Prompt $i").runToList()
+          session.send(s"Prompt $i")
+          val messages = session.stream().runToList()
           // Each turn must end with its own ResultMessage
           val resultMsg = messages
             .collectFirst { case r: ResultMessage => r }
@@ -448,12 +457,8 @@ class SessionTest extends munit.FunSuite:
 
       // Verify the session is no longer usable — send should throw because
       // the underlying stdin writer is closed
-      val caught = intercept[Exception] {
-        session.send("should fail").runToList()
+      intercept[Exception] {
+        session.send("should fail")
       }
-      assert(
-        caught != null,
-        "Expected an exception when sending to a closed session"
-      )
     }
   }

--- a/direct/test/src/works/iterative/claude/direct/SessionTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/SessionTest.scala
@@ -1,0 +1,234 @@
+// PURPOSE: Unit tests for Session trait and SessionProcess implementation
+// PURPOSE: Verifies session lifecycle, message flow, and session ID extraction
+package works.iterative.claude.direct
+
+import ox.*
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.{
+  MockCliScript,
+  MockLogger,
+  SessionMockCliScript
+}
+import io.circe.syntax.*
+import io.circe.parser
+import java.nio.file.Path
+
+class SessionTest extends munit.FunSuite:
+
+  // Track created mock scripts for cleanup
+  private val createdScripts = scala.collection.mutable.ListBuffer[Path]()
+
+  override def afterEach(context: AfterEach): Unit =
+    createdScripts.foreach { path =>
+      val _ = MockCliScript.cleanup(path)
+      val _ = SessionMockCliScript.cleanup(path)
+    }
+    createdScripts.clear()
+    super.afterEach(context)
+
+  // ============================================================
+  // T2: SDKUserMessage stdin encoding test
+  // ============================================================
+
+  test("SDKUserMessage is correctly encoded for stdin") {
+    val msg = SDKUserMessage(content = "Hello, Claude!", sessionId = "sess-42")
+    val json = msg.asJson.noSpaces
+
+    val parsed = parser.parse(json).toOption.get
+    val cursor = parsed.hcursor
+
+    assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
+    assertEquals(
+      cursor
+        .downField("message")
+        .downField("role")
+        .as[String]
+        .toOption,
+      Some("user")
+    )
+    assertEquals(
+      cursor
+        .downField("message")
+        .downField("content")
+        .as[String]
+        .toOption,
+      Some("Hello, Claude!")
+    )
+    assertEquals(
+      cursor.downField("session_id").as[String].toOption,
+      Some("sess-42")
+    )
+  }
+
+  test("SDKUserMessage with pending session ID uses 'pending' literal") {
+    val msg = SDKUserMessage(content = "First prompt", sessionId = "pending")
+    val json = msg.asJson.noSpaces
+    val parsed = parser.parse(json).toOption.get
+    assertEquals(
+      parsed.hcursor.downField("session_id").as[String].toOption,
+      Some("pending")
+    )
+  }
+
+  // ============================================================
+  // T3: Session ID extraction from SystemMessage init
+  // ============================================================
+
+  test("Session ID is extracted from SystemMessage with subtype init") {
+    val initMsg = SystemMessage(
+      subtype = "init",
+      data = Map("session_id" -> "extracted-session-id-123")
+    )
+    val extracted = initMsg.data.get("session_id").map(_.toString)
+    assertEquals(extracted, Some("extracted-session-id-123"))
+  }
+
+  test("Non-init SystemMessage does not provide session ID") {
+    val userContextMsg = SystemMessage(
+      subtype = "user_context",
+      data = Map("context_user_id" -> "user_123")
+    )
+    // We only extract from "init" subtype
+    val extracted =
+      if userContextMsg.subtype == "init" then
+        userContextMsg.data.get("session_id").map(_.toString)
+      else None
+    assertEquals(extracted, None)
+  }
+
+  // ============================================================
+  // T4: Session ID defaults to "pending"
+  // ============================================================
+
+  test("Session ID defaults to 'pending' when no init message received") {
+    // This is a behavioral test: if we create a session against a script
+    // that doesn't emit an init message before the first send, we get "pending"
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val noInitScript = MockCliScript.createSimpleScript(
+        List(
+          // No init message - just jump straight to result
+          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"real-session-id"}"""
+        ),
+        delayMs = 0
+      )
+      createdScripts += noInitScript
+
+      val options = SessionOptions().withClaudeExecutable(noInitScript.toString)
+      val session = ClaudeCode.session(options)
+
+      // Before any send, if no init message was received, sessionId is "pending"
+      assertEquals(session.sessionId, "pending")
+      session.close()
+    }
+  }
+
+  // ============================================================
+  // T5: ResultMessage signals end of Flow
+  // ============================================================
+
+  test("Flow completes after emitting ResultMessage") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val sessionId = "sess-flow-test"
+      // Session script emits assistant + result for the first turn,
+      // then ignores subsequent turns (no more responses configured)
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              """{"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}""",
+              s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$sessionId"}"""
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        val messages = session.send("test").runToList()
+
+        // Should have assistant + result only
+        val resultMessages = messages.collect { case r: ResultMessage => r }
+        assertEquals(resultMessages.length, 1)
+
+        val assistantMessages = messages.collect { case a: AssistantMessage =>
+          a
+        }
+        assertEquals(assistantMessages.length, 1)
+
+        // Total should be 2 (assistant + result)
+        assertEquals(messages.length, 2)
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T6: Session ID updated from ResultMessage
+  // ============================================================
+
+  test("Session ID is updated from ResultMessage after send completes") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      val script = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = List(
+          SessionMockCliScript.TurnResponse(
+            List(
+              s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"updated-session-id-456"}"""
+            )
+          )
+        )
+      )
+      createdScripts += script
+
+      val options = SessionOptions().withClaudeExecutable(script.toString)
+      val session = ClaudeCode.session(options)
+      try
+        // Run the flow to completion
+        val _ = session.send("test").runToList()
+
+        // After send completes, session ID should be updated from ResultMessage
+        assertEquals(session.sessionId, "updated-session-id-456")
+      finally session.close()
+    }
+  }
+
+  // ============================================================
+  // T7: Close terminates process
+  // ============================================================
+
+  test("close() terminates the underlying process") {
+    given logger: MockLogger = MockLogger()
+    supervised {
+      // Create a session script that stays alive waiting for stdin (no turnResponses
+      // means it just reads until EOF, simulating a long-lived process)
+      val hangingScript = SessionMockCliScript.createSessionScript(
+        initMessages = Nil,
+        turnResponses = Nil
+      )
+      createdScripts += hangingScript
+
+      val options =
+        SessionOptions().withClaudeExecutable(hangingScript.toString)
+      val session = ClaudeCode.session(options)
+
+      // The session wraps a Process — extract it to verify it's terminated after close
+      // We know SessionProcess holds the process, so we verify indirectly:
+      // after close(), sending should fail because stdin is closed
+      session.close()
+
+      // Verify the session is no longer usable — send should throw because
+      // the underlying stdin writer is closed
+      val caught = intercept[Exception] {
+        session.send("should fail").runToList()
+      }
+      assert(
+        caught != null,
+        "Expected an exception when sending to a closed session"
+      )
+    }
+  }

--- a/direct/test/src/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
@@ -75,6 +75,19 @@ class JsonParserTest extends munit.FunSuite with munit.ScalaCheckSuite:
         ) ++ optionalFields
         s"""{${allFields.mkString(",")}}"""
 
+      case KeepAliveMessage =>
+        s"""{"type":"keep_alive"}"""
+
+      case StreamEventMessage(data) =>
+        val dataJson = data
+          .map { case (key, value) =>
+            s""""$key":${serializeJsonValue(value)}"""
+          }
+          .mkString(",")
+        s"""{"type":"stream_event"${
+            if dataJson.nonEmpty then "," + dataJson else ""
+          }}"""
+
     private def serializeContentBlock(block: ContentBlock): String = block match
       case TextBlock(text) =>
         s"""{"type":"text","text":${escapeJsonString(text)}}"""
@@ -211,12 +224,23 @@ class JsonParserTest extends munit.FunSuite with munit.ScalaCheckSuite:
       result
     )
 
+    // Generator for KeepAliveMessage
+    val keepAliveGen: Gen[KeepAliveMessage.type] =
+      Gen.const(KeepAliveMessage)
+
+    // Generator for StreamEventMessage
+    val streamEventGen: Gen[StreamEventMessage] = systemDataGen.map(
+      StreamEventMessage.apply
+    )
+
     // Generator for any Message type
     val messageGen: Gen[Message] = Gen.oneOf(
       userMessageGen,
       assistantMessageGen,
       systemMessageGen,
-      resultMessageGen
+      resultMessageGen,
+      keepAliveGen,
+      streamEventGen
     )
 
     // Implicit Arbitrary instances
@@ -225,6 +249,8 @@ class JsonParserTest extends munit.FunSuite with munit.ScalaCheckSuite:
     given Arbitrary[AssistantMessage] = Arbitrary(assistantMessageGen)
     given Arbitrary[SystemMessage] = Arbitrary(systemMessageGen)
     given Arbitrary[ResultMessage] = Arbitrary(resultMessageGen)
+    given Arbitrary[KeepAliveMessage.type] = Arbitrary(keepAliveGen)
+    given Arbitrary[StreamEventMessage] = Arbitrary(streamEventGen)
 
   test("should parse valid JSON messages with line context") {
     // Setup: Valid JSON message strings from CLI output
@@ -517,6 +543,45 @@ class JsonParserTest extends munit.FunSuite with munit.ScalaCheckSuite:
         case other =>
           fail(
             s"Expected Right(Some(ResultMessage(...))) but got: $other for JSON: $jsonString"
+          )
+    }
+  }
+
+  property(
+    "should maintain idempotency for KeepAliveMessage parsing specifically"
+  ) {
+    import MessageGenerators.*
+    import JsonSerializationUtils.*
+
+    forAll(keepAliveGen) { originalMessage =>
+      val jsonString = serializeMessage(originalMessage)
+      val parseResult = JsonParser.parseJsonLineWithContext(jsonString, 1)
+
+      parseResult match
+        case Right(Some(KeepAliveMessage)) => () // success
+        case other                         =>
+          fail(
+            s"Expected Right(Some(KeepAliveMessage)) but got: $other for JSON: $jsonString"
+          )
+    }
+  }
+
+  property(
+    "should maintain idempotency for StreamEventMessage parsing specifically"
+  ) {
+    import MessageGenerators.*
+    import JsonSerializationUtils.*
+
+    forAll(streamEventGen) { originalMessage =>
+      val jsonString = serializeMessage(originalMessage)
+      val parseResult = JsonParser.parseJsonLineWithContext(jsonString, 1)
+
+      parseResult match
+        case Right(Some(streamEvent: StreamEventMessage)) =>
+          assertEquals(streamEvent, originalMessage)
+        case other =>
+          fail(
+            s"Expected Right(Some(StreamEventMessage(...))) but got: $other for JSON: $jsonString"
           )
     }
   }

--- a/direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
@@ -1,0 +1,18 @@
+// PURPOSE: Shared mock Logger for testing that captures log messages by level
+// PURPOSE: Used across unit, integration, and E2E test suites
+package works.iterative.claude.direct.internal.testing
+
+import works.iterative.claude.direct.Logger
+
+class MockLogger extends Logger:
+  var debugMessages: List[String] = List.empty
+  var infoMessages: List[String] = List.empty
+  var warnMessages: List[String] = List.empty
+  var errorMessages: List[String] = List.empty
+
+  def debug(msg: => String): Unit = debugMessages = msg :: debugMessages
+  def info(msg: => String): Unit = infoMessages = msg :: infoMessages
+  def warn(msg: => String): Unit = warnMessages = msg :: warnMessages
+  def error(msg: => String): Unit = errorMessages = msg :: errorMessages
+  def error(msg: => String, exception: Throwable): Unit = errorMessages =
+    s"$msg: ${exception.getMessage}" :: errorMessages

--- a/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
@@ -163,5 +163,106 @@ object SessionMockCliScript:
 
     sb.toString()
 
+  /** Creates a script that exits immediately without reading any stdin. Used to
+    * test send() to a dead process.
+    */
+  def createImmediateExitScript(exitCode: Int = 1): Path =
+    val content = s"#!/bin/bash\nexit $exitCode\n"
+    writeExecutableScript("mock-immediate-exit-", content)
+
+  /** Creates a script that emits one assistant message then crashes with the
+    * given exit code before emitting a ResultMessage.
+    */
+  def createCrashMidTurnScript(exitCode: Int = 1): Path =
+    val initMessages = List(CommonResponses.initMessage())
+    val partialResponse =
+      CommonResponses.assistantMessage("Partial response before crash")
+    val content =
+      generateCrashMidTurnScript(initMessages, partialResponse, exitCode)
+    writeExecutableScript("mock-crash-mid-turn-", content)
+
+  /** Creates a script that completes one full turn (with ResultMessage) then
+    * exits before reading the second prompt.
+    */
+  def createCrashBetweenTurnsScript(exitCode: Int = 1): Path =
+    val sessionId = CommonResponses.initSessionId
+    val turn1 = TurnResponse(
+      List(
+        CommonResponses.assistantMessage("Turn 1 complete"),
+        CommonResponses.resultMessage(sessionId)
+      )
+    )
+    val content = generateCrashBetweenTurnsScript(
+      List(CommonResponses.initMessage()),
+      turn1,
+      exitCode
+    )
+    writeExecutableScript("mock-crash-between-turns-", content)
+
+  /** Creates a script that emits a valid assistant message, then an invalid
+    * JSON line, then a valid ResultMessage.
+    */
+  def createMalformedJsonMidTurnScript(): Path =
+    val sessionId = CommonResponses.initSessionId
+    val messages = List(
+      CommonResponses.assistantMessage("Before bad line"),
+      "{bad json: not valid}",
+      CommonResponses.resultMessage(sessionId)
+    )
+    val turnResponse = TurnResponse(messages)
+    createSessionScript(
+      initMessages = List(CommonResponses.initMessage()),
+      turnResponses = List(turnResponse)
+    )
+
+  private def generateCrashMidTurnScript(
+      initMessages: List[String],
+      partialMessage: String,
+      exitCode: Int
+  ): String =
+    val sb = new StringBuilder
+    sb.append("#!/bin/bash\n")
+    sb.append("# Mock script: emits partial output then crashes\n\n")
+    initMessages.foreach { msg =>
+      sb.append(s"echo '${escapeSingleQuote(msg)}'\n")
+    }
+    // Wait for one line of stdin, then emit partial response and crash
+    sb.append("read -r _line\n")
+    sb.append(s"echo '${escapeSingleQuote(partialMessage)}'\n")
+    sb.append(s"exit $exitCode\n")
+    sb.toString()
+
+  private def generateCrashBetweenTurnsScript(
+      initMessages: List[String],
+      turn1: TurnResponse,
+      exitCode: Int
+  ): String =
+    val sb = new StringBuilder
+    sb.append("#!/bin/bash\n")
+    sb.append("# Mock script: completes one turn then crashes\n\n")
+    initMessages.foreach { msg =>
+      sb.append(s"echo '${escapeSingleQuote(msg)}'\n")
+    }
+    // Read first prompt, respond fully
+    sb.append("read -r _line\n")
+    turn1.messages.foreach { msg =>
+      sb.append(s"echo '${escapeSingleQuote(msg)}'\n")
+    }
+    // Exit before reading second prompt
+    sb.append(s"exit $exitCode\n")
+    sb.toString()
+
+  private def writeExecutableScript(prefix: String, content: String): Path =
+    val tempDir = Files.createTempDirectory(prefix)
+    val scriptPath = tempDir.resolve(s"mock-${System.currentTimeMillis()}")
+    Using.resource(new PrintWriter(new FileWriter(scriptPath.toFile))) {
+      _.write(content)
+    }
+    Files.setPosixFilePermissions(
+      scriptPath,
+      PosixFilePermissions.fromString("rwxr-xr-x")
+    )
+    scriptPath
+
   private def escapeSingleQuote(s: String): String =
     s.replace("'", "'\\''")

--- a/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+++ b/direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
@@ -1,0 +1,167 @@
+// PURPOSE: Mock CLI scripts that simulate the stream-json session protocol
+// PURPOSE: Scripts read SDKUserMessage JSON from stdin and write response JSON to stdout
+package works.iterative.claude.direct.internal.testing
+
+import java.io.{FileWriter, PrintWriter}
+import java.nio.file.{Files, Path}
+import java.nio.file.attribute.PosixFilePermissions
+import scala.util.{Try, Using}
+
+/** Utilities for creating mock CLI scripts that simulate the Claude Code
+  * stream-json session protocol.
+  *
+  * Unlike query-mode mocks (which output all content and exit), session-mode
+  * mocks keep running and read prompts from stdin as newline-delimited JSON
+  * (SDKUserMessage). For each prompt received, the script writes a sequence of
+  * response JSON lines to stdout, ending with a ResultMessage. The script
+  * remains alive until stdin is closed, at which point it exits normally.
+  */
+object SessionMockCliScript:
+
+  /** Configuration for a single turn's response in a session mock. */
+  case class TurnResponse(
+      /** Messages to write to stdout when this turn's prompt is received. */
+      messages: List[String]
+  )
+
+  /** Common pre-built responses for typical session scenarios. */
+  object CommonResponses:
+
+    val initSessionId = "test-session-id-init-001"
+
+    /** The system init message that the CLI emits when first started. */
+    def initMessage(sessionId: String = initSessionId): String =
+      s"""{"type":"system","subtype":"init","session_id":"$sessionId","tools":[],"mcp_servers":[]}"""
+
+    /** A simple assistant response with text content. */
+    def assistantMessage(text: String): String =
+      s"""{"type":"assistant","message":{"content":[{"type":"text","text":"$text"}]}}"""
+
+    /** A ResultMessage signalling end-of-turn. */
+    def resultMessage(
+        sessionId: String = initSessionId,
+        durationMs: Int = 100,
+        numTurns: Int = 1
+    ): String =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":$durationMs,"duration_api_ms":50,"is_error":false,"num_turns":$numTurns,"session_id":"$sessionId"}"""
+
+    /** A keep_alive message. */
+    val keepAliveMessage: String =
+      """{"type":"keep_alive"}"""
+
+    /** A stream_event message. */
+    def streamEventMessage(event: String = "start"): String =
+      s"""{"type":"stream_event","data":{"event":"$event"}}"""
+
+    /** Standard single-turn session: init + one assistant response + result. */
+    def singleTurnSession(
+        prompt: String = "test",
+        sessionId: String = initSessionId
+    ): (String, TurnResponse) =
+      val init = initMessage(sessionId)
+      val response = TurnResponse(
+        List(
+          assistantMessage(s"Response to: $prompt"),
+          resultMessage(sessionId)
+        )
+      )
+      (init, response)
+
+  /** Creates a temporary executable shell script that simulates a session
+    * process. The script:
+    *   1. Writes the given initMessage to stdout (if provided)
+    *   2. Enters a read loop: for each line read from stdin, writes one turn
+    *      response to stdout
+    *   3. Exits when stdin closes (EOF)
+    *
+    * The turn responses are cycled: the nth prompt receives responses[n %
+    * responses.length]. If responses is empty, the script just echoes a default
+    * result for every prompt.
+    *
+    * @param initMessages
+    *   Lines to emit to stdout before reading any stdin (e.g., init message)
+    * @param turnResponses
+    *   Ordered list of response sequences, one per stdin line received
+    * @param captureStdinFile
+    *   If provided, each stdin line is appended to this file for verification
+    */
+  def createSessionScript(
+      initMessages: List[String] = Nil,
+      turnResponses: List[TurnResponse] = Nil,
+      captureStdinFile: Option[Path] = None
+  ): Path =
+    val tempDir = Files.createTempDirectory("mock-session-claude-")
+    val scriptPath = tempDir.resolve(
+      s"mock-session-${System.currentTimeMillis()}"
+    )
+    val content = generateSessionScript(
+      initMessages,
+      turnResponses,
+      captureStdinFile
+    )
+    Using.resource(new PrintWriter(new FileWriter(scriptPath.toFile))) {
+      _.write(content)
+    }
+    Files.setPosixFilePermissions(
+      scriptPath,
+      PosixFilePermissions.fromString("rwxr-xr-x")
+    )
+    scriptPath
+
+  def cleanup(scriptPath: Path): Try[Unit] = Try {
+    if Files.exists(scriptPath) then
+      Files.delete(scriptPath)
+      val parent = scriptPath.getParent
+      if Files.exists(parent) && Files.list(parent).count() == 0 then
+        Files.delete(parent)
+  }
+
+  private def generateSessionScript(
+      initMessages: List[String],
+      turnResponses: List[TurnResponse],
+      captureStdinFile: Option[Path]
+  ): String =
+    val sb = new StringBuilder
+    sb.append("#!/bin/bash\n")
+    sb.append("# Auto-generated mock session CLI script\n\n")
+
+    // Emit init messages immediately at startup
+    initMessages.foreach { msg =>
+      sb.append(s"echo '${escapeSingleQuote(msg)}'\n")
+    }
+
+    if turnResponses.nonEmpty then
+      val turnCount = turnResponses.length
+      sb.append(s"TURN_COUNT=$turnCount\n")
+      sb.append("TURN_INDEX=0\n\n")
+
+      // Read loop: for each line from stdin, cycle through the configured responses
+      sb.append("while IFS= read -r line; do\n")
+      captureStdinFile.foreach { f =>
+        sb.append(s"""  printf '%s\\n' "$$line" >> '${f.toAbsolutePath}'\n""")
+      }
+      sb.append("  IDX=$((TURN_INDEX % TURN_COUNT))\n")
+      sb.append("  case \"$IDX\" in\n")
+      turnResponses.zipWithIndex.foreach { case (turn, idx) =>
+        sb.append(s"    $idx)\n")
+        turn.messages.foreach { msg =>
+          sb.append(s"      echo '${escapeSingleQuote(msg)}'\n")
+        }
+        sb.append("      ;;\n")
+      }
+      sb.append("  esac\n")
+      sb.append("  TURN_INDEX=$((TURN_INDEX + 1))\n")
+      sb.append("done\n")
+    else
+      // No responses configured: just read (and optionally capture) stdin until EOF
+      sb.append("while IFS= read -r line; do\n")
+      captureStdinFile.foreach { f =>
+        sb.append(s"""  printf '%s\\n' "$$line" >> '${f.toAbsolutePath}'\n""")
+      }
+      sb.append("  true\n")
+      sb.append("done\n")
+
+    sb.toString()
+
+  private def escapeSingleQuote(s: String): String =
+    s.replace("'", "'\\''")

--- a/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+++ b/effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
@@ -2,29 +2,32 @@
 // PURPOSE: Provides streaming query interface to Claude Code CLI functionality
 package works.iterative.claude.effectful
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import fs2.Stream
-import fs2.io.process.{Process, ProcessBuilder}
-import fs2.io.file.Path
 import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import works.iterative.claude.core.model.*
-import works.iterative.claude.core.model.QueryOptions
-import works.iterative.claude.effectful.internal.parsing.JsonParser
+import works.iterative.claude.core.model.{QueryOptions, SessionOptions}
 import works.iterative.claude.core.{
   ProcessExecutionError,
   JsonParsingError,
-  ProcessTimeoutError,
   ConfigurationError
 }
 import works.iterative.claude.effectful.internal.cli.{
   CLIDiscovery,
-  ProcessManager
+  ProcessManager,
+  SessionProcess
 }
 import works.iterative.claude.core.cli.CLIArgumentBuilder
 
 object ClaudeCode:
   // Public API - High-level "What" operations
+  def session(options: SessionOptions)(using
+      logger: Logger[IO]
+  ): Resource[IO, Session] =
+    Resource
+      .eval(resolveExecutable(options.pathToClaudeCodeExecutable))
+      .flatMap(SessionProcess.start(_, options))
+
   def queryResult(options: QueryOptions)(using logger: Logger[IO]): IO[String] =
     querySync(options)(using logger).map(extractTextFromMessages)
 
@@ -60,17 +63,21 @@ object ClaudeCode:
   ): Stream[IO, Unit] =
     Stream.eval(logger.info(s"Initiating query with prompt: $prompt"))
 
+  private def resolveExecutable(
+      path: Option[String]
+  )(using logger: Logger[IO]): IO[String] =
+    path match
+      case Some(p) => IO.pure(p)
+      case None    =>
+        CLIDiscovery.findClaude(logger).flatMap {
+          case Right(p)    => IO.pure(p)
+          case Left(error) => IO.raiseError(error)
+        }
+
   private def discoverExecutablePath(options: QueryOptions)(using
       logger: Logger[IO]
   ): Stream[IO, String] =
-    options.pathToClaudeCodeExecutable match
-      case Some(explicitPath) => Stream.eval(IO.pure(explicitPath))
-      case None               =>
-        Stream
-          .eval(CLIDiscovery.findClaude(logger))
-          .flatMap:
-            case Right(path) => Stream.emit(path)
-            case Left(error) => Stream.raiseError[IO](error)
+    Stream.eval(resolveExecutable(options.pathToClaudeCodeExecutable))
 
   private def buildCLIArguments(options: QueryOptions): List[String] =
     List("--print", "--verbose", "--output-format", "stream-json") ++

--- a/effectful/src/works/iterative/claude/effectful/Session.scala
+++ b/effectful/src/works/iterative/claude/effectful/Session.scala
@@ -1,0 +1,36 @@
+// PURPOSE: Trait representing an active conversational session with the Claude Code CLI
+// PURPOSE: Provides send/stream/sessionId interface for multi-turn conversations using cats-effect
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import fs2.Stream
+import works.iterative.claude.core.model.Message
+
+/** An active Claude Code session backed by a long-lived CLI process.
+  *
+  * Each session maintains a single CLI process whose stdin is kept open for
+  * multi-turn conversation. Each turn is initiated with `send` (which writes
+  * the prompt to stdin as an IO effect) and then consumed via `stream` (which
+  * reads stdout until the ResultMessage signals end-of-turn). The session is
+  * acquired as a Resource, which handles process cleanup on both normal exit
+  * and error.
+  */
+trait Session:
+  /** Writes a prompt to the session's stdin as an SDKUserMessage JSON line. */
+  def send(prompt: String): IO[Unit]
+
+  /** Reads stdout messages for the current turn until a ResultMessage.
+    *
+    * Returns a Stream of messages that completes after emitting the
+    * ResultMessage that terminates the current turn. Must be called after
+    * `send`.
+    */
+  def stream: Stream[IO, Message]
+
+  /** The session ID assigned by the CLI, wrapped in IO since it reads a Ref.
+    *
+    * Returns IO("pending") until the CLI emits an init SystemMessage or until
+    * the first turn completes (at which point the ResultMessage session ID is
+    * used).
+    */
+  def sessionId: IO[String]

--- a/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+++ b/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
@@ -10,6 +10,7 @@ import fs2.io.process.ProcessBuilder
 import fs2.io.file.Path
 import io.circe.syntax.*
 import org.typelevel.log4cats.Logger
+import works.iterative.claude.core.{CLIError, SessionProcessDied}
 import works.iterative.claude.core.model.*
 import works.iterative.claude.core.cli.CLIArgumentBuilder
 import works.iterative.claude.effectful.Session
@@ -38,13 +39,25 @@ object SessionProcess:
       // message queue: Some(msg) = message, None = stdout EOF
       messageQueue <- Resource.eval(Queue.unbounded[IO, Option[Message]])
       sessionIdRef <- Resource.eval(Ref.of[IO, String]("pending"))
+      // alive ref: set to false when the process dies
+      aliveRef <- Resource.eval(Ref.of[IO, Boolean](true))
+      // pendingError ref: carries process-death error from stdout reader to stream
+      pendingErrorRef <- Resource.eval(
+        Ref.of[IO, Option[CLIError]](None)
+      )
       // Background fiber: drains stdinQueue into process.stdin
       _ <- Resource.make(
         startStdinWriter(process, stdinQueue).start
       )(_.cancel)
       // Background fiber: reads process.stdout into messageQueue
       _ <- Resource.make(
-        startStdoutReader(process, messageQueue, sessionIdRef).start
+        startStdoutReader(
+          process,
+          messageQueue,
+          sessionIdRef,
+          aliveRef,
+          pendingErrorRef
+        ).start
       )(_.cancel)
       // Background fiber: captures stderr for diagnostics
       _ <- Resource.make(
@@ -52,7 +65,13 @@ object SessionProcess:
       )(_.cancel)
       // Read init message to prime sessionId before returning the session
       _ <- Resource.eval(readInitMessage(messageQueue, sessionIdRef))
-    yield new SessionImpl(stdinQueue, sessionIdRef, messageQueue)
+    yield new SessionImpl(
+      stdinQueue,
+      sessionIdRef,
+      messageQueue,
+      aliveRef,
+      pendingErrorRef
+    )
 
   private def buildProcess(
       executablePath: String,
@@ -83,12 +102,17 @@ object SessionProcess:
       .drain
 
   /** Background fiber: reads stdout lines, parses into messages, and enqueues
-    * them. Also updates sessionIdRef on ResultMessage. Signals EOF with None.
+    * them. Malformed JSON lines are logged and skipped. When stdout completes,
+    * checks the process exit code: non-zero exit sets aliveRef to false and
+    * stores a SessionProcessDied in pendingErrorRef. Always offers None to
+    * signal EOF.
     */
   private def startStdoutReader(
       process: fs2.io.process.Process[IO],
       messageQueue: Queue[IO, Option[Message]],
-      sessionIdRef: Ref[IO, String]
+      sessionIdRef: Ref[IO, String],
+      aliveRef: Ref[IO, Boolean],
+      pendingErrorRef: Ref[IO, Option[CLIError]]
   )(using logger: Logger[IO]): IO[Unit] =
     process.stdout
       .through(fs2.text.utf8.decode)
@@ -98,7 +122,13 @@ object SessionProcess:
         JsonParser.parseJsonLineWithContext(line, idx.toInt + 1, logger)
       }
       .evalMap {
-        case Left(err)        => IO.raiseError(err)
+        case Left(err) =>
+          // Malformed JSON: log and skip rather than terminating the reader
+          logger
+            .warn(s"Malformed JSON line skipped: ${err.message}")
+            .as(
+              None: Option[Message]
+            )
         case Right(None)      => IO.pure(None: Option[Message])
         case Right(Some(msg)) =>
           msg match
@@ -110,6 +140,17 @@ object SessionProcess:
       .evalMap(msg => messageQueue.offer(Some(msg)))
       .compile
       .drain
+      .flatMap { _ =>
+        // When stdout stream completes, the process is dead regardless of exit code
+        aliveRef.set(false) *>
+          IO(process.exitValue).flatten.attempt.flatMap {
+            case Right(code) if code != 0 =>
+              pendingErrorRef.set(
+                Some(SessionProcessDied(Some(code), ""))
+              )
+            case _ => IO.unit
+          }
+      }
       .guarantee(messageQueue.offer(None))
 
   private val InitReadTimeout = 1.second
@@ -164,30 +205,74 @@ object SessionProcess:
 private class SessionImpl(
     stdinQueue: Queue[IO, Option[Chunk[Byte]]],
     sessionIdRef: Ref[IO, String],
-    messageQueue: Queue[IO, Option[Message]]
+    messageQueue: Queue[IO, Option[Message]],
+    aliveRef: Ref[IO, Boolean],
+    pendingErrorRef: Ref[IO, Option[CLIError]]
 )(using logger: Logger[IO])
     extends Session:
 
   def sessionId: IO[String] = sessionIdRef.get
 
   def send(prompt: String): IO[Unit] =
-    sessionIdRef.get.flatMap { currentId =>
-      val msg = SDKUserMessage(content = prompt, sessionId = currentId)
-      val json = msg.asJson.noSpaces + "\n"
-      logger.debug(
-        s"Writing SDKUserMessage to stdin: ${msg.asJson.noSpaces}"
-      ) *>
-        stdinQueue.offer(
-          Some(
-            Chunk.array(json.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-          )
-        )
+    aliveRef.get.flatMap { isAlive =>
+      if !isAlive then
+        pendingErrorRef.get.flatMap {
+          case Some(err) => IO.raiseError(err)
+          case None      =>
+            IO.raiseError(
+              SessionProcessDied(None, "")
+            )
+        }
+      else
+        sessionIdRef.get.flatMap { currentId =>
+          val msg = SDKUserMessage(content = prompt, sessionId = currentId)
+          val json = msg.asJson.noSpaces + "\n"
+          logger.debug(
+            s"Writing SDKUserMessage to stdin: ${msg.asJson.noSpaces}"
+          ) *>
+            stdinQueue.offer(
+              Some(
+                Chunk.array(
+                  json.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                )
+              )
+            )
+        }
     }
 
   /** Reads messages from the shared queue until (and including) a
-    * ResultMessage, then stops.
+    * ResultMessage, then stops. If the queue signals EOF (None) before a
+    * ResultMessage is received, checks pendingErrorRef and raises the error if
+    * present (process died mid-turn).
+    */
+  /** Reads messages from the shared queue until (and including) a
+    * ResultMessage, then stops. If the queue signals EOF (None) before a
+    * ResultMessage is received, checks pendingErrorRef and raises the error if
+    * present (process died mid-turn).
+    *
+    * resultSeenRef tracks whether the stream completed normally (via
+    * ResultMessage). pendingErrorRef carries the process-death error from the
+    * stdout reader fiber. Both are needed because the queue EOF (None) is the
+    * same signal for normal process shutdown and abnormal exit — resultSeenRef
+    * disambiguates the two cases so onFinalize only raises on abnormal exit.
     */
   def stream: Stream[IO, Message] =
-    Stream
-      .fromQueueNoneTerminated(messageQueue)
-      .takeThrough(!_.isInstanceOf[ResultMessage])
+    Stream.eval(IO.ref(false)).flatMap { resultSeenRef =>
+      Stream
+        .fromQueueNoneTerminated(messageQueue)
+        .evalTap {
+          case _: ResultMessage => resultSeenRef.set(true)
+          case _                => IO.unit
+        }
+        .takeThrough(!_.isInstanceOf[ResultMessage])
+        .onFinalize {
+          resultSeenRef.get.flatMap { resultSeen =>
+            if !resultSeen then
+              pendingErrorRef.get.flatMap {
+                case Some(err) => IO.raiseError(err)
+                case None      => IO.unit
+              }
+            else IO.unit
+          }
+        }
+    }

--- a/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+++ b/effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
@@ -1,0 +1,193 @@
+// PURPOSE: Resource-based effectful Session implementation backed by a long-lived CLI process
+// PURPOSE: Handles session startup, multi-turn message routing, and deterministic process cleanup
+package works.iterative.claude.effectful.internal.cli
+
+import cats.effect.{IO, Ref, Resource}
+import cats.effect.std.Queue
+import fs2.{Chunk, Stream}
+import scala.concurrent.duration.*
+import fs2.io.process.ProcessBuilder
+import fs2.io.file.Path
+import io.circe.syntax.*
+import org.typelevel.log4cats.Logger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.core.cli.CLIArgumentBuilder
+import works.iterative.claude.effectful.Session
+import works.iterative.claude.effectful.internal.parsing.JsonParser
+
+/** Starts and manages a long-lived Claude Code CLI session process.
+  *
+  * The process is spawned once and kept alive for multiple turns. A background
+  * fiber writes stdin from a queue (keeping the pipe open across sends); a
+  * second fiber continuously reads stdout lines into a message queue; a third
+  * fiber captures stderr for diagnostics. Cleanup is handled by the Resource
+  * finalizer.
+  */
+object SessionProcess:
+
+  def start(
+      executablePath: String,
+      options: SessionOptions
+  )(using logger: Logger[IO]): Resource[IO, Session] =
+    val args = "--verbose" :: CLIArgumentBuilder.buildSessionArgs(options)
+
+    for
+      process <- buildProcess(executablePath, args, options).spawn[IO]
+      // stdin queue: Some(chunk) = data, None = close signal
+      stdinQueue <- Resource.eval(Queue.unbounded[IO, Option[Chunk[Byte]]])
+      // message queue: Some(msg) = message, None = stdout EOF
+      messageQueue <- Resource.eval(Queue.unbounded[IO, Option[Message]])
+      sessionIdRef <- Resource.eval(Ref.of[IO, String]("pending"))
+      // Background fiber: drains stdinQueue into process.stdin
+      _ <- Resource.make(
+        startStdinWriter(process, stdinQueue).start
+      )(_.cancel)
+      // Background fiber: reads process.stdout into messageQueue
+      _ <- Resource.make(
+        startStdoutReader(process, messageQueue, sessionIdRef).start
+      )(_.cancel)
+      // Background fiber: captures stderr for diagnostics
+      _ <- Resource.make(
+        captureStderr(process).start
+      )(_.cancel)
+      // Read init message to prime sessionId before returning the session
+      _ <- Resource.eval(readInitMessage(messageQueue, sessionIdRef))
+    yield new SessionImpl(stdinQueue, sessionIdRef, messageQueue)
+
+  private def buildProcess(
+      executablePath: String,
+      args: List[String],
+      options: SessionOptions
+  ): ProcessBuilder =
+    val base = ProcessBuilder(executablePath, args)
+      .withInheritEnv(options.inheritEnvironment.getOrElse(true))
+
+    val withEnv = options.environmentVariables.fold(base)(envVars =>
+      base.withExtraEnv(envVars)
+    )
+
+    options.cwd.fold(withEnv)(cwd => withEnv.withWorkingDirectory(Path(cwd)))
+
+  /** Background fiber: reads from stdinQueue and writes to process.stdin.
+    * Terminates when None is dequeued (closes the pipe).
+    */
+  private def startStdinWriter(
+      process: fs2.io.process.Process[IO],
+      stdinQueue: Queue[IO, Option[Chunk[Byte]]]
+  ): IO[Unit] =
+    Stream
+      .fromQueueNoneTerminated(stdinQueue)
+      .flatMap(Stream.chunk)
+      .through(process.stdin)
+      .compile
+      .drain
+
+  /** Background fiber: reads stdout lines, parses into messages, and enqueues
+    * them. Also updates sessionIdRef on ResultMessage. Signals EOF with None.
+    */
+  private def startStdoutReader(
+      process: fs2.io.process.Process[IO],
+      messageQueue: Queue[IO, Option[Message]],
+      sessionIdRef: Ref[IO, String]
+  )(using logger: Logger[IO]): IO[Unit] =
+    process.stdout
+      .through(fs2.text.utf8.decode)
+      .through(fs2.text.lines)
+      .zipWithIndex
+      .evalMap { case (line, idx) =>
+        JsonParser.parseJsonLineWithContext(line, idx.toInt + 1, logger)
+      }
+      .evalMap {
+        case Left(err)        => IO.raiseError(err)
+        case Right(None)      => IO.pure(None: Option[Message])
+        case Right(Some(msg)) =>
+          msg match
+            case result: ResultMessage =>
+              sessionIdRef.set(result.sessionId).as(Some(msg): Option[Message])
+            case _ => IO.pure(Some(msg): Option[Message])
+      }
+      .unNone
+      .evalMap(msg => messageQueue.offer(Some(msg)))
+      .compile
+      .drain
+      .guarantee(messageQueue.offer(None))
+
+  private val InitReadTimeout = 1.second
+
+  /** Waits for the first message from the stdout reader and checks if it's the
+    * init SystemMessage. If so, extracts the session ID. Otherwise, re-enqueues
+    * the message so it appears in the user's stream.
+    *
+    * Waits up to InitReadTimeout. If no message arrives within the timeout, the
+    * session ID stays "pending" (the init message either was not emitted or has
+    * not yet been buffered by the stdout reader fiber).
+    */
+  private def readInitMessage(
+      messageQueue: Queue[IO, Option[Message]],
+      sessionIdRef: Ref[IO, String]
+  )(using logger: Logger[IO]): IO[Unit] =
+    // Wait for the first message with a timeout using race
+    IO.race(
+      messageQueue.take,
+      IO.sleep(InitReadTimeout)
+    ).flatMap {
+      case Left(None) =>
+        // Stdout closed before any message
+        messageQueue.offer(None)
+      case Left(Some(SystemMessage("init", data))) =>
+        data.get("session_id").map(_.toString) match
+          case Some(id) =>
+            logger.info(s"Session ID extracted from init message: $id") *>
+              sessionIdRef.set(id)
+          case None => IO.unit
+      case Left(Some(msg)) =>
+        // Non-init message; put it back for the user's stream
+        messageQueue.offer(Some(msg))
+      case Right(()) =>
+        // Timeout: no message arrived — session ID stays "pending"
+        IO.unit
+    }
+
+  private def captureStderr(
+      process: fs2.io.process.Process[IO]
+  )(using logger: Logger[IO]): IO[Unit] =
+    process.stderr
+      .through(fs2.text.utf8.decode)
+      .through(fs2.text.lines)
+      .evalMap(line => logger.debug(s"session stderr: $line"))
+      .compile
+      .drain
+
+/** Internal Session implementation that writes to a stdin queue and reads from
+  * a shared message queue.
+  */
+private class SessionImpl(
+    stdinQueue: Queue[IO, Option[Chunk[Byte]]],
+    sessionIdRef: Ref[IO, String],
+    messageQueue: Queue[IO, Option[Message]]
+)(using logger: Logger[IO])
+    extends Session:
+
+  def sessionId: IO[String] = sessionIdRef.get
+
+  def send(prompt: String): IO[Unit] =
+    sessionIdRef.get.flatMap { currentId =>
+      val msg = SDKUserMessage(content = prompt, sessionId = currentId)
+      val json = msg.asJson.noSpaces + "\n"
+      logger.debug(
+        s"Writing SDKUserMessage to stdin: ${msg.asJson.noSpaces}"
+      ) *>
+        stdinQueue.offer(
+          Some(
+            Chunk.array(json.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          )
+        )
+    }
+
+  /** Reads messages from the shared queue until (and including) a
+    * ResultMessage, then stops.
+    */
+  def stream: Stream[IO, Message] =
+    Stream
+      .fromQueueNoneTerminated(messageQueue)
+      .takeThrough(!_.isInstanceOf[ResultMessage])

--- a/effectful/src/works/iterative/claude/effectful/package.scala
+++ b/effectful/src/works/iterative/claude/effectful/package.scala
@@ -7,6 +7,8 @@ package object effectful:
   // Type aliases for convenient usage
   type QueryOptions = works.iterative.claude.core.model.QueryOptions
   val QueryOptions = works.iterative.claude.core.model.QueryOptions
+  type SessionOptions = works.iterative.claude.core.model.SessionOptions
+  val SessionOptions = works.iterative.claude.core.model.SessionOptions
 
   // Re-export all model classes that users need
   type Message = works.iterative.claude.core.model.Message

--- a/effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
@@ -12,6 +12,10 @@ class EffectfulPackageReexportTest extends CatsEffectSuite:
     val opts = QueryOptions.simple("hello")
     assertEquals(opts.prompt, "hello")
 
+  test("effectful.* re-exports SessionOptions"):
+    val opts = SessionOptions.defaults
+    assertEquals(opts.cwd, None)
+
   test("effectful.* re-exports UserMessage"):
     val msg: Message = UserMessage("hello")
     assert(msg.isInstanceOf[UserMessage])

--- a/effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
@@ -1,0 +1,112 @@
+// PURPOSE: End-to-end tests for effectful Session using the real Claude Code CLI
+// PURPOSE: Tests are gated on CLI availability and skip gracefully when not present
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+
+class SessionE2ETest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  private def isClaudeCliInstalled(): Boolean =
+    try
+      val process = new ProcessBuilder("claude", "--version").start()
+      process.waitFor() == 0
+    catch case _: Exception => false
+
+  private def hasApiKeyOrCredentials(): Boolean =
+    val hasApiKey = sys.env.contains("ANTHROPIC_API_KEY")
+    val homeDir = sys.env.get("HOME").orElse(sys.env.get("USERPROFILE"))
+    val hasCredentials = homeDir.exists { home =>
+      val path = java.nio.file.Paths.get(home, ".claude", ".credentials.json")
+      java.nio.file.Files.exists(path)
+    }
+    hasApiKey || hasCredentials
+
+  private def assumeClaudeAvailable(): Unit =
+    assume(isClaudeCliInstalled(), "Test requires Claude CLI to be installed")
+    assume(
+      hasApiKeyOrCredentials(),
+      "Test requires API key or credentials file"
+    )
+
+  // ============================================================
+  // E1: Single-turn session with real CLI
+  // ============================================================
+
+  test("E2E: real CLI session completes a single turn") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("What is 1+1? Reply with just the number.")
+          messages <- session.stream.compile.toList
+        yield
+          assert(messages.nonEmpty, "Expected messages from real CLI session")
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            "Expected AssistantMessage in response"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            "Expected ResultMessage signalling end of turn"
+          )
+      }
+  }
+
+  // ============================================================
+  // E2: Multi-turn with context dependency
+  // ============================================================
+
+  test("E2E: two-turn conversation preserves context across turns") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("Remember the number 42. Reply only with 'OK'.")
+          _ <- session.stream.compile.drain
+          _ <- session.send(
+            "What number did I ask you to remember? Reply with just the number."
+          )
+          secondTurnMessages <- session.stream.compile.toList
+        yield
+          val assistantMessages =
+            secondTurnMessages.collect { case a: AssistantMessage => a }
+          assert(
+            assistantMessages.nonEmpty,
+            "Expected AssistantMessage in second turn"
+          )
+          val responseText = assistantMessages
+            .flatMap(_.content.collect { case TextBlock(t) => t })
+            .mkString
+          assert(
+            responseText.contains("42"),
+            s"Expected second turn to reference '42', got: $responseText"
+          )
+      }
+  }
+
+  // ============================================================
+  // E3: Session ID is valid after real CLI interaction
+  // ============================================================
+
+  test("E2E: session ID is a valid non-pending value after first turn") {
+    IO(assumeClaudeAvailable()) *>
+      ClaudeCode.session(SessionOptions()).use { session =>
+        for
+          _ <- session.send("What is 1+1? Reply with just the number.")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+        yield
+          assert(
+            id != "pending",
+            s"Expected a real session ID after first turn, got: $id"
+          )
+          assert(
+            id.nonEmpty,
+            "Session ID should not be empty after first turn"
+          )
+      }
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala
@@ -1,0 +1,144 @@
+// PURPOSE: Integration tests for effectful Session error handling with mock CLI scripts
+// PURPOSE: Verifies process crash, between-turn crash, malformed JSON resilience, and resource cleanup
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.SessionProcessDied
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import scala.concurrent.duration.*
+
+class SessionErrorIntegrationTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // I1: Process crash mid-turn surfaces SessionProcessDied
+  // ============================================================
+
+  test("process crash mid-turn: stream raises SessionProcessDied") {
+    val exitCode = 42
+    val script = SessionMockCliScript.createCrashMidTurnScript(exitCode)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("trigger crash")
+          result <- session.stream.compile.drain.attempt
+        yield
+          assert(result.isLeft, s"Expected stream to fail: $result")
+          val err = result.swap.toOption
+          assert(
+            err.exists(_.isInstanceOf[SessionProcessDied]),
+            s"Expected SessionProcessDied, got: $err"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // I2: Process crash between turns raises SessionProcessDied on second send
+  // ============================================================
+
+  test("process crash between turns: second send raises SessionProcessDied") {
+    val script =
+      SessionMockCliScript.createCrashBetweenTurnsScript(exitCode = 1)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          // First turn should complete normally
+          _ <- session.send("First prompt")
+          turn1Messages <- session.stream.compile.toList
+          _ = assert(
+            turn1Messages.exists(_.isInstanceOf[ResultMessage]),
+            s"Expected ResultMessage in turn 1: $turn1Messages"
+          )
+          // Poll until the process is detected as dead
+          result <- {
+            def pollUntilDead(remaining: Int): IO[Either[Throwable, Unit]] =
+              if remaining <= 0 then IO.pure(Right(()))
+              else
+                session.send("Second prompt").attempt.flatMap {
+                  case Left(err) => IO.pure(Left(err))
+                  case Right(_)  =>
+                    IO.sleep(50.millis) *> pollUntilDead(remaining - 1)
+                }
+            pollUntilDead(100)
+          }
+        yield
+          assert(result.isLeft, s"Expected second send to fail: $result")
+          val err = result.swap.toOption.collect { case e: SessionProcessDied =>
+            e
+          }
+          assert(
+            err.isDefined,
+            s"Expected SessionProcessDied, got: ${result.swap.toOption}"
+          )
+          assertEquals(
+            err.get.exitCode,
+            Some(1),
+            s"Expected exit code 1, got: ${err.get.exitCode}"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // I3: Malformed JSON recovery with mock script
+  // ============================================================
+
+  test(
+    "malformed JSON recovery: bad JSON line followed by valid messages; valid messages arrive"
+  ) {
+    val script = SessionMockCliScript.createMalformedJsonMidTurnScript()
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            s"Expected AssistantMessage: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            s"Expected ResultMessage: $messages"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // I4: Resource cleanup after process crash does not hang
+  // ============================================================
+
+  test("Resource cleanup completes without hanging after process dies") {
+    val script = SessionMockCliScript.createImmediateExitScript(exitCode = 1)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    // The Resource finalizer should complete cleanly even when the process has died
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        // Poll until the process is detected as dead
+        def pollUntilDead(remaining: Int): IO[Unit] =
+          if remaining <= 0 then IO.unit
+          else
+            session.send("probe").attempt.flatMap {
+              case Left(_)  => IO.unit
+              case Right(_) =>
+                IO.sleep(50.millis) *> pollUntilDead(remaining - 1)
+            }
+        pollUntilDead(100)
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+    // If we get here without timeout, the test passes
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala
@@ -1,0 +1,144 @@
+// PURPOSE: Tests for session error handling in the effectful (cats-effect/fs2) API
+// PURPOSE: Covers process crash, malformed JSON resilience, and dead-process detection
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.SessionProcessDied
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import scala.concurrent.duration.*
+
+class SessionErrorTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // E1: send to dead process raises SessionProcessDied in IO
+  // ============================================================
+
+  test("send to a dead process raises SessionProcessDied in IO") {
+    val script = SessionMockCliScript.createImmediateExitScript(exitCode = 1)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        // Poll until send fails (process has exited), with a timeout
+        def pollUntilDead(remaining: Int): IO[Either[Throwable, Unit]] =
+          if remaining <= 0 then IO.pure(Right(()))
+          else
+            session.send("should fail").attempt.flatMap {
+              case Left(err) => IO.pure(Left(err))
+              case Right(_)  =>
+                IO.sleep(50.millis) *> pollUntilDead(remaining - 1)
+            }
+
+        pollUntilDead(100).map { result =>
+          assert(
+            result.isLeft,
+            s"Expected send to fail but got: $result"
+          )
+          assert(
+            result.swap.toOption.exists(_.isInstanceOf[SessionProcessDied]),
+            s"Expected SessionProcessDied, got: ${result.swap.toOption}"
+          )
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // E2: stream raises SessionProcessDied when process exits mid-turn
+  // ============================================================
+
+  test(
+    "stream raises SessionProcessDied when process exits mid-turn (before ResultMessage)"
+  ) {
+    val script = SessionMockCliScript.createCrashMidTurnScript(exitCode = 1)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("trigger crash")
+          result <- session.stream.compile.drain.attempt
+        yield
+          assert(result.isLeft, s"Expected stream to fail but got: $result")
+          assert(
+            result.swap.toOption.exists(_.isInstanceOf[SessionProcessDied]),
+            s"Expected SessionProcessDied, got: ${result.swap.toOption}"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // E3: Malformed JSON line is logged and skipped; valid messages arrive
+  // ============================================================
+
+  test(
+    "malformed JSON line is logged and skipped; valid messages arrive with exactly 1 ResultMessage"
+  ) {
+    val script = SessionMockCliScript.createMalformedJsonMidTurnScript()
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            s"Expected AssistantMessage in stream: $messages"
+          )
+
+          val resultMessages = messages.collect { case r: ResultMessage => r }
+          assertEquals(
+            resultMessages.length,
+            1,
+            s"Expected exactly 1 ResultMessage, got: $messages"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // E4: send after process death with no pending error raises SessionProcessDied
+  // ============================================================
+
+  test(
+    "send after process death with no pending error raises SessionProcessDied"
+  ) {
+    // Use a script that exits immediately — the stdout reader may not have
+    // time to set a pendingError, exercising the None branch in pendingErrorRef
+    val script = SessionMockCliScript.createImmediateExitScript(exitCode = 0)
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        // Poll until the process is detected as dead
+        def pollUntilDead(remaining: Int): IO[Either[Throwable, Unit]] =
+          if remaining <= 0 then IO.pure(Right(()))
+          else
+            session.send("should fail").attempt.flatMap {
+              case Left(err) => IO.pure(Left(err))
+              case Right(_)  =>
+                IO.sleep(50.millis) *> pollUntilDead(remaining - 1)
+            }
+
+        pollUntilDead(100).map { result =>
+          assert(
+            result.isLeft,
+            s"Expected send to fail but got: $result"
+          )
+          assert(
+            result.swap.toOption.exists(_.isInstanceOf[SessionProcessDied]),
+            s"Expected SessionProcessDied, got: ${result.swap.toOption}"
+          )
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
@@ -1,0 +1,458 @@
+// PURPOSE: Integration tests for effectful Session using mock CLI scripts
+// PURPOSE: Verifies full session lifecycle, Resource cleanup, stdin JSON format, and ClaudeCode factory
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import io.circe.parser
+import java.nio.file.Files
+
+class SessionIntegrationTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // IT1: Full single-turn session lifecycle
+  // ============================================================
+
+  test("full single-turn session lifecycle with mock CLI") {
+    val sessionId = "integ-session-001"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "The answer is 42"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("What is the answer?")
+          messages <- session.stream.compile.toList
+        yield
+          assertEquals(messages.length, 2)
+          messages.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("The answer is 42")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          messages.last match
+            case r: ResultMessage =>
+              assertEquals(r.subtype, "conversation_result")
+              assertEquals(r.isError, false)
+              assertEquals(r.sessionId, sessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT2: Resource cleanup on normal exit
+  // ============================================================
+
+  test("Resource cleanup terminates process on normal exit") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(SessionMockCliScript.CommonResponses.resultMessage())
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    // Track whether cleanup ran (we verify indirectly by checking that
+    // the Resource.use block completes without hanging)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.send("test") *> session.stream.compile.drain
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT3: Resource cleanup on error
+  // ============================================================
+
+  test("Resource cleanup terminates process when exception occurs inside use") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = Nil
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { _ =>
+        IO.raiseError(new RuntimeException("deliberate test error"))
+      }
+      .attempt
+      .map {
+        case Left(e: RuntimeException) =>
+          assertEquals(e.getMessage, "deliberate test error")
+        case Left(other) =>
+          fail(
+            s"Expected RuntimeException, got: ${other.getClass.getSimpleName}"
+          )
+        case Right(_) =>
+          fail("Expected exception to propagate through Resource.use")
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT4: Stdin JSON verification
+  // ============================================================
+
+  test("stdin carries correct SDKUserMessage JSON") {
+    val captureFile = Files.createTempFile("stdin-integ-", ".jsonl")
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(SessionMockCliScript.CommonResponses.resultMessage())
+        )
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.send(
+          "Hello from integration test"
+        ) *> session.stream.compile.drain
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+      .flatMap { _ =>
+        IO {
+          val lines = Files.readAllLines(captureFile)
+          assert(lines.size >= 1, "Expected at least one stdin line")
+          val json = parser
+            .parse(lines.get(0))
+            .toOption
+            .getOrElse(fail(s"stdin not valid JSON: ${lines.get(0)}"))
+          val cursor = json.hcursor
+          assertEquals(
+            cursor.downField("type").as[String].toOption,
+            Some("user")
+          )
+          assertEquals(
+            cursor
+              .downField("message")
+              .downField("content")
+              .as[String]
+              .toOption,
+            Some("Hello from integration test")
+          )
+          Files.delete(captureFile)
+        }
+      }
+  }
+
+  // ============================================================
+  // IT5: Session ID from init message
+  // ============================================================
+
+  test("session ID is set from mock init message during acquire") {
+    val expectedSessionId = "integ-init-session-999"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              expectedSessionId
+            )
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, expectedSessionId)
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT6: Two-turn lifecycle
+  // ============================================================
+
+  test("two-turn lifecycle returns correct responses per turn") {
+    val initSessionId = "two-turn-init-001"
+    val turn1SessionId = "two-turn-result-001"
+    val turn2SessionId = "two-turn-result-002"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "First turn answer"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+          )
+        ),
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Second turn answer"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(turn2SessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          initId <- session.sessionId
+          _ = assertEquals(initId, initSessionId)
+          _ <- session.send("First question")
+          turn1 <- session.stream.compile.toList
+          _ = assertEquals(turn1.length, 2)
+          _ = turn1.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("First turn answer")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          _ = turn1.last match
+            case r: ResultMessage => assertEquals(r.sessionId, turn1SessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+          id1 <- session.sessionId
+          _ = assertEquals(id1, turn1SessionId)
+          _ <- session.send("Second question")
+          turn2 <- session.stream.compile.toList
+          _ = assertEquals(turn2.length, 2)
+          _ = turn2.head match
+            case AssistantMessage(content) =>
+              val texts = content.collect { case TextBlock(t) => t }
+              assert(texts.exists(_.contains("Second turn answer")))
+            case other => fail(s"Expected AssistantMessage, got: $other")
+          _ = turn2.last match
+            case r: ResultMessage => assertEquals(r.sessionId, turn2SessionId)
+            case other => fail(s"Expected ResultMessage, got: $other")
+          id2 <- session.sessionId
+          _ = assertEquals(id2, turn2SessionId)
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT7: Session ID progression across turns
+  // ============================================================
+
+  test("stdin capture shows correct session ID progression across turns") {
+    val initSessionId = "progression-init-001"
+    val turn1SessionId = "progression-turn-001"
+    val captureFile = Files.createTempFile("stdin-progression-integ-", ".jsonl")
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(initSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(turn1SessionId)
+          )
+        ),
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              "progression-turn-002"
+            )
+          )
+        )
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("Prompt one")
+          _ <- session.stream.compile.drain
+          _ <- session.send("Prompt two")
+          _ <- session.stream.compile.drain
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+      .flatMap { _ =>
+        IO {
+          val lines = Files.readAllLines(captureFile)
+          assert(
+            lines.size >= 2,
+            s"Expected at least 2 stdin lines, got ${lines.size}"
+          )
+
+          val firstJson = parser
+            .parse(lines.get(0))
+            .toOption
+            .getOrElse(fail(s"First stdin line not valid JSON"))
+          assertEquals(
+            firstJson.hcursor.downField("session_id").as[String].toOption,
+            Some(initSessionId),
+            "First send should carry init session ID"
+          )
+
+          val secondJson = parser
+            .parse(lines.get(1))
+            .toOption
+            .getOrElse(fail(s"Second stdin line not valid JSON"))
+          assertEquals(
+            secondJson.hcursor.downField("session_id").as[String].toOption,
+            Some(turn1SessionId),
+            "Second send should carry session ID from first turn's ResultMessage"
+          )
+          Files.delete(captureFile)
+        }
+      }
+  }
+
+  // ============================================================
+  // IT8: Variable message counts per turn
+  // ============================================================
+
+  test("turns with different message counts emit exactly the right messages") {
+    val sessionId = "msg-count-session"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        // Turn 1: assistant + result (2 messages)
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage("Short"),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        ),
+        // Turn 2: keepalive + stream_event + assistant + result (4 messages)
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.keepAliveMessage,
+            SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+            SessionMockCliScript.CommonResponses.assistantMessage("Verbose"),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("Short turn")
+          turn1 <- session.stream.compile.toList
+          _ = assertEquals(
+            turn1.length,
+            2,
+            s"Turn 1 should have 2 messages, got: $turn1"
+          )
+          _ = assert(
+            turn1.exists(_.isInstanceOf[AssistantMessage]),
+            "Turn 1 must have AssistantMessage"
+          )
+          _ = assert(
+            turn1.exists(_.isInstanceOf[ResultMessage]),
+            "Turn 1 must have ResultMessage"
+          )
+          _ = assert(
+            !turn1.exists(_ == KeepAliveMessage),
+            "Turn 1 must not have KeepAliveMessage"
+          )
+          _ <- session.send("Verbose turn")
+          turn2 <- session.stream.compile.toList
+          _ = assertEquals(
+            turn2.length,
+            4,
+            s"Turn 2 should have 4 messages, got: $turn2"
+          )
+          _ = assert(
+            turn2(0) == KeepAliveMessage,
+            s"Turn 2[0] should be KeepAliveMessage"
+          )
+          _ = assert(
+            turn2(1).isInstanceOf[StreamEventMessage],
+            s"Turn 2[1] should be StreamEventMessage"
+          )
+          _ = assert(
+            turn2(2).isInstanceOf[AssistantMessage],
+            s"Turn 2[2] should be AssistantMessage"
+          )
+          _ = assert(
+            turn2(3).isInstanceOf[ResultMessage],
+            s"Turn 2[3] should be ResultMessage"
+          )
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // IT9: ClaudeCode.session factory
+  // ============================================================
+
+  test("ClaudeCode.session factory produces a working session Resource") {
+    val sessionId = "factory-session-002"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Factory response"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("factory test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            "Expected AssistantMessage"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            "Expected ResultMessage"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }

--- a/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
@@ -1,0 +1,385 @@
+// PURPOSE: Unit tests for effectful Session trait and SessionProcess implementation
+// PURPOSE: Verifies session lifecycle, message flow, and session ID extraction using cats-effect IO
+package works.iterative.claude.effectful
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+import works.iterative.claude.core.model.*
+import works.iterative.claude.direct.internal.testing.SessionMockCliScript
+import io.circe.parser
+import java.nio.file.Files
+
+class SessionTest extends CatsEffectSuite:
+
+  given Logger[IO] = TestingLogger.impl[IO]()
+
+  // ============================================================
+  // T1: SDKUserMessage encoding test
+  // ============================================================
+
+  test("SDKUserMessage is correctly encoded for stdin") {
+    import io.circe.syntax.*
+    val msg = SDKUserMessage(content = "Hello, Claude!", sessionId = "sess-42")
+    val json = msg.asJson.noSpaces
+    val parsed = parser.parse(json).toOption.get
+    val cursor = parsed.hcursor
+
+    assertEquals(cursor.downField("type").as[String].toOption, Some("user"))
+    assertEquals(
+      cursor.downField("message").downField("role").as[String].toOption,
+      Some("user")
+    )
+    assertEquals(
+      cursor.downField("message").downField("content").as[String].toOption,
+      Some("Hello, Claude!")
+    )
+    assertEquals(
+      cursor.downField("session_id").as[String].toOption,
+      Some("sess-42")
+    )
+  }
+
+  // ============================================================
+  // T2: Session ID defaults to "pending"
+  // ============================================================
+
+  test("session ID defaults to 'pending' before any send") {
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = Nil
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, "pending")
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T3: Session ID extracted from init SystemMessage
+  // ============================================================
+
+  test(
+    "session ID is extracted from init SystemMessage during Resource acquire"
+  ) {
+    val expectedSessionId = "init-extracted-001"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(expectedSessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.resultMessage(
+              expectedSessionId
+            )
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        session.sessionId.map { id =>
+          assertEquals(id, expectedSessionId)
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T4: Session ID updated from ResultMessage
+  // ============================================================
+
+  test("session ID is updated from ResultMessage after stream completes") {
+    val updatedSessionId = "updated-session-id-456"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$updatedSessionId"}"""
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+        yield assertEquals(id, updatedSessionId)
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T5: stream returns messages up to and including ResultMessage
+  // ============================================================
+
+  test("stream completes after emitting ResultMessage") {
+    val sessionId = "sess-flow-test"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            """{"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}""",
+            s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$sessionId"}"""
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          val resultMessages = messages.collect { case r: ResultMessage => r }
+          assertEquals(resultMessages.length, 1)
+          val assistantMessages = messages.collect { case a: AssistantMessage =>
+            a
+          }
+          assertEquals(assistantMessages.length, 1)
+          assertEquals(messages.length, 2)
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T6: KeepAlive and StreamEvent pass through
+  // ============================================================
+
+  test("KeepAlive and StreamEvent messages pass through the stream") {
+    val sessionId = "keepalive-stream-session"
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = List(
+        SessionMockCliScript.CommonResponses.initMessage(sessionId)
+      ),
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(
+          List(
+            SessionMockCliScript.CommonResponses.keepAliveMessage,
+            SessionMockCliScript.CommonResponses.streamEventMessage("start"),
+            SessionMockCliScript.CommonResponses.assistantMessage(
+              "Answer with events"
+            ),
+            SessionMockCliScript.CommonResponses.resultMessage(sessionId)
+          )
+        )
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("test")
+          messages <- session.stream.compile.toList
+        yield
+          assert(
+            messages.exists(_ == KeepAliveMessage),
+            s"Expected KeepAliveMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[StreamEventMessage]),
+            s"Expected StreamEventMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[AssistantMessage]),
+            s"Expected AssistantMessage in stream: $messages"
+          )
+          assert(
+            messages.exists(_.isInstanceOf[ResultMessage]),
+            s"Expected ResultMessage in stream: $messages"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T7: Two sequential sends return isolated streams
+  // ============================================================
+
+  test("two sequential sends return isolated message streams") {
+    val turn1Response =
+      """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 1 response"}]}}"""
+    val turn1Result =
+      """{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"session-turn-1"}"""
+    val turn2Response =
+      """{"type":"assistant","message":{"content":[{"type":"text","text":"Turn 2 response"}]}}"""
+    val turn2Result =
+      """{"type":"result","subtype":"conversation_result","duration_ms":150,"duration_api_ms":60,"is_error":false,"num_turns":2,"session_id":"session-turn-2"}"""
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(List(turn1Response, turn1Result)),
+        SessionMockCliScript.TurnResponse(List(turn2Response, turn2Result))
+      )
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("First prompt")
+          turn1Messages <- session.stream.compile.toList
+          _ <- session.send("Second prompt")
+          turn2Messages <- session.stream.compile.toList
+        yield
+          assertEquals(turn1Messages.length, 2)
+          val turn1Assistants = turn1Messages.collect {
+            case a: AssistantMessage => a
+          }
+          assertEquals(turn1Assistants.length, 1)
+
+          assertEquals(turn2Messages.length, 2)
+          val turn2Assistants = turn2Messages.collect {
+            case a: AssistantMessage => a
+          }
+          assertEquals(turn2Assistants.length, 1)
+
+          val turn1Texts = turn1Assistants.flatMap(_.content.collect {
+            case TextBlock(t) => t
+          })
+          assert(
+            turn1Texts.exists(_.contains("Turn 1")),
+            s"Expected 'Turn 1' text: $turn1Texts"
+          )
+
+          val turn2Texts = turn2Assistants.flatMap(_.content.collect {
+            case TextBlock(t) => t
+          })
+          assert(
+            turn2Texts.exists(_.contains("Turn 2")),
+            s"Expected 'Turn 2' text: $turn2Texts"
+          )
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }
+
+  // ============================================================
+  // T8: Session ID propagates from first turn to second send
+  // ============================================================
+
+  test("session ID propagates from first turn ResultMessage to second send") {
+    val firstTurnSessionId = "session-after-turn-1"
+    val captureFile = Files.createTempFile("stdin-capture-effectful-", ".jsonl")
+    val turn1Result =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":1,"session_id":"$firstTurnSessionId"}"""
+    val turn2Result =
+      s"""{"type":"result","subtype":"conversation_result","duration_ms":120,"duration_api_ms":55,"is_error":false,"num_turns":2,"session_id":"session-after-turn-2"}"""
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = List(
+        SessionMockCliScript.TurnResponse(List(turn1Result)),
+        SessionMockCliScript.TurnResponse(List(turn2Result))
+      ),
+      captureStdinFile = Some(captureFile)
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    val test = ClaudeCode
+      .session(options)
+      .use { session =>
+        for
+          _ <- session.send("First prompt")
+          _ <- session.stream.compile.drain
+          id <- session.sessionId
+          _ = assertEquals(id, firstTurnSessionId)
+          _ <- session.send("Second prompt")
+          _ <- session.stream.compile.drain
+        yield ()
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+
+    test.flatMap { _ =>
+      IO {
+        val lines = Files.readAllLines(captureFile)
+        assert(
+          lines.size >= 2,
+          s"Expected at least 2 stdin lines, got ${lines.size}"
+        )
+
+        val secondLine = lines.get(1)
+        val secondJson = parser
+          .parse(secondLine)
+          .toOption
+          .getOrElse(fail(s"Second stdin line not valid JSON: $secondLine"))
+        assertEquals(
+          secondJson.hcursor.downField("session_id").as[String].toOption,
+          Some(firstTurnSessionId)
+        )
+        Files.delete(captureFile)
+      }
+    }
+  }
+
+  // ============================================================
+  // T9: Three-turn cycling
+  // ============================================================
+
+  test("three sequential sends each return only their own turn's messages") {
+    val turns = (1 to 3).map { i =>
+      SessionMockCliScript.TurnResponse(
+        List(
+          s"""{"type":"assistant","message":{"content":[{"type":"text","text":"Response $i"}]}}""",
+          s"""{"type":"result","subtype":"conversation_result","duration_ms":100,"duration_api_ms":50,"is_error":false,"num_turns":$i,"session_id":"session-turn-$i"}"""
+        )
+      )
+    }.toList
+
+    val script = SessionMockCliScript.createSessionScript(
+      initMessages = Nil,
+      turnResponses = turns
+    )
+    val options = SessionOptions().withClaudeExecutable(script.toString)
+    ClaudeCode
+      .session(options)
+      .use { session =>
+        def runTurn(i: Int): IO[List[Message]] =
+          session.send(s"Prompt $i") *> session.stream.compile.toList
+
+        for
+          t1 <- runTurn(1)
+          t2 <- runTurn(2)
+          t3 <- runTurn(3)
+        yield List(t1, t2, t3).zipWithIndex.foreach { case (msgs, idx) =>
+          val i = idx + 1
+          assertEquals(
+            msgs.length,
+            2,
+            s"Turn $i: expected 2 messages, got ${msgs.length}"
+          )
+          assert(
+            msgs.head.isInstanceOf[AssistantMessage],
+            s"Turn $i: first should be AssistantMessage"
+          )
+          assert(
+            msgs.last.isInstanceOf[ResultMessage],
+            s"Turn $i: last should be ResultMessage"
+          )
+          val resultMsg = msgs.last.asInstanceOf[ResultMessage]
+          assertEquals(
+            resultMsg.sessionId,
+            s"session-turn-$i",
+            s"Turn $i: wrong session ID"
+          )
+        }
+      }
+      .guarantee(IO { SessionMockCliScript.cleanup(script): Unit })
+  }

--- a/project-management/issues/CC-15/analysis.md
+++ b/project-management/issues/CC-15/analysis.md
@@ -290,67 +290,51 @@ This is a research-heavy story. The exact stdin JSON format for `--input-format 
 - Newline-delimited JSON writing to process stdin
 - Response boundary detection based on ResultMessage arrival
 
-## Technical Risks & Uncertainties
+## Technical Decisions (Resolved)
 
-### CLARIFY: Exact `--input-format stream-json` protocol
+### RESOLVED: Exact `--input-format stream-json` protocol
 
-The most critical unknown. We need to understand what JSON format the CLI expects on stdin and how it signals response boundaries on stdout.
+Investigated via the `@anthropic-ai/claude-agent-sdk` TypeScript SDK (v0.1.0).
 
-**Questions to answer:**
-1. What is the exact JSON schema for stdin messages? Is it `{"type": "user", "content": "..."}` or something else?
-2. How are response boundaries delimited on stdout? Is it always a `ResultMessage` with `type: "result"`?
-3. Does the CLI support any control messages (e.g., abort current turn, graceful shutdown)?
-4. Is `--print` compatible with `--input-format stream-json`, or does session mode replace it?
+**Stdin format** — `SDKUserMessage`:
+```json
+{"type": "user", "message": {"role": "user", "content": "..."}, "parent_tool_use_id": null, "session_id": "..."}
+```
 
-**Options:**
-- **Option A**: Read Claude Code CLI source / documentation to understand the protocol before implementation
-- **Option B**: Experiment with the CLI manually (`echo '...' | claude --input-format stream-json`) to discover the protocol
-- **Option C**: Start with the Python SDK's session implementation as reference
+**Session lifecycle:**
+1. CLI sends `system`/`init` message on stdout with assigned `session_id`
+2. Client sends `SDKUserMessage` on stdin using that `session_id` (first message can use `"pending"`)
+3. CLI responds with interleaved `stream_event`, `assistant`, and `keep_alive` messages
+4. `ResultMessage` with `type: "result"` signals end-of-turn
+5. Process stays alive for next turn
 
-**Impact:** Blocks Stories 1, 2, 3, and 6. This must be resolved first.
+**Additional message types discovered:**
+- `stream_event` — partial streaming events (content deltas), new type not in current model
+- `keep_alive` — periodic heartbeat messages
+- `control_request` / `control_response` — bidirectional control (interrupt, model switch, etc.) — out of scope for now
 
----
-
-### CLARIFY: Session trait design -- shared or separate per API style
-
-**Questions to answer:**
-1. Should there be a shared `Session` trait in `core` with API-specific implementations?
-2. Or should direct and effectful each define their own Session independently?
-3. Does `Session` need to expose session ID from ResultMessage?
-
-**Options:**
-- **Option A**: Shared trait in `core` with `send` returning a generic streaming type -- likely impractical due to Flow vs Stream difference
-- **Option B**: Separate Session traits per API style with a shared SessionOptions in core -- mirrors current QueryOptions/ClaudeCode split
-- **Option C**: Single Session trait parameterized by effect type (higher-kinded) -- more complex but DRY
-
-**Impact:** Affects code organization and potential code duplication between direct/effectful APIs.
+**CLI flags:** `--print --input-format stream-json --output-format stream-json` (all three required)
 
 ---
 
-### CLARIFY: Turn sequencing semantics
+### RESOLVED: Session trait design — separate per API style (Option B)
 
-**Questions to answer:**
-1. What happens if the user calls `send` before the previous turn's response is fully consumed?
-2. Should we enforce sequential access (error if previous Flow/Stream not drained)?
-3. Or should we auto-drain the previous response before sending the next message?
-
-**Options:**
-- **Option A**: Enforce sequential -- throw/raise error if previous turn not complete
-- **Option B**: Auto-drain previous turn's remaining messages before sending next
-- **Option C**: Let the CLI handle it and don't add client-side enforcement
-
-**Impact:** Affects API ergonomics and potential for data loss (unconsumed messages).
+Separate Session traits for direct and effectful APIs, with shared `SessionOptions` in `core.model`. This mirrors the existing `ClaudeCode` / `QueryOptions` split. `Flow` and `Stream` are fundamentally different types, making a shared trait impractical without unnecessary complexity.
 
 ---
 
-### CLARIFY: CLI argument compatibility with session mode
+### RESOLVED: Turn sequencing — delegate to CLI (Option C)
 
-**Questions to answer:**
-1. Which existing QueryOptions flags are valid in session mode? (`--model`, `--system-prompt`, `--allowed-tools`, etc.)
-2. Is `--print` used in session mode or is it implied?
-3. Are `--continue` and `--resume` meaningful in session mode (the session IS the continuation)?
+No client-side enforcement. The CLI supports queueing messages, so if the user calls `send` before the previous turn is fully consumed, the CLI handles it. This simplifies the implementation and avoids silently discarding messages.
 
-**Impact:** Determines which fields SessionOptions should include vs exclude.
+---
+
+### RESOLVED: CLI argument compatibility with session mode
+
+- `--print` is **required** for `--input-format stream-json` (non-interactive mode prerequisite)
+- `--continue` and `--resume` **are valid** in session mode (resume a previous conversation in streaming mode)
+- All other flags (model, system-prompt, allowed-tools, permission-mode, max-turns, etc.) are valid as startup flags
+- `SessionOptions` should include everything from `QueryOptions` **except `prompt`** (prompts are sent per-turn via stdin)
 
 ## Total Estimates
 
@@ -364,13 +348,13 @@ The most critical unknown. We need to understand what JSON format the CLI expect
 
 **Total Range:** 40 - 56 hours
 
-**Confidence:** Low
+**Confidence:** Medium
 
 **Reasoning:**
-- The `--input-format stream-json` protocol is not well-documented and needs investigation before reliable estimates
-- Story 1 and 3 complexity depends heavily on protocol details discovered in Story 6
+- Protocol is now well-understood from the TypeScript Agent SDK
 - Ox Flow and fs2 Stream composition for long-lived bidirectional I/O is non-trivial
 - No prior art in this codebase for keeping a process alive across multiple interactions
+- Story 6 effort may decrease since protocol research is complete
 
 ## Testing Approach
 
@@ -445,7 +429,6 @@ None -- this is a library, no persistent storage.
 ## Dependencies
 
 ### Prerequisites
-- Resolution of CLARIFY: `--input-format stream-json` protocol (blocks everything)
 - Claude Code CLI version that supports `--input-format stream-json`
 
 ### Story Dependencies
@@ -458,7 +441,6 @@ None -- this is a library, no persistent storage.
 
 ### External Blockers
 - Claude Code CLI must support `--input-format stream-json` in the installed version
-- Protocol documentation or source code access for the CLI
 
 ---
 
@@ -489,11 +471,8 @@ None -- this is a library, no persistent storage.
 
 ---
 
-**Analysis Status:** Ready for Review
+**Analysis Status:** All CLARIFYs Resolved
 
 **Next Steps:**
-1. Resolve CLARIFY markers -- especially the `--input-format stream-json` protocol (investigate CLI source or experiment)
-2. Decide on Session trait design (shared vs separate per API style)
-3. Decide on turn sequencing semantics
-4. Run **ag-create-tasks** with the issue ID
-5. Run **ag-implement** for iterative story implementation
+1. Run **ag-create-tasks** with the issue ID
+2. Run **ag-implement** for iterative story implementation

--- a/project-management/issues/CC-15/analysis.md
+++ b/project-management/issues/CC-15/analysis.md
@@ -1,0 +1,499 @@
+# Story-Driven Analysis: Support persistent two-way conversations with a single Claude Code session
+
+**Issue:** CC-15
+**Created:** 2026-04-02
+**Status:** Draft
+**Classification:** Feature
+
+## Problem Statement
+
+Every API call currently spawns a new Claude Code CLI subprocess that runs to completion and exits. Continuing a conversation requires `--resume sessionId` or `--continue`, which starts a fresh process each turn. This means each turn pays full process startup cost, session state is serialized/deserialized between turns on the CLI side, and there is no way to maintain a live, interactive session from Scala code.
+
+The Claude Code CLI supports `--input-format stream-json`, where JSON messages are written to stdin and JSON responses are read on stdout in a continuous loop. This feature enables a single long-lived process that handles multiple conversational turns without restart overhead.
+
+## User Stories
+
+### Story 1: Direct API - Basic session lifecycle (open, send, close)
+
+```gherkin
+Funkce: Interaktivni relace s Claude Code
+  Jako vyvojar pouzivajici direct API
+  Chci otevrit relaci, poslat zpravu a dostat odpoved
+  Aby jsem nemusel platit startovaci naklady procesu pri kazdem dotazu
+
+Scenar: Zakladni konverzace s jednou zpravou
+  Pokud mam nakonfigurované SessionOptions
+  Kdyz otevru novou relaci pres ClaudeCode.session
+  A poslu zpravu "What files are in this project?"
+  Pak dostanu Flow[Message] s odpovedi asistenta
+  A po zavreni relace se podkladovy proces ukonci
+```
+
+**Estimated Effort:** 12-16h
+**Complexity:** Complex
+
+**Technical Feasibility:**
+This is the core story and the hardest one. The existing ProcessManager closes stdin immediately after process start and waits for process exit. Session mode requires keeping stdin open for writing and stdout open for continuous reading, with a way to delimit response boundaries per turn. The main risk is understanding the exact stdin/stdout protocol of `--input-format stream-json` -- what JSON format stdin expects, and how responses on stdout are delimited between turns.
+
+**Acceptance:**
+- A session can be opened, a message sent, a streaming response received, and the session closed
+- The underlying CLI process starts once and stays alive across send calls
+- Process is terminated cleanly on close
+
+---
+
+### Story 2: Direct API - Multi-turn conversation
+
+```gherkin
+Funkce: Vicekolova konverzace
+  Jako vyvojar pouzivajici direct API
+  Chci poslat vice zprav v ramci jedne relace
+  Aby Claude mel kontext predchozich odpovedi
+
+Scenar: Dve navazujici otazky
+  Pokud mam otevrenu relaci
+  Kdyz poslu zpravu "What files are in this project?"
+  A pockan na dokonceni odpovedi
+  A poslu dalsi zpravu "Now explain the main entry point."
+  Pak druha odpoved reflektuje kontext prvni otazky
+  A obe odpovedi prisly ze stejneho procesu
+```
+
+**Estimated Effort:** 4-6h
+**Complexity:** Moderate
+
+**Technical Feasibility:**
+Once Story 1 works, multi-turn is about correctly delimiting response boundaries. The key challenge is knowing when one turn's response is complete so the next send can proceed. This likely depends on a `ResultMessage` marking end-of-turn in the stream. Sequential-only semantics simplifies this -- no need for concurrent send coordination.
+
+**Acceptance:**
+- Multiple sequential send calls work within one session
+- Each send returns a complete stream of messages for that turn
+- Context is maintained across turns (CLI handles this internally)
+
+---
+
+### Story 3: Effectful API - Session lifecycle with Resource
+
+```gherkin
+Funkce: Efektova relace s automatickym uvolnenim
+  Jako vyvojar pouzivajici cats-effect API
+  Chci pouzit relaci jako Resource[IO, Session]
+  Aby se proces automaticky ukoncil i pri chybe
+
+Scenar: Relace s automatickym uvolnenim
+  Pokud pouziji ClaudeCode.session(...).use
+  Kdyz poslu zpravu a dostanu odpoved
+  Pak se po opusteni bloku use proces automaticky ukonci
+  A i pri vyjimce se proces korektne uklidi
+```
+
+**Estimated Effort:** 8-12h
+**Complexity:** Complex
+
+**Technical Feasibility:**
+The effectful ProcessManager already uses `fs2.io.process.ProcessBuilder.spawn` as a `Resource`. The challenge is adapting this to keep the process alive and pipe multiple messages through stdin while reading responses from stdout as fs2 Streams. Resource semantics provide natural cleanup, but stdin writing needs careful coordination with stdout reading.
+
+**Acceptance:**
+- Session is exposed as Resource[IO, Session] or similar bracket pattern
+- Process cleanup happens automatically on normal exit and on error
+- send returns Stream[IO, Message] for each turn
+
+---
+
+### Story 4: SessionOptions configuration
+
+```gherkin
+Funkce: Konfigurace relace
+  Jako vyvojar
+  Chci nakonfigurovat relaci podobne jako QueryOptions
+  Aby jsem mohl nastavit model, system prompt, povolene nastroje atd.
+
+Scenar: Relace s vlastnim system promptem
+  Pokud vytvorim SessionOptions se systemPrompt "You are a code reviewer"
+  Kdyz otevru relaci s temito moznostmi
+  Pak CLI proces dostane spravne argumenty vcetne system promptu
+  A relace funguje s danou konfiguraci
+```
+
+**Estimated Effort:** 4-6h
+**Complexity:** Straightforward
+
+**Technical Feasibility:**
+SessionOptions shares most fields with QueryOptions minus `prompt` (since prompts are sent per-turn). CLIArgumentBuilder needs minor adaptation to support `--input-format stream-json` and omit the trailing prompt argument. This is largely mechanical.
+
+**Acceptance:**
+- SessionOptions supports all relevant QueryOptions fields (model, systemPrompt, allowedTools, permissionMode, cwd, environment, etc.)
+- CLIArgumentBuilder can build args for session mode
+- prompt is NOT part of SessionOptions
+
+---
+
+### Story 5: Error handling - process crash and malformed JSON
+
+```gherkin
+Funkce: Zpracovani chyb behem relace
+  Jako vyvojar
+  Chci dostat typovane chyby kdyz se neco pokazi
+  Aby jsem mohl chyby spravne osetrit
+
+Scenar: Spadnuty proces behem relace
+  Pokud mam otevrenu relaci
+  Kdyz CLI proces neocekavane skonci
+  Pak dalsi volani send vyhodi typovanou chybu
+  A relace se oznaci jako neplatna
+
+Scenar: Neplatny JSON na vystupu
+  Pokud mam otevrenu relaci
+  Kdyz CLI proces vypise neplatny JSON
+  Pak chyba je zaznamenana
+  A relace zustane funkcni pro dalsi zpravy
+```
+
+**Estimated Effort:** 6-8h
+**Complexity:** Moderate
+
+**Technical Feasibility:**
+The existing CLIError hierarchy covers the error types needed. The main work is detecting process termination during an active session and propagating errors through the stream/Flow to the caller. Malformed JSON handling already exists in JsonParser; it just needs to work in the continuous-reading context.
+
+**Acceptance:**
+- Process crash surfaces as typed CLIError through send's return type
+- Malformed JSON lines are skipped with logging (existing behavior)
+- Session detects when underlying process has died
+- Clear error message distinguishing session-level vs turn-level failures
+
+---
+
+### Story 6: Stdin message format and response delimiting
+
+```gherkin
+Funkce: Spravny format zprav na stdin
+  Jako SDK
+  Chci posilat zpravy ve spravnem JSON formatu na stdin procesu
+  Aby CLI spravne interpretoval moje pozadavky
+
+Scenar: Odeslani uzivatelske zpravy
+  Pokud mam otevreny stream-json proces
+  Kdyz zapisu JSON zpravu na stdin
+  Pak CLI ji prijme a zacne streamovat odpoved
+  A odpoved konci ResultMessage
+
+Scenar: Rozpoznani konce odpovedi
+  Pokud CLI streamuje odpoved
+  Kdyz prijmu ResultMessage na stdout
+  Pak vim ze odpoved je kompletni
+  A mohu poslat dalsi zpravu
+```
+
+**Estimated Effort:** 6-8h
+**Complexity:** Moderate
+
+**Technical Feasibility:**
+This is a research-heavy story. The exact stdin JSON format for `--input-format stream-json` needs investigation. The response end delimiter is likely a `ResultMessage` with `type: "result"` which the parser already handles. The risk is that the protocol may have undocumented nuances.
+
+**Acceptance:**
+- Stdin messages are written in the correct JSON format
+- Response boundary is correctly detected (likely ResultMessage)
+- Works with actual Claude Code CLI (integration test)
+
+## Architectural Sketch
+
+**Purpose:** List WHAT components each story needs, not HOW they're implemented.
+
+### For Story 1: Direct API - Basic session lifecycle
+
+**Domain Layer:**
+- `SessionOptions` -- configuration value object (shared with Story 4)
+- `Session` trait -- represents an active conversational session
+
+**Application Layer:**
+- `ClaudeCode.session(SessionOptions)` -- factory method returning a Session
+- `Session.send(prompt: String): Flow[Message]` -- sends a turn, returns streaming response
+- `Session.close(): Unit` -- terminates the session
+
+**Infrastructure Layer:**
+- New process management mode in direct ProcessManager that keeps stdin open
+- Stdin writer component for sending JSON messages to process
+- Stdout reader that continuously reads and can partition responses per turn
+
+**Presentation Layer:**
+- Extension to `works.iterative.claude.direct.ClaudeCode` with `session` method
+- Re-exports in `direct` package object for Session types
+
+---
+
+### For Story 2: Direct API - Multi-turn conversation
+
+**Domain Layer:**
+- No new types; uses Session from Story 1
+
+**Application Layer:**
+- Turn sequencing logic in Session (ensure previous turn is complete before next send)
+
+**Infrastructure Layer:**
+- Response boundary detection (watching for ResultMessage to signal end-of-turn)
+- Stdin flushing between turns
+
+---
+
+### For Story 3: Effectful API - Session lifecycle with Resource
+
+**Domain Layer:**
+- `Session[F[_]]` trait (or effectful-specific Session trait)
+
+**Application Layer:**
+- `ClaudeCode.session(SessionOptions): Resource[IO, Session]`
+- `Session.send(prompt: String): Stream[IO, Message]`
+
+**Infrastructure Layer:**
+- Adapted effectful ProcessManager that keeps process alive
+- fs2 Pipe or Stream composition for stdin writing
+- Resource finalizer for process cleanup
+
+**Presentation Layer:**
+- Extension to `works.iterative.claude.effectful.ClaudeCode`
+
+---
+
+### For Story 4: SessionOptions configuration
+
+**Domain Layer:**
+- `SessionOptions` case class in `core.model`
+
+**Application Layer:**
+- Fluent builder methods on SessionOptions (matching QueryOptions style)
+
+**Infrastructure Layer:**
+- `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions)` 
+- Adds `--input-format stream-json` and `--verbose --output-format stream-json`
+- Omits trailing prompt argument
+
+---
+
+### For Story 5: Error handling
+
+**Domain Layer:**
+- Possibly new error subtypes: `SessionTerminatedError`, `SessionSendError`
+
+**Infrastructure Layer:**
+- Process liveness check before/during send
+- Error propagation through Flow/Stream when process dies mid-turn
+
+---
+
+### For Story 6: Stdin message format
+
+**Domain Layer:**
+- `StdinMessage` -- representation of JSON message written to CLI stdin
+
+**Infrastructure Layer:**
+- JSON encoder for stdin messages (likely circe Encoder)
+- Newline-delimited JSON writing to process stdin
+- Response boundary detection based on ResultMessage arrival
+
+## Technical Risks & Uncertainties
+
+### CLARIFY: Exact `--input-format stream-json` protocol
+
+The most critical unknown. We need to understand what JSON format the CLI expects on stdin and how it signals response boundaries on stdout.
+
+**Questions to answer:**
+1. What is the exact JSON schema for stdin messages? Is it `{"type": "user", "content": "..."}` or something else?
+2. How are response boundaries delimited on stdout? Is it always a `ResultMessage` with `type: "result"`?
+3. Does the CLI support any control messages (e.g., abort current turn, graceful shutdown)?
+4. Is `--print` compatible with `--input-format stream-json`, or does session mode replace it?
+
+**Options:**
+- **Option A**: Read Claude Code CLI source / documentation to understand the protocol before implementation
+- **Option B**: Experiment with the CLI manually (`echo '...' | claude --input-format stream-json`) to discover the protocol
+- **Option C**: Start with the Python SDK's session implementation as reference
+
+**Impact:** Blocks Stories 1, 2, 3, and 6. This must be resolved first.
+
+---
+
+### CLARIFY: Session trait design -- shared or separate per API style
+
+**Questions to answer:**
+1. Should there be a shared `Session` trait in `core` with API-specific implementations?
+2. Or should direct and effectful each define their own Session independently?
+3. Does `Session` need to expose session ID from ResultMessage?
+
+**Options:**
+- **Option A**: Shared trait in `core` with `send` returning a generic streaming type -- likely impractical due to Flow vs Stream difference
+- **Option B**: Separate Session traits per API style with a shared SessionOptions in core -- mirrors current QueryOptions/ClaudeCode split
+- **Option C**: Single Session trait parameterized by effect type (higher-kinded) -- more complex but DRY
+
+**Impact:** Affects code organization and potential code duplication between direct/effectful APIs.
+
+---
+
+### CLARIFY: Turn sequencing semantics
+
+**Questions to answer:**
+1. What happens if the user calls `send` before the previous turn's response is fully consumed?
+2. Should we enforce sequential access (error if previous Flow/Stream not drained)?
+3. Or should we auto-drain the previous response before sending the next message?
+
+**Options:**
+- **Option A**: Enforce sequential -- throw/raise error if previous turn not complete
+- **Option B**: Auto-drain previous turn's remaining messages before sending next
+- **Option C**: Let the CLI handle it and don't add client-side enforcement
+
+**Impact:** Affects API ergonomics and potential for data loss (unconsumed messages).
+
+---
+
+### CLARIFY: CLI argument compatibility with session mode
+
+**Questions to answer:**
+1. Which existing QueryOptions flags are valid in session mode? (`--model`, `--system-prompt`, `--allowed-tools`, etc.)
+2. Is `--print` used in session mode or is it implied?
+3. Are `--continue` and `--resume` meaningful in session mode (the session IS the continuation)?
+
+**Impact:** Determines which fields SessionOptions should include vs exclude.
+
+## Total Estimates
+
+**Story Breakdown:**
+- Story 1 (Direct API - Basic session lifecycle): 12-16 hours
+- Story 2 (Direct API - Multi-turn conversation): 4-6 hours
+- Story 3 (Effectful API - Session lifecycle): 8-12 hours
+- Story 4 (SessionOptions configuration): 4-6 hours
+- Story 5 (Error handling): 6-8 hours
+- Story 6 (Stdin message format and response delimiting): 6-8 hours
+
+**Total Range:** 40 - 56 hours
+
+**Confidence:** Low
+
+**Reasoning:**
+- The `--input-format stream-json` protocol is not well-documented and needs investigation before reliable estimates
+- Story 1 and 3 complexity depends heavily on protocol details discovered in Story 6
+- Ox Flow and fs2 Stream composition for long-lived bidirectional I/O is non-trivial
+- No prior art in this codebase for keeping a process alive across multiple interactions
+
+## Testing Approach
+
+**Per Story Testing:**
+
+Each story should have:
+1. **Unit Tests**
+2. **Integration Tests**
+3. **E2E Scenario Tests**
+
+**Story-Specific Testing Notes:**
+
+**Story 1 (Direct session lifecycle):**
+- Unit: Session state management (open/closed/error states), turn sequencing logic
+- Integration: Mock CLI script that reads stdin JSON and writes stdout JSON to verify protocol
+- E2E: Real Claude Code CLI session with actual send/receive
+
+**Story 2 (Multi-turn):**
+- Unit: Response boundary detection (ResultMessage signals end-of-turn)
+- Integration: Mock CLI script simulating multi-turn conversation
+- E2E: Real multi-turn conversation verifying context retention
+
+**Story 3 (Effectful session):**
+- Unit: Resource cleanup semantics, error propagation
+- Integration: Mock process with fs2 Process abstraction
+- E2E: Real cats-effect session with Resource.use
+
+**Story 4 (SessionOptions):**
+- Unit: CLIArgumentBuilder produces correct args for session mode
+- Unit: SessionOptions fluent API
+- Integration: Verify CLI receives expected arguments
+
+**Story 5 (Error handling):**
+- Unit: Error type construction and message formatting
+- Integration: Mock CLI that crashes mid-session, produces malformed JSON
+- E2E: Verify error propagation with real CLI edge cases
+
+**Story 6 (Stdin format):**
+- Unit: JSON encoder produces correct stdin messages
+- Integration: Round-trip test with mock CLI
+- E2E: Verify with real Claude Code CLI
+
+**Test Data Strategy:**
+- Mock CLI scripts (bash/python) that simulate stream-json protocol for integration tests
+- Extend existing `MockCliScript` pattern from direct tests
+- Real Claude Code CLI for E2E tests (gated on CLI availability, like existing integration tests)
+
+**Regression Coverage:**
+- Existing query/querySync/queryResult tests must continue passing
+- ProcessManager changes must not break one-shot query mode
+- CLIArgumentBuilder changes must not affect existing argument building
+
+## Deployment Considerations
+
+### Database Changes
+None -- this is a library, no persistent storage.
+
+### Configuration Changes
+- New `SessionOptions` type added to public API
+- New `session` method on both ClaudeCode entry points
+- No environment variable or config file changes
+
+### Rollout Strategy
+- Session API is purely additive -- existing query API unchanged
+- Can ship incrementally: direct API first, effectful API second
+- Feature is opt-in (users must explicitly use `session` method)
+
+### Rollback Plan
+- Remove session-related classes; existing API is unchanged
+- No migration needed since this is new functionality
+
+## Dependencies
+
+### Prerequisites
+- Resolution of CLARIFY: `--input-format stream-json` protocol (blocks everything)
+- Claude Code CLI version that supports `--input-format stream-json`
+
+### Story Dependencies
+- Story 6 (stdin format) should be investigated first as it unblocks all others
+- Story 4 (SessionOptions) is independent and can be done in parallel
+- Story 1 depends on Story 4 and Story 6
+- Story 2 depends on Story 1
+- Story 3 depends on Story 4 and Story 6 (parallel to Story 1)
+- Story 5 depends on Stories 1 and 3
+
+### External Blockers
+- Claude Code CLI must support `--input-format stream-json` in the installed version
+- Protocol documentation or source code access for the CLI
+
+---
+
+## Implementation Sequence
+
+**Recommended Story Order:**
+
+1. **Story 6: Stdin message format and response delimiting** - Must understand the protocol before building anything
+2. **Story 4: SessionOptions configuration** - Independent, provides foundation for session creation
+3. **Story 1: Direct API - Basic session lifecycle** - Core functionality, validates the approach
+4. **Story 2: Direct API - Multi-turn conversation** - Builds on Story 1, proves the value proposition
+5. **Story 3: Effectful API - Session lifecycle** - Parallel implementation using learnings from direct API
+6. **Story 5: Error handling** - Hardens both APIs
+
+**Iteration Plan:**
+
+- **Iteration 1** (Stories 6, 4): Protocol investigation + SessionOptions -- establishes foundation
+- **Iteration 2** (Stories 1, 2): Direct API session with multi-turn -- delivers usable feature
+- **Iteration 3** (Stories 3, 5): Effectful API + error hardening -- completes the feature
+
+## Documentation Requirements
+
+- [ ] Gherkin scenarios serve as living documentation
+- [ ] API documentation (new session methods on both ClaudeCode objects)
+- [ ] ARCHITECTURE.md update with session mode data flow diagram
+- [ ] README.md update with session usage examples
+- [ ] Domain model documentation (SessionOptions, Session trait)
+
+---
+
+**Analysis Status:** Ready for Review
+
+**Next Steps:**
+1. Resolve CLARIFY markers -- especially the `--input-format stream-json` protocol (investigate CLI source or experiment)
+2. Decide on Session trait design (shared vs separate per API style)
+3. Decide on turn sequencing semantics
+4. Run **ag-create-tasks** with the issue ID
+5. Run **ag-implement** for iterative story implementation

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -57,3 +57,42 @@ M  test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
 ```
 
 ---
+
+## Phase 2: SessionOptions configuration (2026-04-04)
+
+**What was built:**
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` - Case class with all 18 fields from `QueryOptions` except `prompt`, fluent `with*` builder methods, and `SessionOptions.defaults` companion factory
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` - Added `buildSessionArgs(options: SessionOptions): List[String]` method that prepends required streaming flags (`--print --input-format stream-json --output-format stream-json`) and maps all option fields to CLI flags
+
+**Decisions made:**
+- Duplicated field-by-field flag mapping in `buildSessionArgs` rather than extracting shared helper with `buildArgs` — both methods are small and mechanical; extraction deferred until a third call site appears (per phase context guidance)
+- `SessionOptions` is a flat case class parallel to `QueryOptions` rather than composing a shared `CommonOptions` — matches existing API ergonomics; refactoring deferred
+
+**Patterns applied:**
+- Fluent builder: Same `with*` method pattern as `QueryOptions` for API consistency
+- Companion object factory: `SessionOptions.defaults` mirrors `QueryOptions.simple(prompt)` idiom
+
+**Testing:**
+- Unit tests: 3 tests for SessionOptions construction, defaults equality, and all 18 builder methods (using structural equality via `copy`)
+- Unit tests: 16 tests for buildSessionArgs covering required flags, flag ordering, each field mapping, None handling, and multi-field combinations
+
+**Code review:**
+- Iterations: 1
+- Review skills: style, testing, scala3, composition
+- Findings addressed: removed redundant self-import, replaced magic number `5` with `requiredFlags.length`, improved builder isolation tests to use full structural equality via `assertEquals(built, base.copy(...))`
+- Deferred: shared arg-building helper extraction, `optArg`/`flagArg` private helpers (deliberate per phase context)
+
+**For next phases:**
+- `SessionOptions` is ready for use as session startup configuration in Phase 3 (direct API) and Phase 5 (effectful API)
+- `buildSessionArgs` provides the CLI arguments needed to launch a streaming session subprocess
+- Process-level fields (`timeout`, `inheritEnvironment`, `environmentVariables`, `executable`, `executableArgs`, `pathToClaudeCodeExecutable`) are carried in `SessionOptions` but not mapped to CLI flags — consumed by the session runner
+
+**Files changed:**
+```
+A  core/src/works/iterative/claude/core/model/SessionOptions.scala
+M  core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+A  core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala
+A  core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -96,3 +96,62 @@ A  core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
 ```
 
 ---
+
+## Phase 3: Direct API - Basic session lifecycle (2026-04-05)
+
+**What was built:**
+- `works/iterative/claude/direct/Session.scala` — `Session` trait with `send(prompt: String): Flow[Message]`, `close(): Unit`, and `sessionId: String`
+- `works/iterative/claude/direct/internal/cli/SessionProcess.scala` — Internal implementation managing a long-lived CLI process with stdin writer, stdout reader, and background stderr capture
+- `works/iterative/claude/direct/ClaudeCode.scala` — Added `session(SessionOptions): Session` factory method on both the `ClaudeCode` class (instance, uses existing Ox scope) and companion object (static, requires `using Logger, Ox`)
+- `works/iterative/claude/direct/package.scala` — Added `SessionOptions` re-export to direct package
+- `works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — Mock CLI script generator that reads stdin JSON and writes stdout JSON responses, simulating the stream-json protocol
+- `works/iterative/claude/direct/internal/testing/MockLogger.scala` — Shared mock logger extracted from test files during code review
+
+**Decisions made:**
+- `--verbose` flag injected at the process boundary in `SessionProcess.configureSessionProcess` rather than in `CLIArgumentBuilder`, matching how the query path adds it in `buildCliArguments` — keeps CLI arg building focused on user-visible options
+- `readInitMessages` uses a polling loop with `reader.ready()` and deadline to distinguish long-lived session processes (which emit init before stdin) from quick-exit mock scripts — avoids blocking on `readLine()` indefinitely
+- `send()` writes the `SDKUserMessage` JSON to stdin eagerly (before returning the Flow), ensuring the CLI starts processing immediately; the Flow then reads stdout until `ResultMessage`
+- `captureStderr` destroys the process on `InterruptedException` to unblock the pipe and prevent scope cancellation from hanging
+- `SDKUserMessage` not re-exported in package.scala — it's an internal protocol detail, not a user-facing type
+- `configureSessionProcess` duplicates a small amount of `ProcessBuilder` configuration from `ProcessManager.configureProcess` rather than extracting a shared helper — both methods are small and the `QueryOptions` vs `SessionOptions` types differ; extraction deferred until a third call site appears
+
+**Patterns applied:**
+- Trait + internal implementation: Public `Session` trait with package-private `SessionProcess` implementation, matching the existing `ClaudeCode` / `ProcessManager` split
+- Factory method: `SessionProcess.start` companion object factory that constructs the process, reads init messages, and returns a ready-to-use `Session`
+- Mock CLI scripts: Extended `MockCliScript` pattern for session protocol — scripts read stdin JSON and respond with stdout JSON, supporting multi-turn simulation
+- Shared test utilities: `MockLogger` extracted to `internal/testing` package for reuse across test suites
+
+**Testing:**
+- Unit tests: 8 tests in `SessionTest.scala` (SDKUserMessage encoding, session ID extraction/defaults/updates, ResultMessage flow termination, close behavior, factory method)
+- Integration tests: 5 tests in `SessionIntegrationTest.scala` (full lifecycle, stdin JSON verification, session ID from init, KeepAlive/StreamEvent passthrough, ClaudeCode.session factory)
+- E2E tests: 2 tests in `SessionE2ETest.scala` (real CLI single turn, session ID validation — gated on CLI availability)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-03-20260405-101513.md
+- Skills applied: architecture, scala3, composition, testing, style
+- Critical findings: 3 (vacuous T1 test, vacuous T7 assertion, MockLogger duplication) — all fixed
+- Major warnings addressed: dead stderrBuffer removed, readInitMessages encapsulated to return Option[String], shared resolveExecutablePath helper extracted, SDKUserMessage re-export removed, Thread.sleep removed from integration test
+- Deferred: `sessionId` as `Option[String]` vs magic string (follow-up), `package object` to top-level definitions (pre-existing, separate refactoring)
+
+**For next phases:**
+- `Session` trait and `ClaudeCode.session` factory are ready for multi-turn conversation support (Phase 4)
+- `SessionProcess.send` already supports multiple sequential calls — Phase 4 adds turn sequencing tests and context verification
+- `SessionMockCliScript` supports multi-turn simulation via `turnResponses: Map[String, TurnResponse]` — Phase 4 can use this directly
+- The effectful API (Phase 5) can reference `SessionProcess` patterns for process lifecycle management with fs2
+- Error handling (Phase 6) can add process liveness checks and typed errors to the existing `send`/`close` methods
+
+**Files changed:**
+```
+M  direct/src/works/iterative/claude/direct/ClaudeCode.scala
+A  direct/src/works/iterative/claude/direct/Session.scala
+A  direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+M  direct/src/works/iterative/claude/direct/package.scala
+A  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+A  direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+A  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+A  direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala
+A  direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -197,3 +197,100 @@ M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
 ```
 
 ---
+
+### Refactoring R1: Split Session.send into send + stream (CQS) (2026-04-05)
+
+**Trigger:** Comparison with the V2 Claude Agent SDK revealed our `send()` combines a command (write prompt to stdin) and a query (read response stream) in one method, violating command-query separation. The V2 SDK separates these as `send()` (void) and `stream()` (async generator).
+
+**What changed:**
+- `direct/src/.../Session.scala` — trait split: `send(prompt: String): Flow[Message]` → `send(prompt: String): Unit` + `stream(): Flow[Message]`
+- `direct/src/.../internal/cli/SessionProcess.scala` — implementation split: stdin write separated from stdout reading loop
+- `direct/test/src/.../SessionTest.scala` — all call sites updated from `session.send(x).runToList()` to `session.send(x); session.stream().runToList()`
+- `direct/test/src/.../SessionIntegrationTest.scala` — same call site pattern update
+- `direct/test/src/.../SessionE2ETest.scala` — same call site pattern update
+
+**Before → After:**
+- `session.send("prompt").forEach(...)` → `session.send("prompt"); session.stream().forEach(...)`
+- `send` no longer returns a value; `stream` is a separate query method
+- Internal mechanics unchanged: stdin writing, stdout reading, session ID updates, stderr capture all preserved
+
+**Patterns applied:**
+- Command-Query Separation (CQS): `send` is a command (side effect, returns Unit), `stream` is a query (returns data, no side effect beyond reading)
+
+**Testing:**
+- Tests updated: 15 call sites across 3 test files
+- All 193 direct tests passing, no regressions
+- No new tests added (mechanical refactoring — same assertions, different call patterns)
+
+**Code review:**
+- Iterations: 1
+- Review file: review-refactor-05-R1-20260405-144725.md
+- Skills applied: style, testing, scala3, composition
+- Composition reviewer raised design concern about CQS split breaking composability — triaged as deliberate decision aligning with V2 SDK direction
+- Warnings addressed: duplicate Scaladoc removed, dead `caught != null` assertion removed, PURPOSE comment updated
+- Deferred to Phase 6: `stream()` without `send()` guard, `close()` without consuming stream test
+
+**Files changed:**
+```
+M  direct/src/works/iterative/claude/direct/Session.scala
+M  direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+M  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+```
+
+---
+
+## Phase 5: Effectful API - Session lifecycle with Resource (2026-04-05)
+
+**What was built:**
+- `effectful/src/.../effectful/Session.scala` — Session trait with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, `sessionId: IO[String]`
+- `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]` with three background fibers (stdin writer, stdout reader, stderr capture), stdin `Queue` to keep pipe open across turns, `IO.race` for init message extraction
+- `effectful/src/.../effectful/ClaudeCode.scala` — Added `session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method and shared `resolveExecutable` helper
+- `effectful/src/.../effectful/package.scala` — Added `SessionOptions` type and value re-exports
+
+**Decisions made:**
+- Used a `Queue[IO, Option[Chunk[Byte]]]` for stdin: fs2 process stdin pipe closes after first stream completes, so a background fiber drains the queue into stdin keeping it open across multiple `send` calls
+- Used `IO.race` between `messageQueue.take` and `IO.sleep(1.second)` for init message extraction: more reliable than polling or timeout-cancellation
+- Reused `SessionMockCliScript` from `direct.internal.testing` rather than duplicating: cross-module test dependency accepted for now, extraction to shared module deferred
+- No `close()` method on effectful Session: Resource finalizer handles cleanup, matching cats-effect idioms
+
+**Patterns applied:**
+- Resource-based lifecycle: `Resource[IO, Session]` for deterministic cleanup on normal exit and error
+- Queue-based stdin bridge: `Queue.unbounded[IO, Option[Chunk[Byte]]]` with `None` as close signal
+- `Stream.fromQueueNoneTerminated` + `takeThrough` for constant-space message consumption (fixed from recursive `++ stream` during code review)
+- Shared executable discovery: extracted `resolveExecutable` helper used by both `session` and `query` paths
+
+**Testing:**
+- Unit tests: 9 tests in SessionTest.scala (encoding, session ID lifecycle, stream termination, multi-turn isolation, three-turn cycling)
+- Integration tests: 9 tests in SessionIntegrationTest.scala (full lifecycle, Resource cleanup, stdin verification, session ID progression, variable message counts, factory method)
+- E2E tests: 3 tests in SessionE2ETest.scala (single-turn, multi-turn context dependency, session ID validation — gated on CLI availability)
+- Re-export test: 1 test added to EffectfulPackageReexportTest.scala
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-05-20260405-152422.md
+- Skills applied: style, testing, scala3, composition, architecture
+- Critical findings: 2 (recursive stream, duplicated executable discovery) — both fixed
+- Warnings addressed: 3 (FiniteDuration string constructor, PURPOSE comment, pure test in IO)
+- Deferred: cross-module test dependency, unbounded queues, `"pending"` sentinel
+
+**For next phases:**
+- Effectful `Session` API is complete and mirrors the direct API with cats-effect idioms
+- `ClaudeCode.session` factory follows the same pattern as `query`/`querySync`/`queryResult`
+- Error handling (Phase 6) can add process liveness checks, typed errors for process crashes, and malformed JSON handling in the continuous-reading context
+- `SessionMockCliScript` should eventually be extracted to shared test-support module
+
+**Files changed:**
+```
+M  effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+A  effectful/src/works/iterative/claude/effectful/Session.scala
+A  effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+M  effectful/src/works/iterative/claude/effectful/package.scala
+M  effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -294,3 +294,56 @@ A  effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
 ```
 
 ---
+
+## Phase 6: Error handling - process crash and malformed JSON (2026-04-05)
+
+**What was built:**
+- `core/src/.../core/CLIError.scala` — Added `SessionProcessDied(exitCode: Option[Int], stderr: String)` and `SessionClosedError(sessionId: String)` to the sealed `CLIError` hierarchy
+- `direct/src/.../internal/cli/SessionProcess.scala` — Added `AtomicBoolean alive` flag, `safeExitCode()` helper, liveness checks in `send()` (throws `SessionClosedError` / `SessionProcessDied`), EOF detection in `stream()` (throws `SessionProcessDied` when no `ResultMessage` seen), idempotent `close()`
+- `effectful/src/.../internal/cli/SessionProcess.scala` — Added `Ref[IO, Boolean] aliveRef` and `Ref[IO, Option[CLIError]] pendingErrorRef`, fixed malformed JSON bug (changed `IO.raiseError` to log+skip), process death detection in stdout reader completion handler, liveness check in `send`, error propagation in `stream` via `onFinalize`
+- `direct/test/.../testing/SessionMockCliScript.scala` — Added `createImmediateExitScript`, `createCrashMidTurnScript`, `createCrashBetweenTurnsScript`, `createMalformedJsonMidTurnScript` builders
+
+**Decisions made:**
+- `SessionClosedError` is direct-API-only (effectful uses Resource lifecycle for close semantics)
+- Effectful `aliveRef` is set to `false` on any stdout stream completion (not just non-zero exit), since a dead process can't accept input regardless of exit code
+- `pendingErrorRef` only set for non-zero exits (zero exit is abnormal for a session but not an error in the same sense)
+- `safeExitCode()` extracted as private helper to eliminate 3x duplication of try/catch pattern in direct SessionProcess
+- Comment added to effectful `stream` explaining the dual `resultSeenRef` + `pendingErrorRef` mechanism
+
+**Patterns applied:**
+- AtomicBoolean liveness flag (direct) / Ref[IO, Boolean] (effectful) for fail-fast error detection
+- Two-ref error propagation: `pendingErrorRef` carries error from background fiber to foreground stream, `resultSeenRef` disambiguates normal vs abnormal EOF
+- Mock script pattern extended with crash and malformed JSON scenarios
+
+**Testing:**
+- Direct unit tests: 5 tests in SessionErrorTest.scala (closed send, idempotent close, dead send, crash mid-turn stream, malformed JSON recovery)
+- Direct integration tests: 4 tests in SessionErrorIntegrationTest.scala (crash mid-turn, crash between turns, malformed JSON, multiple malformed lines)
+- Effectful unit tests: 4 tests in SessionErrorTest.scala (dead send, crash mid-turn stream, malformed JSON, send after death with no pending error)
+- Effectful integration tests: 4 tests in SessionErrorIntegrationTest.scala (crash mid-turn, crash between turns, malformed JSON, resource cleanup after crash)
+
+**Code review:**
+- Iterations: 1
+- Skills applied: style, testing, scala3, composition, architecture
+- Critical findings: 3 (Thread.sleep flaky timing, duplicate tests, missing effectful dead-send test) — all fixed
+- Warnings addressed: import braces, FiniteDuration DSL, duplicated stderr message, exit code duplication, exit code assertions in I2 tests, resultSeenRef comment
+- Deferred: CLIError enum refactoring (pre-existing, applies to whole hierarchy), ProcessMonitor abstraction (would be premature for 2 refs)
+
+**For next phases:**
+- This is the final phase — all session API features are complete
+- Error types are extensible: additional session errors can be added to the CLIError hierarchy
+- Mock script infrastructure supports crash and malformed JSON scenarios for future regression testing
+
+**Files changed:**
+```
+M  core/src/works/iterative/claude/core/CLIError.scala
+M  direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+A  direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala
+A  direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+M  direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+M  effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala
+A  effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -155,3 +155,45 @@ A  direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCli
 ```
 
 ---
+
+## Phase 4: Direct API - Multi-turn conversation (2026-04-05)
+
+**What was built:**
+- Multi-turn conversation test coverage across all three test levels (unit, integration, E2E)
+- No production code changes were needed — `SessionProcess` from Phase 3 already handled multi-turn correctly
+
+**Decisions made:**
+- Phase is purely test-focused: the mechanical infrastructure for multi-turn already existed in Phase 3, so Phase 4 validates it works correctly
+- Removed IT9 (duplicate of T10 in SessionTest) during code review to avoid test duplication across unit/integration layers
+- Added message ordering assertions (not just type membership) to verify protocol ordering
+
+**Patterns applied:**
+- Dedicated `createdFiles` cleanup list in SessionTest (matching SessionIntegrationTest pattern) for non-script temp files
+- Extracted `assumeClaudeAvailable()` helper in E2E tests to reduce repeated assume blocks
+- Used `.getOrElse(fail(...))` instead of `.isDefined`/`.get` for idiomatic Scala 3 Option handling in test assertions
+
+**Testing:**
+- Unit tests: 4 tests added (T8-T11) — message isolation, session ID propagation, session ID updates, three-turn cycling
+- Integration tests: 3 tests added (IT6-IT8) — two-turn lifecycle, stdin capture with ID progression, variable message counts per turn
+- E2E tests: 2 tests added — context-dependent follow-up ("remember 42"), session ID stability across turns
+
+**Code review:**
+- Iterations: 1
+- Skills applied: testing, style, scala3
+- Critical findings: 1 (captureFile cleanup list) — fixed
+- Warnings addressed: duplicate IT9 removed, session ID stability assertion added, message ordering assertions added, test ordering fixed, redundant import removed, fully-qualified imports simplified
+- Suggestions addressed: `.getOrElse(fail(...))` pattern, `assumeClaudeAvailable()` helper
+
+**For next phases:**
+- Multi-turn conversation is fully validated in the direct API — Phase 5 (effectful API) can reference the same test patterns
+- `SessionMockCliScript` multi-turn support confirmed working — no changes were needed to the mock infrastructure
+- Error handling (Phase 6) can build on these tests to add failure scenarios during multi-turn sessions
+
+**Files changed:**
+```
+M  direct/test/src/works/iterative/claude/direct/SessionTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+M  direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+```
+
+---

--- a/project-management/issues/CC-15/implementation-log.md
+++ b/project-management/issues/CC-15/implementation-log.md
@@ -1,0 +1,59 @@
+# Implementation Log: Support persistent two-way conversations with a single Claude Code session
+
+Issue: CC-15
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: Stdin message format and response delimiting (2026-04-04)
+
+**What was built:**
+- `works/iterative/claude/core/model/SDKUserMessage.scala` - Case class representing JSON messages written to CLI stdin in stream-json mode, with circe Encoder producing the exact protocol JSON shape
+- `works/iterative/claude/core/model/Message.scala` - Extended with `KeepAliveMessage` (case object) and `StreamEventMessage(data: Map[String, Any])` for stream-json protocol message types
+- `works/iterative/claude/core/parsing/JsonParser.scala` - Added parsing branches for `keep_alive` and `stream_event` message types
+- `works/iterative/claude/direct/internal/parsing/JsonParser.scala` - Added exhaustive match cases for new message types
+
+**Decisions made:**
+- Named the stdin message type `SDKUserMessage` (matching TypeScript Agent SDK naming) rather than `StdinMessage` (from analysis) to align with the protocol terminology
+- Added `KeepAliveMessage` and `StreamEventMessage` types now rather than deferring, so downstream phases can pattern-match on them
+- `StreamEventMessage` uses `Map[String, Any]` (same pattern as existing `SystemMessage`) rather than typed fields, since the full content delta structure will be refined when consumers exist
+- Encoder produces `type` and `message.role` as constants, not stored as case class fields
+
+**Patterns applied:**
+- Sealed trait extension: Added new subtypes to existing Message hierarchy
+- Companion object given: Circe Encoder instance in SDKUserMessage companion object (first Encoder in the project)
+- Mock CLI scripts: Integration tests use temporary bash scripts simulating CLI stdin/stdout protocol
+
+**Testing:**
+- Unit tests: 4 tests for SDKUserMessage Encoder (shape, parentToolUseId, pending session, no newlines)
+- Unit tests: 3 tests for new parser branches (keep_alive, stream_event with nested data, realistic ResultMessage end-of-turn)
+- Property tests: Added KeepAliveMessage and StreamEventMessage generators to round-trip property tests
+- Integration tests: 2 mock CLI round-trip tests (echo response, session protocol with init message)
+- E2E test: 1 test against real Claude Code CLI (validates stdin format accepted)
+
+**Code review:**
+- Iterations: 1
+- Major findings: Missing property test generators for new types, E2E test was permanently ignored instead of assumption-gated, weak E2E assertion
+- All findings addressed
+
+**For next phases:**
+- `SDKUserMessage` and its Encoder are ready for use in session stdin writing (Phase 3/5)
+- `KeepAliveMessage` and `StreamEventMessage` can be pattern-matched by session response readers
+- `ResultMessage` confirmed as end-of-turn delimiter in the stream-json protocol
+- The mock CLI script pattern in round-trip tests can be extended for session protocol testing
+
+**Files changed:**
+```
+A  works/iterative/claude/core/model/SDKUserMessage.scala
+M  works/iterative/claude/core/model/Message.scala
+M  works/iterative/claude/core/parsing/JsonParser.scala
+M  works/iterative/claude/direct/internal/parsing/JsonParser.scala
+A  test/works/iterative/claude/core/model/SDKUserMessageTest.scala
+A  test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala
+A  test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala
+M  test/works/iterative/claude/core/parsing/JsonParserTest.scala
+M  test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-15/phase-01-context.md
+++ b/project-management/issues/CC-15/phase-01-context.md
@@ -1,0 +1,138 @@
+# Phase 01: Stdin message format and response delimiting
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 6-8 hours
+**Status:** Not started
+
+## Goals
+
+1. Define `SDKUserMessage` case class representing JSON messages written to CLI stdin in `stream-json` mode
+2. Provide a circe `Encoder[SDKUserMessage]` that produces the exact JSON shape the CLI expects
+3. Verify that `ResultMessage` (type `"result"`) correctly signals end-of-turn in the stream-json protocol
+4. Decide on and optionally add parsing support for `stream_event` and `keep_alive` message types that appear in the stream-json protocol but are not yet in the model
+
+## Scope
+
+### In scope
+
+- `SDKUserMessage` case class and its circe Encoder
+- Unit tests for the Encoder output shape
+- Unit tests confirming `ResultMessage` is parsed from end-of-turn JSON
+- Decision (with code if adding) on `stream_event` and `keep_alive` message types
+- Integration test: round-trip stdin write -> mock CLI parse -> stdout response -> SDK parse
+
+### Out of scope
+
+- `SessionOptions` configuration (Phase 02)
+- Process management, stdin writing, stdout reading infrastructure (Phase 03)
+- Multi-turn sequencing (Phase 04)
+- Effectful API (Phase 05)
+- Error handling hardening (Phase 06)
+- `control_request` / `control_response` message types (deferred)
+
+## Dependencies
+
+None. This is the first phase and has no prerequisites beyond the existing codebase.
+
+## Approach
+
+### 1. Define `SDKUserMessage`
+
+Note: The analysis document refers to this as `StdinMessage`, but `SDKUserMessage` matches the TypeScript Agent SDK's naming and accurately describes what this type represents in the Claude Code protocol. Using the protocol's own terminology avoids ambiguity.
+
+Create a new case class in `works/iterative/claude/core/model/`. The required JSON shape is:
+
+```json
+{"type": "user", "message": {"role": "user", "content": "..."}, "parent_tool_use_id": null, "session_id": "..."}
+```
+
+The case class should hold:
+- `content: String` -- the user's message text
+- `sessionId: String` -- the session ID from the `system`/`init` message (or `"pending"` for first message)
+- `parentToolUseId: Option[String]` -- for tool result responses (null in normal user messages)
+
+Note: `type` and `message.role` are constants (`"user"`) and should be produced by the Encoder, not stored as fields.
+
+### 2. Create circe Encoder
+
+This is the first Encoder in the project (all existing circe usage is parsing/decoding). Create an `Encoder[SDKUserMessage]` instance. It can live as a given in the `SDKUserMessage` companion object or in a dedicated codec file. Companion object is simpler and follows circe conventions.
+
+The Encoder must produce exactly:
+```json
+{
+  "type": "user",
+  "message": {"role": "user", "content": "<content>"},
+  "parent_tool_use_id": null,
+  "session_id": "<sessionId>"
+}
+```
+
+When `parentToolUseId` is `Some(id)`, the `parent_tool_use_id` field should contain the string value instead of null.
+
+**Note on line delimiting:** The stdin protocol uses newline-delimited JSON (one JSON object per line, terminated by `\n`). The Encoder itself produces only the JSON object; appending the newline is the responsibility of the stdin writing layer in Phase 03. However, tests should verify the encoded JSON contains no embedded newlines.
+
+### 3. Verify ResultMessage as end-of-turn delimiter
+
+The existing `JsonParser.parseMessage` already handles `type: "result"` and produces `ResultMessage`. Write a focused test that uses a realistic end-of-turn result JSON (matching what stream-json actually emits) and confirms it parses to `ResultMessage` with the expected fields. This validates the existing code works for the session protocol, not just one-shot queries.
+
+### 4. Handle `stream_event` and `keep_alive` types
+
+The stream-json protocol emits these types that the current parser silently drops (returns `None` for unknown types). Two options:
+
+**Decision: Add minimal types now (Option A).** Adding `KeepAliveMessage` and `StreamEventMessage` to the sealed trait ensures downstream phases can pattern-match on them rather than losing them as `None`. `keep_alive` is trivial (no meaningful fields). `stream_event` should carry only the raw JSON data for now -- a `Map[String, Any]` like `SystemMessage` uses -- since the full content delta structure can be refined when Phase 03 consumes it.
+
+## Files to Modify/Create
+
+### New files
+
+- `works/iterative/claude/core/model/SDKUserMessage.scala` -- case class + circe Encoder
+- `test/works/iterative/claude/core/model/SDKUserMessageTest.scala` -- Encoder unit tests
+
+### Files to modify
+
+- `works/iterative/claude/core/model/Message.scala` -- add `KeepAliveMessage` and `StreamEventMessage` subtypes
+- `works/iterative/claude/core/parsing/JsonParser.scala` -- add parsing branches for `keep_alive` and `stream_event` types
+- `test/works/iterative/claude/core/parsing/JsonParserTest.scala` -- tests for new message type parsing
+
+### Files to read (reference, no changes)
+
+- `works/iterative/claude/core/model/Message.scala` -- existing Message hierarchy
+- `works/iterative/claude/core/model/ContentBlock.scala` -- content block types
+- `works/iterative/claude/core/parsing/JsonParser.scala` -- existing parser dispatch
+- `test/works/iterative/claude/core/parsing/JsonParserTest.scala` -- test patterns
+- `project.scala` -- circe dependencies (core + parser already present; no additional deps needed for Encoder)
+
+## Testing Strategy
+
+### Unit tests
+
+1. **SDKUserMessage Encoder output shape** -- encode an SDKUserMessage and verify the JSON structure matches the expected protocol format exactly (field names, nesting, null handling)
+2. **SDKUserMessage Encoder with parentToolUseId** -- verify `Some(id)` produces a string value, `None` produces JSON null
+3. **SDKUserMessage Encoder session_id** -- verify `"pending"` is valid and normal session IDs encode correctly
+4. **ResultMessage end-of-turn parsing** -- parse a realistic stream-json result message and verify all fields
+5. **stream_event parsing** -- verify parsing of content delta events into `StreamEventMessage`
+6. **keep_alive parsing** -- verify heartbeat messages parse into `KeepAliveMessage`
+7. **Encoded JSON has no embedded newlines** -- verify SDKUserMessage encoder output is a single line
+
+### Integration tests
+
+1. **Round-trip encode-decode** -- encode an SDKUserMessage to JSON string, feed it to a mock CLI script (bash) that echoes it back as a response, parse the response. This validates the JSON is well-formed and the format is correct end-to-end.
+2. **Mock session protocol** -- mock CLI script that:
+   - Writes a `system`/`init` message to stdout
+   - Reads a JSON line from stdin (the SDKUserMessage)
+   - Writes an assistant message + result message to stdout
+   - Verify SDK can produce the stdin line and parse the stdout response
+
+### E2E tests
+
+1. **Real CLI stdin format validation** -- if Claude Code CLI is available, start a process with `--print --input-format stream-json --output-format stream-json`, write a properly formatted SDKUserMessage to stdin, and verify the CLI accepts it (does not error). This test should be gated on CLI availability (following existing `TestAssumptions` patterns).
+
+## Acceptance Criteria
+
+1. `SDKUserMessage` case class exists with `content`, `sessionId`, and `parentToolUseId` fields
+2. `Encoder[SDKUserMessage]` produces JSON matching the exact protocol format (verified by tests)
+3. `ResultMessage` parsing is confirmed to work with stream-json end-of-turn messages (verified by test)
+4. `KeepAliveMessage` and `StreamEventMessage` types added to Message hierarchy and parsed correctly
+5. All new code has PURPOSE comments per project conventions
+6. All existing tests continue to pass (no regressions)
+7. Integration test demonstrates the stdin JSON format works with a mock CLI

--- a/project-management/issues/CC-15/phase-01-tasks.md
+++ b/project-management/issues/CC-15/phase-01-tasks.md
@@ -1,37 +1,38 @@
 # Phase 01 Tasks: Stdin message format and response delimiting
 
 ## Setup
-- [ ] [setup] Read existing `Message.scala`, `JsonParser.scala`, `JsonParserTest.scala`, and `project.scala` to confirm circe encoder support is available (circe-core includes `Encoder`) and understand current patterns
-- [ ] [setup] Create empty test file `test/works/iterative/claude/core/model/SDKUserMessageTest.scala` with package declaration, imports, and PURPOSE comments
+- [x] [setup] Read existing `Message.scala`, `JsonParser.scala`, `JsonParserTest.scala`, and `project.scala` to confirm circe encoder support is available (circe-core includes `Encoder`) and understand current patterns
+- [x] [setup] Create empty test file `test/works/iterative/claude/core/model/SDKUserMessageTest.scala` with package declaration, imports, and PURPOSE comments
 
 ## Tests (Red)
 
 ### SDKUserMessage Encoder tests
-- [ ] [test] Write test "Encoder produces correct JSON structure" in `SDKUserMessageTest.scala` -- encode `SDKUserMessage("hello", "session-1", None)` and verify top-level keys `type`, `message`, `parent_tool_use_id`, `session_id` with correct values; `type` is `"user"`, `message` is `{"role":"user","content":"hello"}`, `parent_tool_use_id` is JSON null, `session_id` is `"session-1"`
-- [ ] [test] Write test "Encoder produces string value for Some(parentToolUseId)" -- encode `SDKUserMessage("hello", "s1", Some("tool-123"))` and verify `parent_tool_use_id` is the string `"tool-123"` (not null)
-- [ ] [test] Write test "Encoder accepts pending as session_id" -- encode with `sessionId = "pending"` and verify `session_id` field is `"pending"`
-- [ ] [test] Write test "Encoded JSON contains no embedded newlines" -- encode an SDKUserMessage, call `.noSpaces` on the result, and assert the string contains no `\n` characters
+- [x] [test] Write test "Encoder produces correct JSON structure" in `SDKUserMessageTest.scala` -- encode `SDKUserMessage("hello", "session-1", None)` and verify top-level keys `type`, `message`, `parent_tool_use_id`, `session_id` with correct values; `type` is `"user"`, `message` is `{"role":"user","content":"hello"}`, `parent_tool_use_id` is JSON null, `session_id` is `"session-1"`
+- [x] [test] Write test "Encoder produces string value for Some(parentToolUseId)" -- encode `SDKUserMessage("hello", "s1", Some("tool-123"))` and verify `parent_tool_use_id` is the string `"tool-123"` (not null)
+- [x] [test] Write test "Encoder accepts pending as session_id" -- encode with `sessionId = "pending"` and verify `session_id` field is `"pending"`
+- [x] [test] Write test "Encoded JSON contains no embedded newlines" -- encode an SDKUserMessage, call `.noSpaces` on the result, and assert the string contains no `\n` characters
 
 ### New message type parsing tests
-- [ ] [test] Write test "parseMessage parses keep_alive into KeepAliveMessage" in `JsonParserTest.scala` -- parse `{"type":"keep_alive"}` and assert result is `Some(KeepAliveMessage)`
-- [ ] [test] Write test "parseMessage parses stream_event into StreamEventMessage" in `JsonParserTest.scala` -- parse a stream_event JSON with `event` and `data` fields, assert result is `Some(StreamEventMessage(...))` carrying the raw data map
+- [x] [test] Write test "parseMessage parses keep_alive into KeepAliveMessage" in `JsonParserTest.scala` -- parse `{"type":"keep_alive"}` and assert result is `Some(KeepAliveMessage)`
+- [x] [test] Write test "parseMessage parses stream_event into StreamEventMessage" in `JsonParserTest.scala` -- parse a stream_event JSON with `event` and `data` fields, assert result is `Some(StreamEventMessage(...))` carrying the raw data map
 
 ### ResultMessage end-of-turn verification
-- [ ] [test] Write test "ResultMessage parses realistic stream-json end-of-turn" in `JsonParserTest.scala` -- use a full result JSON matching real CLI output (subtype `"success"`, sessionId, duration fields, cost, usage, result text) and verify all fields parse correctly; this confirms ResultMessage works as end-of-turn delimiter in the session protocol
+- [x] [test] Write test "ResultMessage parses realistic stream-json end-of-turn" in `JsonParserTest.scala` -- use a full result JSON matching real CLI output (subtype `"success"`, sessionId, duration fields, cost, usage, result text) and verify all fields parse correctly; this confirms ResultMessage works as end-of-turn delimiter in the session protocol
 
 ## Implementation (Green)
 
 ### SDKUserMessage
-- [ ] [impl] Create `works/iterative/claude/core/model/SDKUserMessage.scala` with case class `SDKUserMessage(content: String, sessionId: String, parentToolUseId: Option[String] = None)` and a `given Encoder[SDKUserMessage]` in the companion object that produces the exact protocol JSON shape; include PURPOSE comments
-- [ ] [impl] Run SDKUserMessage tests and verify they pass
+- [x] [impl] Create `works/iterative/claude/core/model/SDKUserMessage.scala` with case class `SDKUserMessage(content: String, sessionId: String, parentToolUseId: Option[String] = None)` and a `given Encoder[SDKUserMessage]` in the companion object that produces the exact protocol JSON shape; include PURPOSE comments
+- [x] [impl] Run SDKUserMessage tests and verify they pass
 
 ### Message hierarchy additions
-- [ ] [impl] Add `case object KeepAliveMessage extends Message` to `Message.scala`
-- [ ] [impl] Add `case class StreamEventMessage(data: Map[String, Any]) extends Message` to `Message.scala`
-- [ ] [impl] Add `"keep_alive"` and `"stream_event"` branches to `JsonParser.parseMessage` dispatch, with corresponding private parser methods
-- [ ] [impl] Run all JsonParser tests and verify they pass (new + existing)
+- [x] [impl] Add `case object KeepAliveMessage extends Message` to `Message.scala`
+- [x] [impl] Add `case class StreamEventMessage(data: Map[String, Any]) extends Message` to `Message.scala`
+- [x] [impl] Add `"keep_alive"` and `"stream_event"` branches to `JsonParser.parseMessage` dispatch, with corresponding private parser methods
+- [x] [impl] Run all JsonParser tests and verify they pass (new + existing)
 
 ## Integration
-- [ ] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala` -- write a mock CLI bash script (inline heredoc) that reads a JSON line from stdin and echoes back an assistant message + result message to stdout; test encodes an SDKUserMessage, feeds it to the script via `ProcessBuilder`, reads stdout lines, parses them with `JsonParser`, and verifies the round-trip produces `AssistantMessage` and `ResultMessage`
-- [ ] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala` -- gated on `claude` CLI availability via `TestAssumptions.assumeCommand("claude")`; starts `claude --print --input-format stream-json --output-format stream-json`, writes a properly formatted SDKUserMessage JSON line to stdin, and verifies the CLI does not error (exit code 0 or produces parseable output)
-- [ ] [integration] Run full test suite (`scala-cli test .`) to confirm no regressions
+- [x] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala` -- write a mock CLI bash script (inline heredoc) that reads a JSON line from stdin and echoes back an assistant message + result message to stdout; test encodes an SDKUserMessage, feeds it to the script via `ProcessBuilder`, reads stdout lines, parses them with `JsonParser`, and verifies the round-trip produces `AssistantMessage` and `ResultMessage`
+- [x] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala` -- gated on `claude` CLI availability via `TestAssumptions.assumeCommand("claude")`; starts `claude --print --input-format stream-json --output-format stream-json`, writes a properly formatted SDKUserMessage JSON line to stdin, and verifies the CLI does not error (exit code 0 or produces parseable output)
+- [x] [integration] Run full test suite (`scala-cli test .`) to confirm no regressions
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-01-tasks.md
+++ b/project-management/issues/CC-15/phase-01-tasks.md
@@ -1,0 +1,37 @@
+# Phase 01 Tasks: Stdin message format and response delimiting
+
+## Setup
+- [ ] [setup] Read existing `Message.scala`, `JsonParser.scala`, `JsonParserTest.scala`, and `project.scala` to confirm circe encoder support is available (circe-core includes `Encoder`) and understand current patterns
+- [ ] [setup] Create empty test file `test/works/iterative/claude/core/model/SDKUserMessageTest.scala` with package declaration, imports, and PURPOSE comments
+
+## Tests (Red)
+
+### SDKUserMessage Encoder tests
+- [ ] [test] Write test "Encoder produces correct JSON structure" in `SDKUserMessageTest.scala` -- encode `SDKUserMessage("hello", "session-1", None)` and verify top-level keys `type`, `message`, `parent_tool_use_id`, `session_id` with correct values; `type` is `"user"`, `message` is `{"role":"user","content":"hello"}`, `parent_tool_use_id` is JSON null, `session_id` is `"session-1"`
+- [ ] [test] Write test "Encoder produces string value for Some(parentToolUseId)" -- encode `SDKUserMessage("hello", "s1", Some("tool-123"))` and verify `parent_tool_use_id` is the string `"tool-123"` (not null)
+- [ ] [test] Write test "Encoder accepts pending as session_id" -- encode with `sessionId = "pending"` and verify `session_id` field is `"pending"`
+- [ ] [test] Write test "Encoded JSON contains no embedded newlines" -- encode an SDKUserMessage, call `.noSpaces` on the result, and assert the string contains no `\n` characters
+
+### New message type parsing tests
+- [ ] [test] Write test "parseMessage parses keep_alive into KeepAliveMessage" in `JsonParserTest.scala` -- parse `{"type":"keep_alive"}` and assert result is `Some(KeepAliveMessage)`
+- [ ] [test] Write test "parseMessage parses stream_event into StreamEventMessage" in `JsonParserTest.scala` -- parse a stream_event JSON with `event` and `data` fields, assert result is `Some(StreamEventMessage(...))` carrying the raw data map
+
+### ResultMessage end-of-turn verification
+- [ ] [test] Write test "ResultMessage parses realistic stream-json end-of-turn" in `JsonParserTest.scala` -- use a full result JSON matching real CLI output (subtype `"success"`, sessionId, duration fields, cost, usage, result text) and verify all fields parse correctly; this confirms ResultMessage works as end-of-turn delimiter in the session protocol
+
+## Implementation (Green)
+
+### SDKUserMessage
+- [ ] [impl] Create `works/iterative/claude/core/model/SDKUserMessage.scala` with case class `SDKUserMessage(content: String, sessionId: String, parentToolUseId: Option[String] = None)` and a `given Encoder[SDKUserMessage]` in the companion object that produces the exact protocol JSON shape; include PURPOSE comments
+- [ ] [impl] Run SDKUserMessage tests and verify they pass
+
+### Message hierarchy additions
+- [ ] [impl] Add `case object KeepAliveMessage extends Message` to `Message.scala`
+- [ ] [impl] Add `case class StreamEventMessage(data: Map[String, Any]) extends Message` to `Message.scala`
+- [ ] [impl] Add `"keep_alive"` and `"stream_event"` branches to `JsonParser.parseMessage` dispatch, with corresponding private parser methods
+- [ ] [impl] Run all JsonParser tests and verify they pass (new + existing)
+
+## Integration
+- [ ] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala` -- write a mock CLI bash script (inline heredoc) that reads a JSON line from stdin and echoes back an assistant message + result message to stdout; test encodes an SDKUserMessage, feeds it to the script via `ProcessBuilder`, reads stdout lines, parses them with `JsonParser`, and verifies the round-trip produces `AssistantMessage` and `ResultMessage`
+- [ ] [integration] Create `test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala` -- gated on `claude` CLI availability via `TestAssumptions.assumeCommand("claude")`; starts `claude --print --input-format stream-json --output-format stream-json`, writes a properly formatted SDKUserMessage JSON line to stdin, and verifies the CLI does not error (exit code 0 or produces parseable output)
+- [ ] [integration] Run full test suite (`scala-cli test .`) to confirm no regressions

--- a/project-management/issues/CC-15/phase-02-context.md
+++ b/project-management/issues/CC-15/phase-02-context.md
@@ -1,0 +1,182 @@
+# Phase 02: SessionOptions configuration
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 4-6 hours
+**Status:** Not started
+
+## Goals
+
+1. Define `SessionOptions` case class in `core.model` holding all startup configuration for a streaming session (everything from `QueryOptions` except `prompt`)
+2. Provide fluent builder methods on `SessionOptions` matching the `QueryOptions` style
+3. Add `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions): List[String]` that produces the correct CLI flags for streaming session mode, including the required `--print --input-format stream-json --output-format stream-json` flags and omitting the trailing prompt argument
+
+## Scope
+
+### In scope
+
+- `SessionOptions` case class with all fields from `QueryOptions` except `prompt`
+- Fluent `with*` builder methods on `SessionOptions`
+- `SessionOptions.defaults` companion object factory method
+- `CLIArgumentBuilder.buildSessionArgs` for converting `SessionOptions` to CLI args
+- Unit tests for every `SessionOptions` field mapping in `buildSessionArgs`
+- Unit tests confirming the three required session flags are always present
+- Unit tests confirming `prompt` is not part of `SessionOptions`
+
+### Out of scope
+
+- Process management, stdin/stdout wiring (Phase 03)
+- Multi-turn sequencing (Phase 04)
+- Effectful API surface (Phase 05)
+- `SDKUserMessage` encoding (Phase 01)
+- `mcpTools` flag mapping (no corresponding CLI flag was identified; carry the field but do not emit args unless a flag is confirmed)
+
+## Dependencies
+
+- No code dependency on Phase 01. Phases 01 and 02 are independent foundations.
+- Phase 03 depends on both Phase 01 and Phase 02.
+
+## Approach
+
+### 1. Create `SessionOptions` case class
+
+Create `core/src/works/iterative/claude/core/model/SessionOptions.scala`.
+
+Copy every field from `QueryOptions` verbatim **except `prompt`**. Field names, types, and default values must be identical so that code migrating from `QueryOptions` only needs to drop the `prompt` argument. Fields to include:
+
+| Field | Type | Default |
+|---|---|---|
+| `cwd` | `Option[String]` | `None` |
+| `executable` | `Option[String]` | `None` |
+| `executableArgs` | `Option[List[String]]` | `None` |
+| `pathToClaudeCodeExecutable` | `Option[String]` | `None` |
+| `maxTurns` | `Option[Int]` | `None` |
+| `allowedTools` | `Option[List[String]]` | `None` |
+| `disallowedTools` | `Option[List[String]]` | `None` |
+| `systemPrompt` | `Option[String]` | `None` |
+| `appendSystemPrompt` | `Option[String]` | `None` |
+| `mcpTools` | `Option[List[String]]` | `None` |
+| `permissionMode` | `Option[PermissionMode]` | `None` |
+| `continueConversation` | `Option[Boolean]` | `None` |
+| `resume` | `Option[String]` | `None` |
+| `model` | `Option[String]` | `None` |
+| `maxThinkingTokens` | `Option[Int]` | `None` |
+| `timeout` | `Option[scala.concurrent.duration.FiniteDuration]` | `None` |
+| `inheritEnvironment` | `Option[Boolean]` | `None` |
+| `environmentVariables` | `Option[Map[String, String]]` | `None` |
+
+Note: `timeout`, `inheritEnvironment`, `environmentVariables`, `executable`, `executableArgs`, and `pathToClaudeCodeExecutable` are process-level configuration consumed by the session runner (Phase 03), not translated to CLI flags. Include them so the caller has one place to specify all session configuration.
+
+### 2. Add fluent builder methods
+
+Add a `with*` method for each field, following the exact same pattern used in `QueryOptions`:
+
+```scala
+def withCwd(cwd: String): SessionOptions = copy(cwd = Some(cwd))
+def withModel(model: String): SessionOptions = copy(model = Some(model))
+// ... etc for every field
+```
+
+### 3. Add `SessionOptions.defaults` factory
+
+In the companion object, add:
+
+```scala
+object SessionOptions:
+  /** Create SessionOptions with all defaults */
+  val defaults: SessionOptions = SessionOptions()
+```
+
+This mirrors the spirit of `QueryOptions.simple(prompt)` but without needing a required argument.
+
+### 4. Add `CLIArgumentBuilder.buildSessionArgs`
+
+Extend `CLIArgumentBuilder` with a new method. The implementation should:
+
+1. Reuse the per-option argument lists that already exist in `buildArgs` (extract them or duplicate with `SessionOptions` parameter types — see note below)
+2. Prepend the three required streaming flags: `--print`, `--input-format`, `stream-json`, `--output-format`, `stream-json`
+3. Append all the option-driven flags (same as `buildArgs` minus any prompt-specific logic)
+4. **Not** append a trailing prompt argument
+
+The cleanest implementation is to extract the repeated argument-building logic into a private helper that accepts the shared fields, then call it from both `buildArgs` and `buildSessionArgs`. This avoids duplicating the per-option mapping logic. However, since `QueryOptions` and `SessionOptions` are separate case classes (not related by inheritance), the shared fields would need to be passed individually or the helper could accept a structural type. The simplest approach: duplicate the field-by-field logic in `buildSessionArgs` since it is mechanical and all the field names are identical — the duplication is acceptable given the small size. Defer extraction to a future refactor only if a third call site appears.
+
+Expected output for `SessionOptions.defaults`:
+
+```
+List("--print", "--input-format", "stream-json", "--output-format", "stream-json")
+```
+
+Expected output for `SessionOptions().withModel("claude-opus-4-5").withSystemPrompt("You are a code reviewer")`:
+
+```
+List("--print", "--input-format", "stream-json", "--output-format", "stream-json",
+     "--model", "claude-opus-4-5",
+     "--system-prompt", "You are a code reviewer")
+```
+
+## Files to Modify/Create
+
+### New files
+
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` — case class with fluent builder methods and companion object
+- `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` — unit tests for `buildSessionArgs`
+- `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` — unit tests for `SessionOptions` construction and builder methods
+
+### Files to modify
+
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — add `buildSessionArgs(options: SessionOptions): List[String]` method and update import
+
+### Reference files (no changes)
+
+- `core/src/works/iterative/claude/core/model/QueryOptions.scala` — field list and fluent builder pattern to replicate
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — existing arg-building patterns
+- `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` — test style to follow
+- `core/src/works/iterative/claude/core/model/PermissionMode.scala` — imported by both options classes
+
+## Testing Strategy
+
+### Unit tests — `SessionOptionsTest`
+
+1. **`SessionOptions()` has all None fields** — construct with no args, verify no field is set
+2. **`SessionOptions.defaults` equals `SessionOptions()`** — sanity check on the factory
+3. **Each `with*` builder sets the correct field** — one test per builder method (18 tests), verifying only the targeted field changes and all others remain as before
+4. **`SessionOptions` has no `prompt` field** — compile-time fact; add a comment in the test explaining this is enforced by the type
+
+### Unit tests — `SessionOptionsArgsTest`
+
+1. **Default options produce the three required flags** — `buildSessionArgs(SessionOptions())` contains `--print`, `--input-format stream-json`, `--output-format stream-json`
+2. **Required flags appear first** — verify the three flags are at the start of the list (index 0..4)
+3. **No trailing prompt argument** — `buildSessionArgs(SessionOptions())` result has exactly 5 elements (the three flag pairs)
+4. **`maxTurns` maps to `--max-turns`** — mirrors existing `CLIArgumentBuilderTest` pattern
+5. **`model` maps to `--model`**
+6. **`allowedTools` maps to `--allowedTools`** with comma-joined value
+7. **`disallowedTools` maps to `--disallowedTools`** with comma-joined value
+8. **`systemPrompt` maps to `--system-prompt`**
+9. **`appendSystemPrompt` maps to `--append-system-prompt`**
+10. **`continueConversation = Some(true)` maps to `--continue`**
+11. **`continueConversation = Some(false)` produces no flag**
+12. **`resume` maps to `--resume`**
+13. **`permissionMode` maps to `--permission-mode`** (all three enum values)
+14. **`maxThinkingTokens` maps to `--max-thinking-tokens`**
+15. **`None` values produce no extra args** — options with all None fields produce only the 5 required flag tokens
+16. **Multiple options combine correctly** — set several fields, verify all flags present with correct values
+
+### Integration tests
+
+None required for this phase. `SessionOptions` and `buildSessionArgs` are pure data transformation with no I/O. Phase 03 will add integration tests that exercise the full process launch path using `SessionOptions`.
+
+### E2E tests
+
+None required for this phase. Phase 03 carries E2E coverage.
+
+## Acceptance Criteria
+
+1. `SessionOptions` case class exists in `works.iterative.claude.core.model` with all fields from `QueryOptions` except `prompt`
+2. `SessionOptions` has no `prompt` field (enforced at compile time)
+3. Every field has a corresponding fluent `with*` builder method returning `SessionOptions`
+4. `SessionOptions.defaults` exists and equals `SessionOptions()` with all None fields
+5. `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions): List[String]` exists and always includes `--print`, `--input-format stream-json`, `--output-format stream-json`
+6. `buildSessionArgs` maps all option fields to the same CLI flags as `buildArgs` does for `QueryOptions`
+7. `buildSessionArgs` does not append a trailing prompt argument
+8. All new files start with the required two-line PURPOSE comment
+9. All unit tests pass with no compilation warnings
+10. All existing tests continue to pass (no regressions in `CLIArgumentBuilderTest`)

--- a/project-management/issues/CC-15/phase-02-tasks.md
+++ b/project-management/issues/CC-15/phase-02-tasks.md
@@ -7,44 +7,45 @@
 
 ### Setup
 
-- [ ] [setup] Read `QueryOptions.scala`, `CLIArgumentBuilder.scala`, `CLIArgumentBuilderTest.scala`, and `PermissionMode.scala` to confirm field names, types, defaults, and test patterns
-- [ ] [setup] Create empty test file `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` with package declaration, imports, and PURPOSE comments
-- [ ] [setup] Create empty test file `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` with package declaration, imports, and PURPOSE comments
+- [x] [setup] Read `QueryOptions.scala`, `CLIArgumentBuilder.scala`, `CLIArgumentBuilderTest.scala`, and `PermissionMode.scala` to confirm field names, types, defaults, and test patterns
+- [x] [setup] Create empty test file `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` with package declaration, imports, and PURPOSE comments
+- [x] [setup] Create empty test file `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` with package declaration, imports, and PURPOSE comments
 
 ### Tests (Red Phase)
 
 #### SessionOptions construction and builder tests
 
-- [ ] [test] Write test "SessionOptions() has all None fields" -- construct with no args, verify every field is `None`
-- [ ] [test] Write test "SessionOptions.defaults equals SessionOptions()" -- verify `SessionOptions.defaults == SessionOptions()`
-- [ ] [test] Write tests for each `with*` builder method (one test per method, 18 total) -- verify calling `withX(value)` on `SessionOptions()` sets only the targeted field and all others remain `None`; group in a single test to keep the file manageable, e.g. "each with* builder sets only its field"
+- [x] [test] Write test "SessionOptions() has all None fields" -- construct with no args, verify every field is `None`
+- [x] [test] Write test "SessionOptions.defaults equals SessionOptions()" -- verify `SessionOptions.defaults == SessionOptions()`
+- [x] [test] Write tests for each `with*` builder method (one test per method, 18 total) -- verify calling `withX(value)` on `SessionOptions()` sets only the targeted field and all others remain `None`; group in a single test to keep the file manageable, e.g. "each with* builder sets only its field"
 
 #### SessionOptions CLI argument mapping tests
 
-- [ ] [test] Write test "default options produce only the three required session flags" -- `buildSessionArgs(SessionOptions())` returns exactly `List("--print", "--input-format", "stream-json", "--output-format", "stream-json")`
-- [ ] [test] Write test "required session flags appear at the start of the argument list" -- set a field like `model`, verify the first 5 elements are the required flags
-- [ ] [test] Write test "no trailing prompt argument" -- `buildSessionArgs(SessionOptions())` has exactly 5 elements
-- [ ] [test] Write test "maxTurns maps to --max-turns" -- mirror pattern from `CLIArgumentBuilderTest`
-- [ ] [test] Write test "model maps to --model"
-- [ ] [test] Write test "allowedTools maps to --allowedTools with comma-joined value"
-- [ ] [test] Write test "disallowedTools maps to --disallowedTools with comma-joined value"
-- [ ] [test] Write test "systemPrompt maps to --system-prompt"
-- [ ] [test] Write test "appendSystemPrompt maps to --append-system-prompt"
-- [ ] [test] Write test "continueConversation Some(true) maps to --continue, Some(false) produces no flag"
-- [ ] [test] Write test "resume maps to --resume"
-- [ ] [test] Write test "permissionMode maps to --permission-mode for all three enum values"
-- [ ] [test] Write test "maxThinkingTokens maps to --max-thinking-tokens"
-- [ ] [test] Write test "None values produce no extra args beyond the required flags"
-- [ ] [test] Write test "multiple options combine correctly" -- set several fields, verify all flags present with correct values after the required prefix
+- [x] [test] Write test "default options produce only the three required session flags" -- `buildSessionArgs(SessionOptions())` returns exactly `List("--print", "--input-format", "stream-json", "--output-format", "stream-json")`
+- [x] [test] Write test "required session flags appear at the start of the argument list" -- set a field like `model`, verify the first 5 elements are the required flags
+- [x] [test] Write test "no trailing prompt argument" -- `buildSessionArgs(SessionOptions())` has exactly 5 elements
+- [x] [test] Write test "maxTurns maps to --max-turns" -- mirror pattern from `CLIArgumentBuilderTest`
+- [x] [test] Write test "model maps to --model"
+- [x] [test] Write test "allowedTools maps to --allowedTools with comma-joined value"
+- [x] [test] Write test "disallowedTools maps to --disallowedTools with comma-joined value"
+- [x] [test] Write test "systemPrompt maps to --system-prompt"
+- [x] [test] Write test "appendSystemPrompt maps to --append-system-prompt"
+- [x] [test] Write test "continueConversation Some(true) maps to --continue, Some(false) produces no flag"
+- [x] [test] Write test "resume maps to --resume"
+- [x] [test] Write test "permissionMode maps to --permission-mode for all three enum values"
+- [x] [test] Write test "maxThinkingTokens maps to --max-thinking-tokens"
+- [x] [test] Write test "None values produce no extra args beyond the required flags"
+- [x] [test] Write test "multiple options combine correctly" -- set several fields, verify all flags present with correct values after the required prefix
 
 ### Implementation (Green Phase)
 
-- [ ] [impl] Create `core/src/works/iterative/claude/core/model/SessionOptions.scala` -- case class with all fields from `QueryOptions` except `prompt`, all defaulting to `None`; include fluent `with*` builder methods matching `QueryOptions` style; companion object with `val defaults: SessionOptions = SessionOptions()`; include PURPOSE comments
-- [ ] [impl] Run `SessionOptionsTest` and verify all construction/builder tests pass
-- [ ] [impl] Add `buildSessionArgs(options: SessionOptions): List[String]` method to `CLIArgumentBuilder.scala` -- prepend `--print`, `--input-format`, `stream-json`, `--output-format`, `stream-json`; append per-field flag mapping duplicated from `buildArgs` (same logic, same flag names); no trailing prompt; add `SessionOptions` to the import
-- [ ] [impl] Run `SessionOptionsArgsTest` and verify all argument mapping tests pass
+- [x] [impl] Create `core/src/works/iterative/claude/core/model/SessionOptions.scala` -- case class with all fields from `QueryOptions` except `prompt`, all defaulting to `None`; include fluent `with*` builder methods matching `QueryOptions` style; companion object with `val defaults: SessionOptions = SessionOptions()`; include PURPOSE comments
+- [x] [impl] Run `SessionOptionsTest` and verify all construction/builder tests pass
+- [x] [impl] Add `buildSessionArgs(options: SessionOptions): List[String]` method to `CLIArgumentBuilder.scala` -- prepend `--print`, `--input-format`, `stream-json`, `--output-format`, `stream-json`; append per-field flag mapping duplicated from `buildArgs` (same logic, same flag names); no trailing prompt; add `SessionOptions` to the import
+- [x] [impl] Run `SessionOptionsArgsTest` and verify all argument mapping tests pass
 
 ### Integration
 
-- [ ] [integration] Run full test suite (`./mill __.test`) to confirm no regressions in existing `CLIArgumentBuilderTest` and all other tests
-- [ ] [integration] Verify no compilation warnings in `./mill __.compile`
+- [x] [integration] Run full test suite (`./mill __.test`) to confirm no regressions in existing `CLIArgumentBuilderTest` and all other tests
+- [x] [integration] Verify no compilation warnings in `./mill __.compile`
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-02-tasks.md
+++ b/project-management/issues/CC-15/phase-02-tasks.md
@@ -1,0 +1,50 @@
+# Phase 02 Tasks: SessionOptions configuration
+
+**Issue:** CC-15
+**Phase Context:** phase-02-context.md
+
+## Tasks
+
+### Setup
+
+- [ ] [setup] Read `QueryOptions.scala`, `CLIArgumentBuilder.scala`, `CLIArgumentBuilderTest.scala`, and `PermissionMode.scala` to confirm field names, types, defaults, and test patterns
+- [ ] [setup] Create empty test file `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` with package declaration, imports, and PURPOSE comments
+- [ ] [setup] Create empty test file `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` with package declaration, imports, and PURPOSE comments
+
+### Tests (Red Phase)
+
+#### SessionOptions construction and builder tests
+
+- [ ] [test] Write test "SessionOptions() has all None fields" -- construct with no args, verify every field is `None`
+- [ ] [test] Write test "SessionOptions.defaults equals SessionOptions()" -- verify `SessionOptions.defaults == SessionOptions()`
+- [ ] [test] Write tests for each `with*` builder method (one test per method, 18 total) -- verify calling `withX(value)` on `SessionOptions()` sets only the targeted field and all others remain `None`; group in a single test to keep the file manageable, e.g. "each with* builder sets only its field"
+
+#### SessionOptions CLI argument mapping tests
+
+- [ ] [test] Write test "default options produce only the three required session flags" -- `buildSessionArgs(SessionOptions())` returns exactly `List("--print", "--input-format", "stream-json", "--output-format", "stream-json")`
+- [ ] [test] Write test "required session flags appear at the start of the argument list" -- set a field like `model`, verify the first 5 elements are the required flags
+- [ ] [test] Write test "no trailing prompt argument" -- `buildSessionArgs(SessionOptions())` has exactly 5 elements
+- [ ] [test] Write test "maxTurns maps to --max-turns" -- mirror pattern from `CLIArgumentBuilderTest`
+- [ ] [test] Write test "model maps to --model"
+- [ ] [test] Write test "allowedTools maps to --allowedTools with comma-joined value"
+- [ ] [test] Write test "disallowedTools maps to --disallowedTools with comma-joined value"
+- [ ] [test] Write test "systemPrompt maps to --system-prompt"
+- [ ] [test] Write test "appendSystemPrompt maps to --append-system-prompt"
+- [ ] [test] Write test "continueConversation Some(true) maps to --continue, Some(false) produces no flag"
+- [ ] [test] Write test "resume maps to --resume"
+- [ ] [test] Write test "permissionMode maps to --permission-mode for all three enum values"
+- [ ] [test] Write test "maxThinkingTokens maps to --max-thinking-tokens"
+- [ ] [test] Write test "None values produce no extra args beyond the required flags"
+- [ ] [test] Write test "multiple options combine correctly" -- set several fields, verify all flags present with correct values after the required prefix
+
+### Implementation (Green Phase)
+
+- [ ] [impl] Create `core/src/works/iterative/claude/core/model/SessionOptions.scala` -- case class with all fields from `QueryOptions` except `prompt`, all defaulting to `None`; include fluent `with*` builder methods matching `QueryOptions` style; companion object with `val defaults: SessionOptions = SessionOptions()`; include PURPOSE comments
+- [ ] [impl] Run `SessionOptionsTest` and verify all construction/builder tests pass
+- [ ] [impl] Add `buildSessionArgs(options: SessionOptions): List[String]` method to `CLIArgumentBuilder.scala` -- prepend `--print`, `--input-format`, `stream-json`, `--output-format`, `stream-json`; append per-field flag mapping duplicated from `buildArgs` (same logic, same flag names); no trailing prompt; add `SessionOptions` to the import
+- [ ] [impl] Run `SessionOptionsArgsTest` and verify all argument mapping tests pass
+
+### Integration
+
+- [ ] [integration] Run full test suite (`./mill __.test`) to confirm no regressions in existing `CLIArgumentBuilderTest` and all other tests
+- [ ] [integration] Verify no compilation warnings in `./mill __.compile`

--- a/project-management/issues/CC-15/phase-03-context.md
+++ b/project-management/issues/CC-15/phase-03-context.md
@@ -1,0 +1,239 @@
+# Phase 03: Direct API - Basic session lifecycle
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 12-16 hours
+**Status:** Not started
+
+## Goals
+
+1. Create a `Session` trait in the direct module representing an active conversational session with `send` and `close` methods
+2. Add a `ClaudeCode.session(SessionOptions)` factory method (both instance and companion object variants) that starts a CLI process and returns a `Session`
+3. Implement `Session.send(prompt: String): Flow[Message]` that writes an `SDKUserMessage` to stdin and returns a streaming `Flow[Message]` terminating at `ResultMessage`
+4. Implement `Session.close(): Unit` that terminates the underlying CLI process cleanly
+5. The CLI process starts once at session creation and stays alive across `send` calls
+6. Extract session ID from the CLI's initial `SystemMessage` (subtype `init`) for use in subsequent `SDKUserMessage` payloads
+
+## Scope
+
+### In scope
+
+- `Session` trait with `send(prompt: String): Flow[Message]` and `close(): Unit`
+- `SessionProcess` (or similar internal implementation) managing the long-lived CLI process, its stdin writer, and its stdout reader
+- `ClaudeCode.session(SessionOptions): Session` factory method on the class (requires `Ox`, `Logger`)
+- `ClaudeCode.session(SessionOptions)(using Logger): Session` blocking factory on the companion object
+- Writing `SDKUserMessage` JSON to process stdin (newline-delimited)
+- Reading stdout lines, parsing via `JsonParser`, and emitting as `Flow[Message]`
+- Detecting `ResultMessage` as end-of-turn delimiter to complete the `Flow`
+- Extracting `session_id` from the initial `SystemMessage` for use in `SDKUserMessage`
+- Using `"pending"` as the session ID for the first `send` if no init message arrives before first send
+- Process cleanup on `close()` (close stdin, wait briefly, destroy if needed)
+- Re-exporting `Session` and `SessionOptions` in `direct` package object
+- Mock CLI scripts for integration testing that simulate the stream-json protocol (read stdin, write stdout)
+
+### Out of scope
+
+- Turn sequencing enforcement (Phase 04 adds multi-turn; Phase 03 only needs single-turn to work, but does not prevent multiple sends)
+- Client-side concurrency guards on `send` (per RESOLVED decision: delegate to CLI)
+- Effectful API session (Phase 05)
+- Error handling for process crashes mid-session (Phase 06 hardens error paths)
+- `control_request` / `control_response` messages
+- Timeout on individual `send` calls (session-level timeout can be added later)
+
+## Dependencies
+
+**Phase 01 delivered:**
+- `SDKUserMessage` case class with circe `Encoder` at `core/src/works/iterative/claude/core/model/SDKUserMessage.scala`
+- `KeepAliveMessage` and `StreamEventMessage` types in `Message` hierarchy at `core/src/works/iterative/claude/core/model/Message.scala`
+- `ResultMessage` confirmed as end-of-turn delimiter
+- `JsonParser.parseMessage` handles all message types including `keep_alive` and `stream_event`
+
+**Phase 02 delivered:**
+- `SessionOptions` case class at `core/src/works/iterative/claude/core/model/SessionOptions.scala`
+- `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions): List[String]` at `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`
+- Produces correct CLI flags including `--print --input-format stream-json --output-format stream-json`
+
+## Approach
+
+### 1. Define the `Session` trait
+
+Create `direct/src/works/iterative/claude/direct/Session.scala`.
+
+```scala
+trait Session:
+  def send(prompt: String): Flow[Message]
+  def close(): Unit
+  def sessionId: String
+```
+
+- `send` writes an `SDKUserMessage` to stdin and returns a `Flow[Message]` that emits messages until a `ResultMessage` is received
+- `close` shuts down the underlying process
+- `sessionId` exposes the session ID assigned by the CLI (or `"pending"` before the first init message)
+
+### 2. Implement `SessionProcess` (internal)
+
+Create `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala`.
+
+This is the core implementation managing the long-lived process. Key design:
+
+**Process lifecycle:**
+- Constructor starts the CLI process using `ProcessBuilder` with args from `CLIArgumentBuilder.buildSessionArgs`
+- Reuse the existing `ProcessManager.configureProcess` pattern for setting cwd, environment, etc. — but note that `configureProcess` currently takes `QueryOptions`. Create a new overload or extract a helper that takes the common fields (executable path, args, cwd, inheritEnvironment, environmentVariables). The simplest approach: create a `configureSessionProcess` method that takes `SessionOptions` directly, duplicating the small amount of process builder configuration.
+- stdin is kept open (do NOT close it like `ProcessManager` does for queries)
+- stdout is read via a `BufferedReader` stored as a field
+- stderr is captured in a background fork (reuse pattern from `ProcessManager.captureStderrStream`)
+
+**Session ID extraction:**
+- After process starts, read stdout lines until a `SystemMessage` with subtype `"init"` arrives
+- Extract `session_id` from the init message's `data` map
+- Store the session ID in a `@volatile var` (or `AtomicReference`) for thread safety
+- If no init message arrives before the first `send`, use `"pending"`
+
+**`send` implementation:**
+- Construct an `SDKUserMessage(content = prompt, sessionId = currentSessionId)`
+- Encode to JSON using the circe `Encoder`, append newline, write to stdin, flush
+- Return a `Flow.usingEmit` that reads stdout lines, parses them via `JsonParser.parseJsonLineWithContextWithLogging`, and emits parsed `Message` values
+- When a `ResultMessage` is encountered, emit it and then stop (complete the Flow)
+- Update stored `sessionId` from the `ResultMessage.sessionId` field (it may differ from the init one)
+- `KeepAliveMessage` and `StreamEventMessage` are emitted like any other message — the caller decides what to do with them
+
+**`close` implementation:**
+- Close the stdin `OutputStream`
+- Wait briefly for the process to exit (e.g., `process.waitFor(5, TimeUnit.SECONDS)`)
+- If still alive, call `process.destroyForcibly()`
+- Close the stdout reader
+
+### 3. Add `ClaudeCode.session` factory methods
+
+Modify `direct/src/works/iterative/claude/direct/ClaudeCode.scala`.
+
+**Instance method** (within supervised scope):
+```scala
+def session(options: SessionOptions): Session =
+  ClaudeCode.createSession(options)
+```
+
+**Companion object method:**
+```scala
+def session(options: SessionOptions)(using Logger, Ox): Session
+```
+
+The factory method requires `(using Logger, Ox)` because the session's background forks (stderr capture) need a supervised scope. The caller must provide the `Ox` scope (e.g., inside `supervised { ... }`), since the session must outlive the factory call.
+
+- **Instance method:** `def session(options: SessionOptions): Session` — uses the existing `Ox` scope from the class constructor
+- **Companion object:** `def session(options: SessionOptions)(using Logger, Ox): Session` — requires the caller to provide an `Ox` scope
+
+Validate the session options (cwd exists) using the same `validateWorkingDirectory` logic.
+
+Resolve the executable path using the same `resolveClaudeExecutablePath` logic, adapted to read from `SessionOptions` fields.
+
+Build CLI args via `CLIArgumentBuilder.buildSessionArgs(options)`.
+
+Construct and return a `SessionProcess` instance.
+
+### 4. Wire up process startup in `SessionProcess`
+
+The constructor or a factory method should:
+1. Build args: `CLIArgumentBuilder.buildSessionArgs(options)`
+2. Resolve executable: `options.pathToClaudeCodeExecutable.getOrElse(CLIDiscovery.findClaude.getOrElse(throw ...))`
+3. Create `ProcessBuilder` with `(executablePath :: args).asJava`
+4. Set cwd from `options.cwd`
+5. Configure environment from `options.inheritEnvironment` / `options.environmentVariables`
+6. Start process
+7. Fork stderr capture in background
+8. Read initial messages from stdout to extract session ID
+9. Return ready-to-use `Session`
+
+### 5. Re-export types in package object
+
+Add to `direct/src/works/iterative/claude/direct/package.scala`:
+```scala
+type Session = works.iterative.claude.direct.Session
+type SessionOptions = works.iterative.claude.core.model.SessionOptions
+val SessionOptions = works.iterative.claude.core.model.SessionOptions
+```
+
+### 6. Write tests (TDD)
+
+Follow TDD: write failing test first, then implement.
+
+**Order of implementation via TDD cycles:**
+
+1. Test: `Session` trait compiles with expected method signatures → Implement trait
+2. Test: `SessionProcess` can start a mock CLI process and extract session ID from init message → Implement process startup + init reading
+3. Test: `send` writes correct JSON to stdin → Implement stdin writing
+4. Test: `send` returns Flow that emits parsed messages up to ResultMessage → Implement stdout reading + Flow emission
+5. Test: `close` terminates the process → Implement close logic
+6. Test: `ClaudeCode.session` factory creates a working Session → Wire up factory
+7. Integration test: full send/receive cycle with mock CLI script
+8. E2E test: real CLI session (gated on CLI availability)
+
+## Files to Modify/Create
+
+### New files
+
+- `direct/src/works/iterative/claude/direct/Session.scala` — Session trait definition
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` — internal implementation of Session backed by a long-lived CLI process
+- `direct/test/src/works/iterative/claude/direct/SessionTest.scala` — unit tests for Session trait and SessionProcess
+- `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` — integration tests with mock CLI scripts
+- `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` — E2E tests with real CLI (gated on availability)
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — mock CLI script generator for session protocol (reads stdin JSON, writes stdout JSON responses)
+
+### Files to modify
+
+- `direct/src/works/iterative/claude/direct/ClaudeCode.scala` — add `session(SessionOptions): Session` factory methods
+- `direct/src/works/iterative/claude/direct/package.scala` — add `Session` and `SessionOptions` re-exports
+
+### Reference files (no changes)
+
+- `core/src/works/iterative/claude/core/model/SDKUserMessage.scala` — stdin message format and Encoder
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` — session configuration
+- `core/src/works/iterative/claude/core/model/Message.scala` — Message hierarchy (ResultMessage as delimiter)
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — `buildSessionArgs` for CLI flag generation
+- `core/src/works/iterative/claude/core/parsing/JsonParser.scala` — message parsing logic
+- `direct/src/works/iterative/claude/direct/internal/cli/ProcessManager.scala` — reference for process management patterns (configureProcess, stderr capture, stdout reading)
+- `direct/src/works/iterative/claude/direct/internal/parsing/JsonParser.scala` — direct-style JSON parsing with logging
+- `direct/src/works/iterative/claude/direct/Logger.scala` — Logger trait
+- `direct/src/works/iterative/claude/direct/internal/testing/MockCliScript.scala` — existing mock CLI script patterns
+- `direct/src/works/iterative/claude/direct/internal/testing/TestConstants.scala` — test constants
+- `direct/test/src/works/iterative/claude/direct/ClaudeCodeIntegrationTest.scala` — reference for integration test patterns
+
+## Testing Strategy
+
+### Unit tests (`SessionTest.scala`)
+
+1. **Session trait has expected method signatures** — compile-time verification that `send` returns `Flow[Message]` and `close` returns `Unit`
+2. **SDKUserMessage is correctly encoded for stdin** — verify JSON output matches expected format with session ID and content
+3. **ResultMessage signals end of Flow** — given a sequence of messages including a ResultMessage, verify the Flow emits up to and including ResultMessage then completes
+4. **Session ID is extracted from SystemMessage init** — given a SystemMessage with subtype "init" and session_id in data, verify extraction
+5. **Session ID defaults to "pending" when no init received** — verify fallback behavior
+6. **Session ID is updated from ResultMessage** — after a send completes, verify sessionId reflects the ResultMessage's sessionId
+7. **Close terminates process** — verify that close destroys the process
+
+### Integration tests (`SessionIntegrationTest.scala`)
+
+1. **Full single-turn session lifecycle** — start session with mock CLI, send one message, receive streaming response ending with ResultMessage, close session, verify process exited
+2. **Mock CLI receives correct stdin JSON** — mock CLI script captures stdin input to a temp file; verify the written JSON matches `SDKUserMessage` format
+3. **Session extracts session ID from init message** — mock CLI outputs a system/init message with session_id; verify `session.sessionId` returns it
+4. **KeepAlive and StreamEvent messages are emitted in Flow** — mock CLI outputs keep_alive and stream_event messages interleaved with assistant messages; verify all appear in the collected Flow
+5. **ClaudeCode.session factory creates working session** — use `ClaudeCode.session(options)` to create session, send a message, verify response
+
+### E2E tests (`SessionE2ETest.scala`)
+
+1. **Real CLI session with single turn** — gated on CLI availability (same pattern as `ClaudeCodeIntegrationTest`); open session, send "What is 1+1?", verify response contains assistant message and ResultMessage, close session
+2. **Session ID is a valid non-pending value after first turn** — after completing a turn with real CLI, verify `session.sessionId` is not "pending"
+
+## Acceptance Criteria
+
+1. `Session` trait exists at `works.iterative.claude.direct.Session` with `send(prompt: String): Flow[Message]`, `close(): Unit`, and `sessionId: String`
+2. `ClaudeCode.session(SessionOptions): Session` factory method exists on the `ClaudeCode` class (requires `Ox`, `Logger`)
+3. `ClaudeCode.session(SessionOptions)(using Logger, Ox): Session` factory method exists on the `ClaudeCode` companion object
+4. `send` writes a correctly-formatted `SDKUserMessage` JSON line to the process stdin
+5. `send` returns a `Flow[Message]` that streams parsed messages from stdout and completes after emitting a `ResultMessage`
+6. The underlying CLI process starts once at session creation and remains alive after `send` completes
+7. `close` terminates the CLI process (stdin closed, process destroyed if necessary)
+8. Session ID is extracted from the CLI's initial `SystemMessage` and used in `SDKUserMessage` payloads
+9. `Session` and `SessionOptions` are re-exported in the `direct` package object
+10. All new files start with the required two-line PURPOSE comments
+11. All unit, integration, and E2E tests pass with no compilation warnings
+12. All existing tests continue to pass (no regressions)
+13. Mock CLI script for session testing reads stdin and writes stdout, simulating the stream-json protocol

--- a/project-management/issues/CC-15/phase-03-tasks.md
+++ b/project-management/issues/CC-15/phase-03-tasks.md
@@ -1,0 +1,44 @@
+# Phase 03 Tasks: Direct API - Basic session lifecycle
+
+**Issue:** CC-15
+**Phase Context:** phase-03-context.md
+
+## Tasks
+
+### Setup
+
+- [x] [setup] Review existing ProcessManager, MockCliScript, and ClaudeCode patterns for reuse
+
+### Tests First (TDD)
+
+- [x] [test] Session trait compilation test - verify trait compiles with expected method signatures
+- [x] [test] SDKUserMessage stdin encoding test - verify JSON written to stdin matches expected format with session ID
+- [x] [test] Session ID extraction test - extract session_id from SystemMessage init
+- [x] [test] Session ID pending default test - defaults to "pending" when no init received
+- [x] [test] ResultMessage end-of-flow test - Flow emits up to and including ResultMessage then completes
+- [x] [test] Session ID update from ResultMessage test - sessionId updated after send completes
+- [x] [test] Close terminates process test - verify close destroys process
+
+### Implementation
+
+- [x] [impl] Create Session trait with send, close, sessionId methods
+- [x] [impl] Create SessionProcess - process startup, stdin/stdout management, stderr capture
+- [x] [impl] Implement session ID extraction from init SystemMessage
+- [x] [impl] Implement send() - write SDKUserMessage to stdin, return Flow[Message] up to ResultMessage
+- [x] [impl] Implement close() - close stdin, wait, destroy if needed
+- [x] [impl] Add ClaudeCode.session factory methods (instance and companion)
+- [x] [impl] Add Session and SessionOptions re-exports to package.scala
+
+### Integration
+
+- [x] [integ] Create SessionMockCliScript for session protocol simulation
+- [x] [integ] Integration test: full single-turn session lifecycle with mock CLI
+- [x] [integ] Integration test: mock CLI receives correct stdin JSON
+- [x] [integ] Integration test: session extracts session ID from init message
+- [x] [integ] Integration test: KeepAlive and StreamEvent messages emitted in Flow
+- [x] [integ] Integration test: ClaudeCode.session factory creates working session
+- [x] [integ] E2E test: real CLI session with single turn (gated on CLI availability)
+- [x] [integ] E2E test: session ID is valid non-pending after first turn
+- [x] [integ] Verify all existing tests still pass (no regressions)
+
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-04-context.md
+++ b/project-management/issues/CC-15/phase-04-context.md
@@ -1,0 +1,120 @@
+# Phase 04: Direct API - Multi-turn conversation
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 4-6 hours
+**Status:** Not started
+
+## Goals
+
+1. Verify that multiple sequential `send` calls within a single `Session` produce correct, isolated responses per turn
+2. Verify that response messages from one turn do not bleed into the next turn's `Flow`
+3. Verify that the session ID remains consistent (or updates correctly) across turns
+4. Verify that context is maintained across turns (the CLI handles this internally; we verify the SDK does not break it)
+5. Fix any issues discovered during multi-turn testing
+
+## Scope
+
+### In scope
+
+- Multi-turn unit tests: two or more sequential `send` calls on a single session, verifying each returns its own complete message stream
+- Multi-turn integration tests: mock CLI scripts that respond differently per turn, verifying correct turn-to-response mapping
+- Multi-turn E2E test: real CLI session with a follow-up question that requires context from the first answer
+- Verifying the `SDKUserMessage` sent for the second turn includes the session ID from the first turn's `ResultMessage`
+- Verifying that `session.sessionId` is updated after each completed turn
+- Any bug fixes in `SessionProcess.send` discovered during multi-turn testing (e.g., boundary detection issues, stale state)
+
+### Out of scope
+
+- Concurrent `send` calls (per RESOLVED decision: no client-side enforcement, CLI handles queueing)
+- Turn-level timeouts
+- Error handling for process crashes mid-conversation (Phase 06)
+- Effectful API sessions (Phase 05)
+- Any new public API surface (Phase 03 already defined everything needed)
+
+## Dependencies
+
+**Phase 03 delivered:**
+- `Session` trait at `direct/src/works/iterative/claude/direct/Session.scala` with `send(prompt: String): Flow[Message]`, `close(): Unit`, `sessionId: String`
+- `SessionProcess` at `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` — already supports multiple sequential `send` calls mechanically (stdin stays open, stdout reader persists across calls)
+- `ClaudeCode.session(SessionOptions): Session` factory on both class and companion object
+- `SessionMockCliScript` at `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — already supports multi-turn via `turnResponses: List[TurnResponse]` with index cycling
+- Session ID extracted from init `SystemMessage`, updated from each `ResultMessage`
+- Existing single-turn tests (unit, integration, E2E) all passing
+
+**Key insight:** The mechanical infrastructure for multi-turn already exists. Phase 4 is primarily about comprehensive testing to prove it works correctly and fixing any issues found.
+
+## Approach
+
+### 1. Add multi-turn unit tests to `SessionTest.scala`
+
+Add tests that call `send` twice on the same session and verify:
+- Each `send` returns only messages for that turn (no bleeding)
+- The second `send`'s `SDKUserMessage` uses the session ID from the first turn's `ResultMessage`
+- `session.sessionId` is updated after each turn
+
+### 2. Add multi-turn integration tests to `SessionIntegrationTest.scala`
+
+Use `SessionMockCliScript.createSessionScript` with multiple `TurnResponse` entries. Tests should:
+- Send two prompts sequentially, collecting each turn's messages independently
+- Verify each turn gets exactly the messages configured for that turn index
+- Verify stdin capture shows two `SDKUserMessage` JSON lines with correct session IDs
+- Verify that different response content per turn maps correctly (turn 1 gets response 1, turn 2 gets response 2)
+
+### 3. Add multi-turn E2E test to `SessionE2ETest.scala`
+
+A single test that sends two messages to the real CLI where the second depends on context from the first (e.g., "Remember the number 42" then "What number did I ask you to remember?"). Verify the second response references the first turn's context.
+
+### 4. Fix any issues discovered
+
+If multi-turn testing reveals issues (e.g., session ID not propagating correctly, stdout reader state problems between turns), fix them in `SessionProcess`.
+
+## Files to Modify/Create
+
+### New files
+
+None expected. All tests go into existing test files.
+
+### Files to modify
+
+- `direct/test/src/works/iterative/claude/direct/SessionTest.scala` — add multi-turn unit tests
+- `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` — add multi-turn integration tests
+- `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` — add multi-turn E2E test
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` — only if bugs are found during testing
+
+### Reference files (no changes)
+
+- `direct/src/works/iterative/claude/direct/Session.scala` — Session trait (no changes expected)
+- `direct/src/works/iterative/claude/direct/ClaudeCode.scala` — factory methods (no changes expected)
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` — mock script generator (already supports multi-turn)
+- `direct/test/src/works/iterative/claude/direct/internal/testing/MockLogger.scala` — test logger
+
+## Testing Strategy
+
+### Unit tests (additions to `SessionTest.scala`)
+
+1. **Two sequential sends return isolated message streams** — configure a mock script with two turn responses, call `send` twice, verify each returns exactly the messages for its turn index and no more
+2. **Session ID propagates from first turn to second send** — after the first `send` completes, verify `session.sessionId` is updated, then use stdin capture to verify the second `SDKUserMessage` contains the updated session ID
+3. **Three turns work correctly** — extend to three sequential sends to test the cycling/indexing beyond two turns
+
+### Integration tests (additions to `SessionIntegrationTest.scala`)
+
+1. **Full two-turn session lifecycle** — start session with init message, send two prompts with different expected responses per turn, verify each `send` returns the correct response content, verify session ID consistency throughout
+2. **Stdin capture shows correct session ID progression** — use `captureStdinFile`, send two prompts, verify first `SDKUserMessage` has the init session ID and second has the session ID from the first `ResultMessage`
+3. **Turn responses with different message counts** — configure turn 1 with 2 messages (assistant + result) and turn 2 with 4 messages (keepalive + stream_event + assistant + result), verify each turn's `Flow` emits exactly the right number and type of messages
+4. **Session ID updates across turns when ResultMessage has different IDs** — configure turn 1 and turn 2 with different session IDs in their `ResultMessage`, verify `session.sessionId` reflects the most recent one after each turn
+
+### E2E tests (additions to `SessionE2ETest.scala`)
+
+1. **Two-turn conversation with context dependency** — gated on CLI availability; send "Remember the number 42. Reply only with 'OK'." then send "What number did I ask you to remember? Reply with just the number." Verify the second response contains "42". This confirms the CLI maintains conversation context across turns and the SDK does not break it.
+2. **Session ID remains valid across multiple turns** — after two turns with the real CLI, verify `session.sessionId` is non-empty and not "pending"
+
+## Acceptance Criteria
+
+1. Two or more sequential `send` calls within one session each return a complete `Flow[Message]` ending with a `ResultMessage`
+2. Messages from one turn do not appear in another turn's `Flow` (no bleeding)
+3. The `SDKUserMessage` for the second turn includes the session ID obtained from the first turn's `ResultMessage`
+4. `session.sessionId` is updated after each completed turn
+5. Context is maintained across turns (verified via E2E test with context-dependent follow-up)
+6. Both turns originate from the same underlying CLI process (verified by the session staying open and functional)
+7. All new tests pass with no compilation warnings
+8. All existing Phase 03 tests continue to pass (no regressions)

--- a/project-management/issues/CC-15/phase-04-tasks.md
+++ b/project-management/issues/CC-15/phase-04-tasks.md
@@ -1,0 +1,31 @@
+# Phase 04 Tasks: Direct API - Multi-turn conversation
+
+## Tests
+
+### Unit tests (SessionTest.scala)
+
+- [ ] [test] Two sequential sends return isolated message streams — configure mock with two TurnResponses, call send twice, verify each returns only its own turn's messages (no bleeding)
+- [ ] [test] Session ID propagates from first turn's ResultMessage to second send's SDKUserMessage — after first send completes, verify session.sessionId is updated, then verify second SDKUserMessage (via stdin capture) contains the updated session ID
+- [ ] [test] Session ID updates after each turn — send twice with different session IDs in each ResultMessage, verify session.sessionId reflects the most recent one after each turn
+- [ ] [test] Three sequential sends work correctly — extend to three turns to verify indexing/cycling beyond two turns
+
+### Integration tests (SessionIntegrationTest.scala)
+
+- [ ] [test] Full two-turn session lifecycle — start session with init message, send two prompts with different response content per turn, verify each send returns the correct response content
+- [ ] [test] Stdin capture shows correct session ID progression — use captureStdinFile, send two prompts, verify first SDKUserMessage has init session ID and second has the session ID from first turn's ResultMessage
+- [ ] [test] Turn responses with different message counts — configure turn 1 with 2 messages (assistant + result) and turn 2 with 4 messages (keepalive + stream_event + assistant + result), verify each turn's Flow emits exactly the right count and types
+- [ ] [test] Session ID updates across turns when ResultMessage has different IDs — configure turn 1 and turn 2 with distinct session IDs in their ResultMessage, verify session.sessionId reflects the most recent after each turn
+
+### E2E tests (SessionE2ETest.scala)
+
+- [ ] [test] Two-turn conversation with context dependency — gated on CLI availability; send "Remember the number 42. Reply only with 'OK'." then "What number did I ask you to remember? Reply with just the number." Verify second response contains "42"
+- [ ] [test] Session ID remains valid across multiple turns — after two turns with real CLI, verify session.sessionId is non-empty and not "pending"
+
+## Implementation
+
+- [ ] [impl] Fix any bugs discovered during multi-turn testing in SessionProcess.send (e.g., boundary detection issues, stale state, session ID propagation)
+
+## Integration
+
+- [ ] [integration] Verify all new multi-turn tests pass alongside existing Phase 03 tests with no regressions (./mill direct.test)
+- [ ] [integration] Verify no compilation warnings in direct module

--- a/project-management/issues/CC-15/phase-04-tasks.md
+++ b/project-management/issues/CC-15/phase-04-tasks.md
@@ -4,28 +4,29 @@
 
 ### Unit tests (SessionTest.scala)
 
-- [ ] [test] Two sequential sends return isolated message streams — configure mock with two TurnResponses, call send twice, verify each returns only its own turn's messages (no bleeding)
-- [ ] [test] Session ID propagates from first turn's ResultMessage to second send's SDKUserMessage — after first send completes, verify session.sessionId is updated, then verify second SDKUserMessage (via stdin capture) contains the updated session ID
-- [ ] [test] Session ID updates after each turn — send twice with different session IDs in each ResultMessage, verify session.sessionId reflects the most recent one after each turn
-- [ ] [test] Three sequential sends work correctly — extend to three turns to verify indexing/cycling beyond two turns
+- [x] [test] Two sequential sends return isolated message streams — configure mock with two TurnResponses, call send twice, verify each returns only its own turn's messages (no bleeding)
+- [x] [test] Session ID propagates from first turn's ResultMessage to second send's SDKUserMessage — after first send completes, verify session.sessionId is updated, then verify second SDKUserMessage (via stdin capture) contains the updated session ID
+- [x] [test] Session ID updates after each turn — send twice with different session IDs in each ResultMessage, verify session.sessionId reflects the most recent one after each turn
+- [x] [test] Three sequential sends work correctly — extend to three turns to verify indexing/cycling beyond two turns
 
 ### Integration tests (SessionIntegrationTest.scala)
 
-- [ ] [test] Full two-turn session lifecycle — start session with init message, send two prompts with different response content per turn, verify each send returns the correct response content
-- [ ] [test] Stdin capture shows correct session ID progression — use captureStdinFile, send two prompts, verify first SDKUserMessage has init session ID and second has the session ID from first turn's ResultMessage
-- [ ] [test] Turn responses with different message counts — configure turn 1 with 2 messages (assistant + result) and turn 2 with 4 messages (keepalive + stream_event + assistant + result), verify each turn's Flow emits exactly the right count and types
-- [ ] [test] Session ID updates across turns when ResultMessage has different IDs — configure turn 1 and turn 2 with distinct session IDs in their ResultMessage, verify session.sessionId reflects the most recent after each turn
+- [x] [test] Full two-turn session lifecycle — start session with init message, send two prompts with different response content per turn, verify each send returns the correct response content
+- [x] [test] Stdin capture shows correct session ID progression — use captureStdinFile, send two prompts, verify first SDKUserMessage has init session ID and second has the session ID from first turn's ResultMessage
+- [x] [test] Turn responses with different message counts — configure turn 1 with 2 messages (assistant + result) and turn 2 with 4 messages (keepalive + stream_event + assistant + result), verify each turn's Flow emits exactly the right count and types
+- [x] [test] Session ID updates across turns when ResultMessage has different IDs — configure turn 1 and turn 2 with distinct session IDs in their ResultMessage, verify session.sessionId reflects the most recent after each turn
 
 ### E2E tests (SessionE2ETest.scala)
 
-- [ ] [test] Two-turn conversation with context dependency — gated on CLI availability; send "Remember the number 42. Reply only with 'OK'." then "What number did I ask you to remember? Reply with just the number." Verify second response contains "42"
-- [ ] [test] Session ID remains valid across multiple turns — after two turns with real CLI, verify session.sessionId is non-empty and not "pending"
+- [x] [test] Two-turn conversation with context dependency — gated on CLI availability; send "Remember the number 42. Reply only with 'OK'." then "What number did I ask you to remember? Reply with just the number." Verify second response contains "42"
+- [x] [test] Session ID remains valid across multiple turns — after two turns with real CLI, verify session.sessionId is non-empty and not "pending"
 
 ## Implementation
 
-- [ ] [impl] Fix any bugs discovered during multi-turn testing in SessionProcess.send (e.g., boundary detection issues, stale state, session ID propagation)
+- [x] [impl] Fix any bugs discovered during multi-turn testing in SessionProcess.send (e.g., boundary detection issues, stale state, session ID propagation)
 
 ## Integration
 
-- [ ] [integration] Verify all new multi-turn tests pass alongside existing Phase 03 tests with no regressions (./mill direct.test)
-- [ ] [integration] Verify no compilation warnings in direct module
+- [x] [integration] Verify all new multi-turn tests pass alongside existing Phase 03 tests with no regressions (./mill direct.test)
+- [x] [integration] Verify no compilation warnings in direct module
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-05-context.md
+++ b/project-management/issues/CC-15/phase-05-context.md
@@ -1,0 +1,216 @@
+# Phase 05: Effectful API - Session lifecycle with Resource
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 8-12 hours
+**Status:** Not started
+
+## Goals
+
+1. Expose an effectful `Session` trait with `send(prompt): IO[Unit]` (command) and `stream: Stream[IO, Message]` (query), acquired as `Resource[IO, Session]`
+2. Implement session process management using `fs2.io.process.ProcessBuilder.spawn` with Resource-based cleanup
+3. Add `ClaudeCode.session(SessionOptions): Resource[IO, Session]` factory to the effectful API
+4. Re-export `SessionOptions` in the effectful package object
+5. Validate multi-turn conversation support from the start (lessons from Phase 4)
+6. Provide full test coverage: unit, integration, and E2E
+
+## Scope
+
+### In scope
+
+- `Session` trait in `effectful` package with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
+- Internal `SessionProcess` implementation using `fs2.io.process.Process[IO]` from `ProcessBuilder.spawn`
+- `Resource[IO, Session]` lifecycle: process start in acquire, process kill + stdin close in release
+- Stdin writing via `process.stdin` pipe (write SDKUserMessage JSON, flush)
+- Stdout reading via `process.stdout` pipe, parsed line-by-line through the effectful `JsonParser`, terminated at `ResultMessage`
+- Stderr capture as a background fiber (matching the existing effectful `ProcessManager` pattern)
+- Session ID extraction from init `SystemMessage` and update from each `ResultMessage`
+- Multi-turn support: sequential `send` calls reuse the same process, each returning its own `Stream[IO, Message]`
+- `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method
+- `SessionOptions` re-export in `effectful/package.scala`
+
+### Out of scope
+
+- Concurrent `send` calls (per RESOLVED decision: no client-side enforcement, CLI handles queueing)
+- Turn-level timeouts (can be composed by caller via `stream.timeout`)
+- Error handling for process crashes mid-conversation (Phase 06)
+- `--continue` / `--resume` validation for session mode
+- Control messages (`control_request` / `control_response`)
+
+## Dependencies
+
+**Prior phases delivered:**
+
+- **Phase 01:** `SDKUserMessage` with circe `Encoder` in `core/src/.../model/SDKUserMessage.scala` -- ready for stdin writing. `KeepAliveMessage`, `StreamEventMessage` types and parser branches in core `JsonParser`. `ResultMessage` confirmed as end-of-turn delimiter.
+- **Phase 02:** `SessionOptions` in `core/src/.../model/SessionOptions.scala` with fluent builders. `CLIArgumentBuilder.buildSessionArgs` producing `--print --input-format stream-json --output-format stream-json` plus all option flags.
+- **Phase 03:** Direct `Session` trait and `SessionProcess` implementation -- reference for session lifecycle, init message reading, stdin/stdout protocol, stderr capture, close semantics.
+- **Phase 04:** Multi-turn test patterns -- `SessionMockCliScript` with `TurnResponse` cycling, stdin capture verification, context-dependent E2E tests. Key lesson: the infrastructure from Phase 3 handled multi-turn correctly without code changes; thorough testing is what matters.
+
+**Existing effectful patterns to follow:**
+
+- `effectful/src/.../ClaudeCode.scala` -- query methods returning `Stream[IO, Message]`, CLI discovery, argument building, configuration validation
+- `effectful/src/.../internal/cli/ProcessManager.scala` -- `ProcessBuilder.spawn[IO]` as `Resource`, stderr capture via fiber, stdout line parsing through effectful `JsonParser`
+- `effectful/src/.../internal/parsing/JsonParser.scala` -- wraps core `JsonParser` with IO effects and logging
+- `effectful/src/.../package.scala` -- type/value re-exports for single-import usage
+- `effectful/test/.../internal/testing/MockScriptResource.scala` -- classpath-based mock script extraction
+
+## Approach
+
+### 1. Create the effectful Session trait
+
+Define `Session` in `effectful/src/works/iterative/claude/effectful/Session.scala`:
+
+```scala
+trait Session:
+  def send(prompt: String): IO[Unit]
+  def stream: Stream[IO, Message]
+  def sessionId: IO[String]
+```
+
+Key differences from the direct `Session`:
+- `send` returns `IO[Unit]` instead of `Unit` (effectful command)
+- `stream` returns `Stream[IO, Message]` instead of `Flow[Message]`
+- `sessionId` returns `IO[String]` instead of `String` (since reading a `Ref` is an effect)
+- No `close()` method -- cleanup is handled by the `Resource` finalizer
+
+Note: The direct `Session` trait is being refactored as part of R1 (see Refactoring Decisions) to match this same send/stream separation pattern.
+
+### 2. Implement SessionProcess
+
+Create `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala`:
+
+- Use `ProcessBuilder(executablePath, args).spawn[IO]` to get `Resource[IO, Process[IO]]`
+- In the Resource acquire phase:
+  1. Spawn the process
+  2. Start a background fiber for stderr capture (same pattern as existing `ProcessManager.captureStderr`)
+  3. Read init messages from stdout to extract session ID into a `Ref[IO, String]`
+  4. Return the `Session` instance
+- In the Resource release phase:
+  1. Write EOF to stdin (close the stdin pipe)
+  2. Wait briefly for process exit
+  3. Cancel the stderr fiber
+- `send` implementation:
+  1. Encode `SDKUserMessage` to JSON using circe
+  2. Write JSON + newline to `process.stdin` via `Stream.emit(bytes).through(process.stdin).compile.drain`
+  3. Return a `Stream` that reads `process.stdout`, decodes UTF-8, splits lines, parses via effectful `JsonParser`, and completes when a `ResultMessage` is emitted (using `takeThrough` or similar)
+  4. Update the session ID `Ref` when `ResultMessage` is encountered
+
+Key implementation detail: stdout must be read as a continuous stream across turns. The `send` method should not re-create the stdout stream each time. Instead, use a shared `Queue[IO, Option[String]]` or similar mechanism where a single background fiber reads stdout lines into the queue, and each `send` call pulls from the queue until it sees a `ResultMessage`. Alternatively, use `fs2.concurrent.Topic` or simply rely on the process stdout pipe being consumed incrementally across `send` calls.
+
+The simplest approach: keep a `Ref` to the current state of the stdout byte stream. Each `send` call reads lines from it until `ResultMessage`. Since sends are sequential, there is no contention.
+
+### 3. Add factory method to ClaudeCode
+
+Add to `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala`:
+
+```scala
+def session(options: SessionOptions)(using logger: Logger[IO]): Resource[IO, Session] =
+  // validate config, discover executable, build args, delegate to SessionProcess
+```
+
+Follow the same pattern as `query`: validate configuration, discover executable path, build CLI arguments, then delegate to `SessionProcess.start`.
+
+### 4. Update package re-exports
+
+Add `SessionOptions` type and value aliases to `effectful/package.scala`, matching the existing re-export pattern.
+
+### 5. Create mock session script infrastructure for effectful tests
+
+Port or share `SessionMockCliScript` from the direct module. Since the script generation is pure (it creates bash scripts on disk), consider either:
+- Extracting `SessionMockCliScript` to a shared test-support location, or
+- Creating a thin effectful wrapper that creates scripts as `Resource[IO, Path]` for automatic cleanup
+
+### 6. Write tests at all three levels
+
+Follow the test patterns established in Phases 3-4, adapted for cats-effect and fs2.
+
+## Files to Modify/Create
+
+### New files
+
+- `effectful/src/works/iterative/claude/effectful/Session.scala` -- Session trait
+- `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` -- Process-backed implementation
+- `effectful/test/src/works/iterative/claude/effectful/SessionTest.scala` -- Unit tests
+- `effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala` -- Integration tests with mock scripts
+- `effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala` -- E2E tests with real CLI
+- `effectful/test/src/works/iterative/claude/effectful/internal/testing/SessionMockCliScript.scala` -- Mock script utilities (or shared from direct module)
+
+### Files to modify
+
+- `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` -- add `session` factory method
+- `effectful/src/works/iterative/claude/effectful/package.scala` -- add `SessionOptions` re-export
+
+### Reference files (no changes)
+
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` -- session configuration
+- `core/src/works/iterative/claude/core/model/SDKUserMessage.scala` -- stdin message type with Encoder
+- `core/src/works/iterative/claude/core/model/Message.scala` -- message hierarchy including ResultMessage, KeepAliveMessage, StreamEventMessage
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` -- `buildSessionArgs` for CLI flags
+- `core/src/works/iterative/claude/core/parsing/JsonParser.scala` -- core pure parsing logic
+- `effectful/src/works/iterative/claude/effectful/internal/parsing/JsonParser.scala` -- effectful parsing wrapper
+- `effectful/src/works/iterative/claude/effectful/internal/cli/ProcessManager.scala` -- reference for fs2 process patterns
+- `effectful/src/works/iterative/claude/effectful/internal/cli/CLIDiscovery.scala` -- executable path resolution
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` -- reference implementation for session protocol
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` -- reference for mock script generation
+
+## Testing Strategy
+
+### Unit tests (`SessionTest.scala`)
+
+1. **SDKUserMessage encoding for send** -- verify the JSON written to stdin matches the protocol format
+2. **Session ID defaults to "pending"** -- verify initial session ID before any send
+3. **Session ID extracted from init message** -- verify session ID updates from init SystemMessage
+4. **Session ID updates from ResultMessage** -- verify session ID updates after send completes
+5. **send returns messages up to and including ResultMessage** -- verify stream terminates correctly at end-of-turn
+6. **KeepAlive and StreamEvent pass through** -- verify non-terminal message types are emitted
+7. **Two sequential sends return isolated streams** -- verify messages from turn 1 do not bleed into turn 2
+8. **Session ID propagates from first turn to second send** -- verify the second SDKUserMessage uses the updated session ID
+9. **Three-turn cycling** -- verify three sequential sends work correctly
+
+### Integration tests (`SessionIntegrationTest.scala`)
+
+1. **Full session lifecycle with Resource** -- acquire session, send one message, verify response, release (process cleanup)
+2. **Resource cleanup on normal exit** -- verify process is terminated after Resource.use completes
+3. **Resource cleanup on error** -- verify process is terminated when an exception occurs inside Resource.use
+4. **Stdin JSON verification** -- use captureStdinFile to verify SDKUserMessage JSON format
+5. **Session ID from init message** -- verify session ID is set from the mock init message
+6. **Two-turn lifecycle** -- send two prompts with different configured responses, verify correct mapping
+7. **Session ID progression across turns** -- verify stdin capture shows correct session ID in each SDKUserMessage
+8. **Variable message counts per turn** -- turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
+9. **ClaudeCode.session factory** -- verify the factory method produces a working session Resource
+
+### E2E tests (`SessionE2ETest.scala`)
+
+1. **Single-turn session with real CLI** -- gated on CLI availability; open session, send one prompt, verify AssistantMessage and ResultMessage in response stream, verify Resource cleanup
+2. **Multi-turn with context dependency** -- send "Remember the number 42" then "What number did I ask you to remember?", verify the second response references 42
+3. **Session ID is valid after real CLI interaction** -- verify session ID is non-empty and not "pending" after a send
+
+## Acceptance Criteria
+
+1. `Session` trait exists in `effectful` package with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
+2. `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method works
+3. Resource acquire starts the CLI process; Resource release terminates it
+4. Process cleanup happens on both normal exit and error (Resource finalizer)
+5. `send` returns a `Stream[IO, Message]` that completes after the turn's `ResultMessage`
+6. Multiple sequential `send` calls within one session each return their own complete stream
+7. Session ID is extracted from init message and updated from each ResultMessage
+8. Messages from one turn do not appear in another turn's stream
+9. `SessionOptions` is re-exported in the effectful package object
+10. All unit, integration, and E2E tests pass with no compilation warnings
+11. All existing effectful query tests continue to pass (no regressions)
+12. All existing direct session tests continue to pass (no regressions)
+
+## Refactoring Decisions
+
+### R1: Split Session.send into send + stream (CQS) (2026-04-05)
+
+**Trigger:** Comparison with the V2 Claude Agent SDK revealed our `send()` combines a command (write prompt to stdin) and a query (read response stream) in one method, violating command-query separation. The V2 SDK separates these as `send()` → `Promise<void>` and `stream()` → `AsyncGenerator<SDKMessage>`.
+**Decision:** Split `Session.send(prompt): Flow[Message]` into two methods:
+- `send(prompt: String): Unit` — command: writes SDKUserMessage JSON to stdin
+- `stream(): Flow[Message]` — query: reads stdout until ResultMessage
+
+This applies to both the direct Session (refactoring existing code) and the effectful Session (new code, designed this way from the start).
+**Scope:**
+- Files affected: `Session.scala` (trait), `SessionProcess.scala` (impl), `SessionTest.scala`, `SessionIntegrationTest.scala`, `SessionE2ETest.scala`
+- Components: direct Session trait, SessionProcess implementation, all session tests
+- Boundaries: do NOT touch core model types, CLIArgumentBuilder, effectful module, ClaudeCode factory methods
+**Approach:** Mechanical split — extract stdin-write from `send` into a void method, create `stream()` from the stdout-reading portion, update all test call sites from `session.send(x).forEach(...)` to `session.send(x); session.stream().forEach(...)`

--- a/project-management/issues/CC-15/phase-05-tasks.md
+++ b/project-management/issues/CC-15/phase-05-tasks.md
@@ -1,0 +1,56 @@
+# Phase 05 Tasks: Effectful API - Session lifecycle with Resource
+
+## Refactoring
+
+- [x] [impl] Refactoring R1: Split direct Session.send into send + stream (CQS) — see `refactor-phase-05-R1.md`
+
+## Setup
+
+- [x] [impl] Create effectful `Session` trait in `effectful/src/.../effectful/Session.scala` with `send(prompt: String): IO[Unit]`, `stream: Stream[IO, Message]`, and `sessionId: IO[String]`
+- [x] [impl] Add `SessionOptions` re-export to `effectful/src/.../effectful/package.scala` (type alias + value alias, matching existing re-export pattern)
+
+## Tests
+
+### Unit tests (SessionTest.scala)
+
+- [x] [test] SDKUserMessage encoding for send — verify the JSON written to a mock stdin pipe matches the protocol format (`type`, `message.role`, `message.content`, `session_id`)
+- [x] [test] Session ID defaults to "pending" — verify `sessionId` returns IO("pending") before any send
+- [x] [test] Session ID extracted from init SystemMessage — verify sessionId updates from init message during Resource acquire
+- [x] [test] Session ID updates from ResultMessage — verify sessionId reflects the session_id from each ResultMessage after stream completes
+- [x] [test] stream returns messages up to and including ResultMessage — verify the stream terminates correctly at end-of-turn
+- [x] [test] KeepAlive and StreamEvent pass through — verify non-terminal message types are emitted in the stream
+- [x] [test] Two sequential sends return isolated streams — configure mock with two turns, verify each stream returns only its own turn's messages
+- [x] [test] Session ID propagates from first turn to second send — verify the second SDKUserMessage uses the updated session ID from the first turn's ResultMessage
+- [x] [test] Three-turn cycling — verify three sequential send/stream cycles work correctly
+
+### Integration tests (SessionIntegrationTest.scala)
+
+- [x] [test] Full session lifecycle with Resource — acquire session, send one message, consume stream, verify response, release (process cleanup)
+- [x] [test] Resource cleanup on normal exit — verify process is terminated after Resource.use completes
+- [x] [test] Resource cleanup on error — verify process is terminated when an exception occurs inside Resource.use
+- [x] [test] Stdin JSON verification — use captureStdinFile in mock script to verify SDKUserMessage JSON format
+- [x] [test] Session ID from init message — verify session ID is set from the mock init message during acquire
+- [x] [test] Two-turn lifecycle — send two prompts with different configured responses, verify correct mapping
+- [x] [test] Session ID progression across turns — verify stdin capture shows correct session ID in each SDKUserMessage
+- [x] [test] Variable message counts per turn — turn 1 with 2 messages, turn 2 with 4 messages (including keepalive/stream_event)
+- [x] [test] ClaudeCode.session factory — verify the factory method produces a working session Resource
+
+### E2E tests (SessionE2ETest.scala)
+
+- [x] [test] Single-turn session with real CLI — gated on CLI availability; open session Resource, send one prompt, verify AssistantMessage and ResultMessage in stream, verify Resource cleanup
+- [x] [test] Multi-turn with context dependency — send "Remember the number 42" then "What number did I ask you to remember?", verify second response references 42
+- [x] [test] Session ID is valid after real CLI interaction — verify session ID is non-empty and not "pending" after a send
+
+## Implementation
+
+- [x] [impl] Create `SessionProcess` in `effectful/src/.../internal/cli/SessionProcess.scala` — Resource-based implementation using `ProcessBuilder.spawn[IO]`, background stderr fiber, shared stdout stream, stdin writing via process.stdin pipe
+- [x] [impl] Add `ClaudeCode.session(SessionOptions)(using Logger[IO]): Resource[IO, Session]` factory method to `effectful/src/.../effectful/ClaudeCode.scala`
+- [x] [impl] Create mock script infrastructure for effectful tests — `SessionMockCliScript.scala` in effectful test internal/testing (Resource[IO, Path] wrapper or shared from direct module)
+
+## Integration
+
+- [x] [integration] Verify all new effectful session tests pass (`./mill effectful.test`)
+- [x] [integration] Verify no regressions in existing effectful query tests
+- [x] [integration] Verify no regressions in direct module tests (`./mill direct.test`)
+- [x] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-06-context.md
+++ b/project-management/issues/CC-15/phase-06-context.md
@@ -1,0 +1,218 @@
+# Phase 06: Error handling - process crash and malformed JSON
+
+**Issue:** CC-15 - Support persistent two-way conversations with a single Claude Code session
+**Estimated Effort:** 6-8 hours
+**Status:** Not started
+
+## Goals
+
+1. Detect when the underlying CLI process crashes or exits unexpectedly during an active session and surface this as a typed `CLIError` through the send/stream API
+2. Ensure malformed JSON lines on stdout are handled gracefully in the continuous-reading session context (logged and skipped without killing the session)
+3. Mark sessions as invalid after process death so subsequent `send` calls fail with a clear error rather than silently hanging or producing confusing exceptions
+4. Apply error handling consistently across both the direct (Ox) and effectful (cats-effect/fs2) Session implementations
+
+## Scope
+
+### In scope
+
+- New `SessionError` case class (or similar) in the `CLIError` hierarchy for session-specific failures (process died, session closed)
+- **Direct API:** Process liveness check in `send()` before writing to stdin; stdout EOF detection in `stream()` producing a typed error instead of silent completion; `close()` idempotency
+- **Effectful API:** Process liveness detection in `send` (before enqueuing to stdinQueue); stdout reader fiber propagating process death through the messageQueue as an error; stream surfacing the error to the caller
+- Malformed JSON resilience: verify that the existing JSON parsing error handling (log + skip in direct; log + skip in effectful) works correctly in the continuous session context where the session must survive bad lines and continue reading
+- Session state tracking: an `isAlive` flag (AtomicBoolean / Ref[IO, Boolean]) that is set to false when the process exits, enabling `send` to fail fast
+
+### Out of scope
+
+- Automatic session reconnection or retry after process crash
+- Timeout handling for individual turns (callers can compose this via `stream.timeout` / `Flow.timeout`)
+- Concurrent send protection (per prior decision: CLI handles queueing)
+- Control messages (`control_request` / `control_response`)
+- Changes to the query-mode (non-session) error handling
+
+## Dependencies
+
+**Prior phases delivered:**
+
+- **Phase 01:** `SDKUserMessage` encoder, `ResultMessage` as end-of-turn delimiter, `KeepAliveMessage`/`StreamEventMessage` types, core `JsonParser` with `parseJsonLine` and `parseMessage`
+- **Phase 02:** `SessionOptions` with fluent builders, `CLIArgumentBuilder.buildSessionArgs`
+- **Phase 03:** Direct `Session` trait (`send`/`stream`/`close`/`sessionId`), `SessionProcess` managing process lifecycle, init message reading, `SessionMockCliScript` test infrastructure
+- **Phase 04:** Multi-turn tests proving sequential send/stream isolation, session ID propagation across turns
+- **Phase 05:** Effectful `Session` trait (`send`/`stream`/`sessionId`), Resource-based `SessionProcess` with background fibers (stdin writer, stdout reader, stderr capture), `Queue`-based message routing, init message extraction
+
+**Key existing code to build on:**
+
+- `CLIError` hierarchy in `core/src/.../core/CLIError.scala`: sealed trait with `CLINotFoundError`, `ProcessError`, `ProcessExecutionError`, `JsonParsingError`, `ProcessTimeoutError`, `ConfigurationError`, `EnvironmentValidationError`
+- Direct `SessionProcess.stream()` (lines 50-75): reads `stdoutReader.readLine()` in a loop; on `null` (EOF) sets `done = true` and silently ends the flow; on `Left(error)` from JSON parsing, logs the error but continues reading
+- Effectful `SessionProcess.startStdoutReader` (lines 88-113): reads stdout as a stream, parses JSON; on `Left(err)` calls `IO.raiseError(err)` which terminates the stdout reader fiber; guarantees `messageQueue.offer(None)` on completion
+- Direct `SessionProcess.send()` (lines 41-48): writes to `stdinWriter` with no process liveness check; will throw `IOException` if the pipe is broken
+- Effectful `SessionImpl.send()` (lines 173-185): offers to `stdinQueue` with no process liveness check; will not fail even if process is dead (queue accepts the message, but stdin writer fiber will fail)
+
+## Approach
+
+### 1. Extend CLIError hierarchy with session-specific errors
+
+Add to `core/src/works/iterative/claude/core/CLIError.scala`:
+
+```scala
+case class SessionProcessDied(
+    exitCode: Option[Int],
+    stderr: String
+) extends CLIError:
+  val message = exitCode match
+    case Some(code) => s"Session process exited unexpectedly with code $code. $stderr"
+    case None       => s"Session process is not alive. $stderr"
+
+case class SessionClosedError(sessionId: String) extends CLIError:
+  val message = s"Cannot send to closed session '$sessionId'"
+```
+
+`SessionProcessDied` covers the case where the CLI process crashes mid-session. `SessionClosedError` covers calling `send` after `close()` (direct) or after the Resource is released (effectful -- though this is typically caught by the Resource lifecycle).
+
+### 2. Direct API error handling
+
+**`SessionProcess` changes:**
+
+a) Add a process liveness flag:
+```scala
+private val alive = new AtomicBoolean(true)
+```
+
+b) In `send()`, check `process.isAlive` before writing. If dead, throw `SessionProcessDied` with the exit code and any captured stderr. Also check the `alive` flag for the post-`close()` case.
+
+c) In `stream()`, when `readLine()` returns `null` (stdout EOF), check if this was expected (session was closed by user) vs. unexpected (process crashed). If the process exited with a non-zero exit code mid-turn (before a `ResultMessage` was seen), emit or throw `SessionProcessDied`. If `close()` was called, treat EOF as normal termination.
+
+d) For malformed JSON: the current behavior in `stream()` (lines 73-74) logs the error and continues the loop. This is already correct for session resilience. Verify with a test that a malformed JSON line mid-turn does not break the session.
+
+e) Make `close()` idempotent by checking and setting the `alive` flag.
+
+**Error propagation detail for `stream()`:**
+
+Currently, when stdout returns `null`, the direct `stream()` just sets `done = true` and the Flow completes. This means if the process crashes mid-turn, the caller gets an incomplete message stream with no error signal. The fix is:
+- Track whether a `ResultMessage` was emitted during the current `stream()` call
+- If `readLine()` returns `null` and no `ResultMessage` was emitted, the turn ended abnormally
+- In that case, throw `SessionProcessDied` so the caller sees a typed error
+
+### 3. Effectful API error handling
+
+**`SessionProcess` / `SessionImpl` changes:**
+
+a) Add a process alive `Ref[IO, Boolean]` initialized to `true`.
+
+b) In `SessionImpl.send()`, check the alive ref before offering to the stdinQueue. If dead, raise `SessionProcessDied`.
+
+c) In `startStdoutReader`, the current behavior on `Left(err)` is `IO.raiseError(err)` which terminates the fiber and guarantees `messageQueue.offer(None)`. This means a JSON parsing error kills the entire stdout reader. **This needs fixing for session resilience:** malformed JSON should be logged and skipped (matching the direct API behavior), not raised as a fatal error. Change:
+   - `case Left(err) => IO.raiseError(err)` to `case Left(err) => logger.error(s"JSON parsing error: ${err.getMessage}").as(None: Option[Message])`
+   - This way, malformed lines are logged and filtered out, and the stdout reader continues
+
+d) When the stdout stream completes (process exits), before offering `None` to the messageQueue, check the process exit code. If non-zero, set alive ref to `false` and offer an error marker. The simplest approach: change the messageQueue type to `Queue[IO, Option[Either[CLIError, Message]]]`, or use a separate error Ref that `stream` checks after receiving `None`.
+
+A simpler approach: keep the current `Queue[IO, Option[Message]]` but add a `Ref[IO, Option[CLIError]]` for the process error. When the stdout reader finishes, it checks the exit code and sets the error ref if non-zero. When `stream` sees `None` from the queue (no `ResultMessage` received for the current turn), it checks the error ref and raises the error if present.
+
+e) After process death is detected, set `alive` ref to `false` so subsequent `send` calls fail immediately.
+
+### 4. Malformed JSON in session context -- verify existing behavior
+
+**Direct API:** The `stream()` method at line 73-74 handles `Left(error)` by logging and continuing the loop. This is already correct. Write a test to confirm.
+
+**Effectful API:** The stdout reader at line 101 handles `Left(err)` with `IO.raiseError(err)`, which terminates the reader fiber. **This is a bug for session mode** -- a single malformed line kills the entire session. Fix this to log and skip (see 3c above). Write a test to confirm the fix.
+
+### 5. Mock script enhancements for error testing
+
+Extend `SessionMockCliScript` with:
+- A script that crashes (exits with non-zero code) after emitting partial output for a turn
+- A script that emits malformed JSON lines interspersed with valid messages
+- A script that crashes between turns (after completing one turn, before reading the next prompt)
+
+## Files to Modify/Create
+
+### Files to modify
+
+- `core/src/works/iterative/claude/core/CLIError.scala` -- add `SessionProcessDied` and `SessionClosedError`
+- `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` -- add liveness checking in `send()`, error detection on EOF in `stream()`, idempotent `close()`
+- `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` -- add liveness checking in `send`, fix malformed JSON handling in stdout reader, process death detection, alive ref
+- `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` -- add crash/malformed-JSON script generators
+
+### New files
+
+- `direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala` -- unit tests for error scenarios (direct)
+- `direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala` -- integration tests with crash/malformed scripts (direct)
+- `effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala` -- unit tests for error scenarios (effectful)
+- `effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala` -- integration tests with crash/malformed scripts (effectful)
+
+### Reference files (no changes expected)
+
+- `core/src/works/iterative/claude/core/parsing/JsonParser.scala` -- core pure parsing (already handles errors correctly)
+- `effectful/src/works/iterative/claude/effectful/internal/parsing/JsonParser.scala` -- effectful parsing wrapper (returns `Either`, does not throw)
+- `direct/src/works/iterative/claude/direct/internal/parsing/JsonParser.scala` -- direct parsing (returns `Either`, does not throw)
+- `direct/src/works/iterative/claude/direct/Session.scala` -- trait definition (no API changes)
+- `effectful/src/works/iterative/claude/effectful/Session.scala` -- trait definition (no API changes)
+
+## Testing Strategy
+
+### Unit tests -- Direct (`SessionErrorTest.scala`)
+
+1. **`send` after `close()` throws `SessionClosedError`** -- close session, call send, expect typed error
+2. **`send` to dead process throws `SessionProcessDied`** -- use a script that exits immediately, attempt send, expect typed error
+3. **`stream` on dead process surfaces `SessionProcessDied`** -- use a script that crashes mid-turn (emits partial output then exits), stream should raise typed error
+4. **Malformed JSON line is skipped in `stream()`** -- use a script that emits invalid JSON between valid messages, verify valid messages are received and the malformed line is logged
+5. **`close()` is idempotent** -- calling close() twice does not throw
+6. **Session remains functional after malformed JSON** -- emit malformed line, then valid assistant + result; verify stream completes normally
+
+### Integration tests -- Direct (`SessionErrorIntegrationTest.scala`)
+
+1. **Process crash mid-turn with mock script** -- script emits assistant message then exits with code 1; verify `stream()` raises `SessionProcessDied` with exit code
+2. **Process crash between turns** -- script completes turn 1, then exits before turn 2; verify second `send` or `stream` raises `SessionProcessDied`
+3. **Malformed JSON recovery with mock script** -- script emits `{bad json}` followed by valid assistant + result; verify all valid messages arrive and session completes normally
+4. **Multiple malformed lines do not accumulate errors** -- script emits several bad lines interspersed with valid messages; verify the session handles all of them
+
+### Unit tests -- Effectful (`SessionErrorTest.scala`)
+
+1. **`send` to dead process raises `SessionProcessDied`** -- script exits immediately, send should fail with typed error
+2. **`stream` on dead process surfaces `SessionProcessDied`** -- script crashes mid-turn, stream should raise typed error
+3. **Malformed JSON line is skipped in stream** -- verify malformed line is logged and skipped, valid messages arrive
+4. **Session remains functional after malformed JSON** -- verify multi-turn works even with bad JSON lines in the output
+
+### Integration tests -- Effectful (`SessionErrorIntegrationTest.scala`)
+
+1. **Process crash mid-turn** -- script exits with code 1 after partial output; verify stream raises `SessionProcessDied`
+2. **Process crash between turns** -- script completes turn 1, crashes before turn 2; verify second send/stream raises `SessionProcessDied`
+3. **Malformed JSON recovery** -- script emits bad JSON + valid messages; verify valid messages arrive
+4. **Resource cleanup after process crash** -- verify Resource finalizer runs without hanging after process dies
+
+### E2E tests
+
+No new E2E tests needed. Process crashes and malformed JSON are not reproducible with the real CLI in a controlled way. The existing E2E tests validate normal session operation.
+
+## Acceptance Criteria
+
+1. New `SessionProcessDied` error type exists in `CLIError` hierarchy, carrying optional exit code and stderr content
+2. New `SessionClosedError` error type exists for post-close `send` attempts (direct API)
+3. **Direct API:** `send()` on a dead/closed session throws a typed `CLIError` (not `IOException` or `NullPointerException`)
+4. **Direct API:** `stream()` raises `SessionProcessDied` when the process exits mid-turn (before `ResultMessage`)
+5. **Direct API:** `stream()` gracefully handles malformed JSON lines (logs and skips them, session continues)
+6. **Direct API:** `close()` is idempotent
+7. **Effectful API:** `send` on a dead session raises `SessionProcessDied` in the IO
+8. **Effectful API:** `stream` raises `SessionProcessDied` when the process exits mid-turn
+9. **Effectful API:** Malformed JSON lines are logged and skipped (fixing the current behavior where they terminate the stdout reader fiber)
+10. **Effectful API:** Resource cleanup completes without hanging after process crash
+11. All new unit and integration tests pass with no compilation warnings
+12. All existing session tests (direct + effectful) continue to pass (no regressions)
+13. All existing query tests (direct + effectful) continue to pass (no regressions)
+
+## Key Implementation Notes
+
+### Effectful malformed JSON bug
+
+The current effectful `SessionProcess.startStdoutReader` (line 101) handles JSON parsing errors with `IO.raiseError(err)`, which terminates the stdout reader fiber. This is correct for query mode (where a malformed line is a fatal error for a single invocation) but wrong for session mode (where the session should survive and continue). This must be fixed to log and skip, matching the direct API behavior.
+
+### Direct API stdout EOF semantics
+
+The current direct `SessionProcess.stream()` treats `readLine() == null` as normal completion (line 57-58). In a healthy session, stdout EOF means the process exited. If this happens mid-turn (no `ResultMessage` seen), it is an error condition that must surface to the caller rather than silently ending the stream.
+
+### Process exit code availability
+
+For the direct API, `process.exitValue()` returns the exit code (blocking if not yet exited) and `process.isAlive` checks liveness. For the effectful API, `process.exitValue: IO[Int]` semantically waits for exit. The liveness check approach differs: direct can poll `process.isAlive`; effectful should use the alive Ref set by the stdout reader fiber completion handler.
+
+### Stdin write failure vs. liveness check
+
+When the process is dead, writing to stdin throws `IOException` (broken pipe). The liveness check in `send` provides a better error message than catching the IOException. However, both paths should result in a `SessionProcessDied` error -- the liveness check is the fast path, and the IOException catch is the fallback.

--- a/project-management/issues/CC-15/phase-06-tasks.md
+++ b/project-management/issues/CC-15/phase-06-tasks.md
@@ -2,74 +2,75 @@
 
 ## Setup
 
-- [ ] [setup] Add `SessionProcessDied(exitCode: Option[Int], stderr: String)` to `core/src/.../core/CLIError.scala`
-- [ ] [setup] Add `SessionClosedError(sessionId: String)` to `core/src/.../core/CLIError.scala`
-- [ ] [setup] Verify the new error types compile and integrate cleanly into the sealed `CLIError` hierarchy
+- [x] [setup] Add `SessionProcessDied(exitCode: Option[Int], stderr: String)` to `core/src/.../core/CLIError.scala`
+- [x] [setup] Add `SessionClosedError(sessionId: String)` to `core/src/.../core/CLIError.scala`
+- [x] [setup] Verify the new error types compile and integrate cleanly into the sealed `CLIError` hierarchy
 
 ## Tests
 
 ### Mock script enhancements
 
-- [ ] [test] Add `crashMidTurn(exitCode: Int)` script builder to `SessionMockCliScript` — emits a partial assistant message then exits with the given code (no ResultMessage)
-- [ ] [test] Add `crashBetweenTurns(exitCode: Int)` script builder — completes one full turn (with ResultMessage), then exits before reading the second prompt
-- [ ] [test] Add `malformedJsonMidTurn()` script builder — emits a valid assistant message, then an invalid JSON line, then a valid ResultMessage
+- [x] [test] Add `crashMidTurn(exitCode: Int)` script builder to `SessionMockCliScript` — emits a partial assistant message then exits with the given code (no ResultMessage)
+- [x] [test] Add `crashBetweenTurns(exitCode: Int)` script builder — completes one full turn (with ResultMessage), then exits before reading the second prompt
+- [x] [test] Add `malformedJsonMidTurn()` script builder — emits a valid assistant message, then an invalid JSON line, then a valid ResultMessage
 
 ### Direct API unit tests (`SessionErrorTest.scala`)
 
-- [ ] [test] `send` after `close()` throws `SessionClosedError`
-- [ ] [test] `close()` is idempotent — calling it twice does not throw
-- [ ] [test] `send` to a dead process throws `SessionProcessDied`
-- [ ] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
-- [ ] [test] Malformed JSON line mid-turn is skipped and stream completes normally with the valid messages
-- [ ] [test] Session remains functional after a malformed JSON line — valid assistant + ResultMessage arrive after the bad line
+- [x] [test] `send` after `close()` throws `SessionClosedError`
+- [x] [test] `close()` is idempotent — calling it twice does not throw
+- [x] [test] `send` to a dead process throws `SessionProcessDied`
+- [x] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
+- [x] [test] Malformed JSON line mid-turn is skipped and stream completes normally with the valid messages
+- [x] [test] Session remains functional after a malformed JSON line — valid assistant + ResultMessage arrive after the bad line
 
 ### Direct API integration tests (`SessionErrorIntegrationTest.scala`)
 
-- [ ] [test] Process crash mid-turn with mock script — script emits partial output then exits with code 1; verify `stream()` raises `SessionProcessDied` carrying the exit code
-- [ ] [test] Process crash between turns with mock script — first turn completes, process exits; verify second `send` or `stream` raises `SessionProcessDied`
-- [ ] [test] Malformed JSON recovery with mock script — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive and stream completes normally
-- [ ] [test] Multiple malformed lines do not accumulate errors — several bad lines interspersed with valid messages; verify all valid messages arrive
+- [x] [test] Process crash mid-turn with mock script — script emits partial output then exits with code 1; verify `stream()` raises `SessionProcessDied` carrying the exit code
+- [x] [test] Process crash between turns with mock script — first turn completes, process exits; verify second `send` or `stream` raises `SessionProcessDied`
+- [x] [test] Malformed JSON recovery with mock script — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive and stream completes normally
+- [x] [test] Multiple malformed lines do not accumulate errors — several bad lines interspersed with valid messages; verify all valid messages arrive
 
 ### Effectful API unit tests (`SessionErrorTest.scala`)
 
-- [ ] [test] `send` to a dead process raises `SessionProcessDied` in IO
-- [ ] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
-- [ ] [test] Malformed JSON line is logged and skipped; valid messages in the same turn arrive normally
-- [ ] [test] Session remains functional after a malformed JSON line — next message in the stream arrives correctly
+- [x] [test] `send` to a dead process raises `SessionProcessDied` in IO
+- [x] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
+- [x] [test] Malformed JSON line is logged and skipped; valid messages in the same turn arrive normally
+- [x] [test] Session remains functional after a malformed JSON line — next message in the stream arrives correctly
 
 ### Effectful API integration tests (`SessionErrorIntegrationTest.scala`)
 
-- [ ] [test] Process crash mid-turn — script exits with code 1 after partial output; verify stream raises `SessionProcessDied`
-- [ ] [test] Process crash between turns — script completes turn 1 then exits; verify second send/stream raises `SessionProcessDied`
-- [ ] [test] Malformed JSON recovery — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive
-- [ ] [test] Resource cleanup after process crash — verify Resource finalizer completes without hanging when process dies
+- [x] [test] Process crash mid-turn — script exits with code 1 after partial output; verify stream raises `SessionProcessDied`
+- [x] [test] Process crash between turns — script completes turn 1 then exits; verify second send/stream raises `SessionProcessDied`
+- [x] [test] Malformed JSON recovery — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive
+- [x] [test] Resource cleanup after process crash — verify Resource finalizer completes without hanging when process dies
 
 ## Implementation
 
 ### Core
 
-- [ ] [impl] `CLIError.scala`: implement `SessionProcessDied.message` (with/without exit code) and `SessionClosedError.message`
+- [x] [impl] `CLIError.scala`: implement `SessionProcessDied.message` (with/without exit code) and `SessionClosedError.message`
 
 ### Direct API (`direct/src/.../internal/cli/SessionProcess.scala`)
 
-- [ ] [impl] Add `AtomicBoolean alive` flag to `SessionProcess`; set to `false` in `close()`
-- [ ] [impl] Make `close()` idempotent by guarding on the `alive` flag before closing streams/process
-- [ ] [impl] In `send()`, check `alive` flag (closed) and `process.isAlive` (crashed); throw `SessionClosedError` or `SessionProcessDied` accordingly; keep `IOException` catch as fallback that also produces `SessionProcessDied`
-- [ ] [impl] In `stream()`, track whether a `ResultMessage` was emitted during the current call; on `readLine() == null` (stdout EOF), if no `ResultMessage` was seen, throw `SessionProcessDied` with process exit code and captured stderr; if `ResultMessage` was seen, end normally
+- [x] [impl] Add `AtomicBoolean alive` flag to `SessionProcess`; set to `false` in `close()`
+- [x] [impl] Make `close()` idempotent by guarding on the `alive` flag before closing streams/process
+- [x] [impl] In `send()`, check `alive` flag (closed) and `process.isAlive` (crashed); throw `SessionClosedError` or `SessionProcessDied` accordingly; keep `IOException` catch as fallback that also produces `SessionProcessDied`
+- [x] [impl] In `stream()`, track whether a `ResultMessage` was emitted during the current call; on `readLine() == null` (stdout EOF), if no `ResultMessage` was seen, throw `SessionProcessDied` with process exit code and captured stderr; if `ResultMessage` was seen, end normally
 
 ### Effectful API (`effectful/src/.../internal/cli/SessionProcess.scala`)
 
-- [ ] [impl] Add `Ref[IO, Boolean] alive` initialized to `true`
-- [ ] [impl] In `startStdoutReader`, change `case Left(err) => IO.raiseError(err)` to log the error and return `None` (filter it out) so malformed JSON lines are skipped rather than terminating the reader fiber
-- [ ] [impl] Add a `Ref[IO, Option[CLIError]] pendingError` to carry process-death errors out of the stdout reader fiber
-- [ ] [impl] In `startStdoutReader` completion handler: check process exit code; on non-zero, set `alive` to `false` and set `pendingError` to `SessionProcessDied`; always offer `None` to `messageQueue` as the termination sentinel
-- [ ] [impl] In `SessionImpl.send()`, check the `alive` ref before offering to `stdinQueue`; if dead, raise `SessionProcessDied`
-- [ ] [impl] In `SessionImpl.stream`, after receiving `None` from the queue without a `ResultMessage`, check `pendingError` ref and raise the error if present
+- [x] [impl] Add `Ref[IO, Boolean] alive` initialized to `true`
+- [x] [impl] In `startStdoutReader`, change `case Left(err) => IO.raiseError(err)` to log the error and return `None` (filter it out) so malformed JSON lines are skipped rather than terminating the reader fiber
+- [x] [impl] Add a `Ref[IO, Option[CLIError]] pendingError` to carry process-death errors out of the stdout reader fiber
+- [x] [impl] In `startStdoutReader` completion handler: check process exit code; on non-zero, set `alive` to `false` and set `pendingError` to `SessionProcessDied`; always offer `None` to `messageQueue` as the termination sentinel
+- [x] [impl] In `SessionImpl.send()`, check the `alive` ref before offering to `stdinQueue`; if dead, raise `SessionProcessDied`
+- [x] [impl] In `SessionImpl.stream`, after receiving `None` from the queue without a `ResultMessage`, check `pendingError` ref and raise the error if present
 
 ## Integration
 
-- [ ] [integration] Verify all new direct error tests pass (`./mill direct.test`)
-- [ ] [integration] Verify all new effectful error tests pass (`./mill effectful.test`)
-- [ ] [integration] Verify no regressions in existing direct session and query tests
-- [ ] [integration] Verify no regressions in existing effectful session and query tests
-- [ ] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
+- [x] [integration] Verify all new direct error tests pass (`./mill direct.test`)
+- [x] [integration] Verify all new effectful error tests pass (`./mill effectful.test`)
+- [x] [integration] Verify no regressions in existing direct session and query tests
+- [x] [integration] Verify no regressions in existing effectful session and query tests
+- [x] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)
+**Phase Status:** Complete

--- a/project-management/issues/CC-15/phase-06-tasks.md
+++ b/project-management/issues/CC-15/phase-06-tasks.md
@@ -1,0 +1,75 @@
+# Phase 06 Tasks: Error handling - process crash and malformed JSON
+
+## Setup
+
+- [ ] [setup] Add `SessionProcessDied(exitCode: Option[Int], stderr: String)` to `core/src/.../core/CLIError.scala`
+- [ ] [setup] Add `SessionClosedError(sessionId: String)` to `core/src/.../core/CLIError.scala`
+- [ ] [setup] Verify the new error types compile and integrate cleanly into the sealed `CLIError` hierarchy
+
+## Tests
+
+### Mock script enhancements
+
+- [ ] [test] Add `crashMidTurn(exitCode: Int)` script builder to `SessionMockCliScript` — emits a partial assistant message then exits with the given code (no ResultMessage)
+- [ ] [test] Add `crashBetweenTurns(exitCode: Int)` script builder — completes one full turn (with ResultMessage), then exits before reading the second prompt
+- [ ] [test] Add `malformedJsonMidTurn()` script builder — emits a valid assistant message, then an invalid JSON line, then a valid ResultMessage
+
+### Direct API unit tests (`SessionErrorTest.scala`)
+
+- [ ] [test] `send` after `close()` throws `SessionClosedError`
+- [ ] [test] `close()` is idempotent — calling it twice does not throw
+- [ ] [test] `send` to a dead process throws `SessionProcessDied`
+- [ ] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
+- [ ] [test] Malformed JSON line mid-turn is skipped and stream completes normally with the valid messages
+- [ ] [test] Session remains functional after a malformed JSON line — valid assistant + ResultMessage arrive after the bad line
+
+### Direct API integration tests (`SessionErrorIntegrationTest.scala`)
+
+- [ ] [test] Process crash mid-turn with mock script — script emits partial output then exits with code 1; verify `stream()` raises `SessionProcessDied` carrying the exit code
+- [ ] [test] Process crash between turns with mock script — first turn completes, process exits; verify second `send` or `stream` raises `SessionProcessDied`
+- [ ] [test] Malformed JSON recovery with mock script — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive and stream completes normally
+- [ ] [test] Multiple malformed lines do not accumulate errors — several bad lines interspersed with valid messages; verify all valid messages arrive
+
+### Effectful API unit tests (`SessionErrorTest.scala`)
+
+- [ ] [test] `send` to a dead process raises `SessionProcessDied` in IO
+- [ ] [test] `stream` raises `SessionProcessDied` when process exits mid-turn (before ResultMessage)
+- [ ] [test] Malformed JSON line is logged and skipped; valid messages in the same turn arrive normally
+- [ ] [test] Session remains functional after a malformed JSON line — next message in the stream arrives correctly
+
+### Effectful API integration tests (`SessionErrorIntegrationTest.scala`)
+
+- [ ] [test] Process crash mid-turn — script exits with code 1 after partial output; verify stream raises `SessionProcessDied`
+- [ ] [test] Process crash between turns — script completes turn 1 then exits; verify second send/stream raises `SessionProcessDied`
+- [ ] [test] Malformed JSON recovery — bad JSON line followed by valid assistant + ResultMessage; verify valid messages arrive
+- [ ] [test] Resource cleanup after process crash — verify Resource finalizer completes without hanging when process dies
+
+## Implementation
+
+### Core
+
+- [ ] [impl] `CLIError.scala`: implement `SessionProcessDied.message` (with/without exit code) and `SessionClosedError.message`
+
+### Direct API (`direct/src/.../internal/cli/SessionProcess.scala`)
+
+- [ ] [impl] Add `AtomicBoolean alive` flag to `SessionProcess`; set to `false` in `close()`
+- [ ] [impl] Make `close()` idempotent by guarding on the `alive` flag before closing streams/process
+- [ ] [impl] In `send()`, check `alive` flag (closed) and `process.isAlive` (crashed); throw `SessionClosedError` or `SessionProcessDied` accordingly; keep `IOException` catch as fallback that also produces `SessionProcessDied`
+- [ ] [impl] In `stream()`, track whether a `ResultMessage` was emitted during the current call; on `readLine() == null` (stdout EOF), if no `ResultMessage` was seen, throw `SessionProcessDied` with process exit code and captured stderr; if `ResultMessage` was seen, end normally
+
+### Effectful API (`effectful/src/.../internal/cli/SessionProcess.scala`)
+
+- [ ] [impl] Add `Ref[IO, Boolean] alive` initialized to `true`
+- [ ] [impl] In `startStdoutReader`, change `case Left(err) => IO.raiseError(err)` to log the error and return `None` (filter it out) so malformed JSON lines are skipped rather than terminating the reader fiber
+- [ ] [impl] Add a `Ref[IO, Option[CLIError]] pendingError` to carry process-death errors out of the stdout reader fiber
+- [ ] [impl] In `startStdoutReader` completion handler: check process exit code; on non-zero, set `alive` to `false` and set `pendingError` to `SessionProcessDied`; always offer `None` to `messageQueue` as the termination sentinel
+- [ ] [impl] In `SessionImpl.send()`, check the `alive` ref before offering to `stdinQueue`; if dead, raise `SessionProcessDied`
+- [ ] [impl] In `SessionImpl.stream`, after receiving `None` from the queue without a `ResultMessage`, check `pendingError` ref and raise the error if present
+
+## Integration
+
+- [ ] [integration] Verify all new direct error tests pass (`./mill direct.test`)
+- [ ] [integration] Verify all new effectful error tests pass (`./mill effectful.test`)
+- [ ] [integration] Verify no regressions in existing direct session and query tests
+- [ ] [integration] Verify no regressions in existing effectful session and query tests
+- [ ] [integration] Verify no compilation warnings across all modules (`./mill __.compile`)

--- a/project-management/issues/CC-15/refactor-phase-05-R1.md
+++ b/project-management/issues/CC-15/refactor-phase-05-R1.md
@@ -1,0 +1,67 @@
+# Refactoring R1: Split Session.send into send + stream (CQS)
+
+**Phase:** 5
+**Created:** 2026-04-05
+**Status:** Complete
+
+## Decision Summary
+
+Our `Session.send(prompt)` combines a command (write prompt to stdin) and a query (return response stream) in one method, violating command-query separation. The V2 Claude Agent SDK separates these as `send()` (void) and `stream()` (async generator). Splitting them makes the API cleaner, aligns with the official SDK direction, and makes the turn lifecycle explicit.
+
+## Current State
+
+Direct `Session` trait (`direct/src/works/iterative/claude/direct/Session.scala`):
+
+```scala
+trait Session:
+  def send(prompt: String): Flow[Message]  // combined command+query
+  def close(): Unit
+  def sessionId: String
+```
+
+`SessionProcess.send()` eagerly writes to stdin, then returns a `Flow` that reads stdout until `ResultMessage`.
+
+All tests use `session.send("...").forEach(...)` or `session.send("...").toList()`.
+
+## Target State
+
+Direct `Session` trait:
+
+```scala
+trait Session:
+  def send(prompt: String): Unit      // command: write SDKUserMessage to stdin
+  def stream(): Flow[Message]         // query: read stdout until ResultMessage
+  def close(): Unit
+  def sessionId: String
+```
+
+Test usage becomes `session.send("..."); session.stream().forEach(...)`.
+
+## Constraints
+
+- PRESERVE: All existing test assertions and coverage — only call sites change, not what's being tested
+- PRESERVE: `SessionProcess` internal mechanics (stdin writing, stdout reading, session ID update, stderr capture)
+- PRESERVE: `ClaudeCode.session()` factory methods — no signature changes
+- DO NOT TOUCH: Core model types (Message, SDKUserMessage, SessionOptions)
+- DO NOT TOUCH: CLIArgumentBuilder
+- DO NOT TOUCH: Effectful module (it will be built with the new pattern from scratch)
+- DO NOT TOUCH: `SessionMockCliScript` or `MockLogger`
+
+## Tasks
+
+- [x] [impl] [Analysis] Review all usages of `Session.send` in tests to confirm scope
+- [x] [impl] [Refactor] Split `Session` trait: `send(prompt: String): Unit` + `stream(): Flow[Message]`
+- [x] [impl] [Refactor] Split `SessionProcess.send` into `send` (stdin write) and `stream` (stdout read + emit)
+- [x] [impl] [Test] Update `SessionTest.scala` call sites: `send` then `stream`
+- [x] [impl] [Test] Update `SessionIntegrationTest.scala` call sites
+- [x] [impl] [Test] Update `SessionE2ETest.scala` call sites
+- [x] [impl] [Verify] Run all tests (`./mill __.test`), ensure nothing broke
+- [x] [impl] [Cleanup] Remove any dead code from the split
+
+## Verification
+
+- [x] All existing tests pass
+- [x] `Session` trait has separate `send` and `stream` methods
+- [x] `send` returns `Unit`, `stream` returns `Flow[Message]`
+- [x] No regressions in functionality
+- [ ] Direct API ClaudeCode.session factory still works

--- a/project-management/issues/CC-15/release-notes.md
+++ b/project-management/issues/CC-15/release-notes.md
@@ -1,0 +1,38 @@
+# CC-15: Persistentni konverzacni session pro Claude Code CLI
+
+**Datum:** 2026-04-05
+
+SDK nyni podporuje viceturnove konverzacni session s procesem Claude Code CLI. Namisto jednorázovych dotazu, kde se pro kazdy pozadavek spoustel novy proces, je nyni mozne otevrit dlouhodobou session a vest s CLI souvisly dialog — vcetne navazovani na predchozi kontext konverzace.
+
+## Nova funkcionalita
+
+Session komunikuji s CLI prostrednictvim protokolu `--input-format stream-json`. SDK spravuje zivotni cyklus procesu, odesila uživatelske zpravy ve formatu `SDKUserMessage` na stdin a cte proud odpovedi z stdout. Kazdy turn konverzace je ukoncen prijmem `ResultMessage`, coz umoznuje strídání dotazu a odpovedi v ramci jedne session.
+
+Konfigurace session se provadi prostrednictvim `SessionOptions` — datove tridy s 18 parametry pokryvajicimi pracovni adresar, model, system prompt, povolene nastroje, MCP servery a dalsi. Vsechny parametry jsou volitelne s rozumnými výchozimi hodnotami.
+
+Obe stavajici API varianty nyni nabizeji session:
+
+- **Direct API (Ox):** `ClaudeCode.session(options)(Ox)` vraci `Session` s metodami `send(prompt)` a `stream()`. Session se zavre automaticky pri ukonceni Ox scope.
+- **Effectful API (cats-effect/fs2):** `ClaudeCode.session(options)` vraci `Resource[IO, Session]`. Zpravy se ctou jako `Stream[IO, Message]` a session se uklizi pri uvolneni resource.
+
+V obou pripadech metoda `send` odesle textovy prompt jako JSON zpravu a `stream` vraci proud typovanych zprav az do vysledku aktuálniho turnu.
+
+## Osetreni chyb
+
+Session spravne reaguje na nestandardni situace:
+
+- **Pad procesu** — pokud CLI proces neocekavane skonci, SDK emituje `SessionProcessDied` s navratovym kodem a stderr obsahem.
+- **Uzavrena session** — pokus o odeslani zpravy do jiz ukoncene session vyvolá `SessionClosedError`.
+- **Poskozeny JSON** — vadne radky na stdout jsou preskoceny s varovanim misto ukonceni cele session.
+
+## Nove typy
+
+- `Session` — rozhrani pro komunikaci s CLI procesem (v modulech `direct` i `effectful`)
+- `SessionOptions` — konfigurace session (modul `core`)
+- `SDKUserMessage` — format zpravy odeslane na stdin procesu (modul `core`)
+- `CLIError.SessionProcessDied` — chyba pri neocekavanem ukonceni procesu
+- `CLIError.SessionClosedError` — chyba pri pokusu o komunikaci s uzavrenou session
+
+## Zpetna kompatibilita
+
+Zadne stavajici API se nemeni. Jednorázove metody `query` a `stream` na `ClaudeCode` funguji beze zmen. Session jsou ciste aditivni rozsireni.

--- a/project-management/issues/CC-15/review-packet-phase-01.md
+++ b/project-management/issues/CC-15/review-packet-phase-01.md
@@ -1,0 +1,129 @@
+---
+generated_from: 73dd140feaa23c6ac94eaec24eec4540d90f1013
+generated_at: 2026-04-04T18:20:03Z
+branch: CC-15-phase-01
+issue_id: CC-15
+phase: 1
+files_analyzed:
+  - works/iterative/claude/core/model/SDKUserMessage.scala
+  - works/iterative/claude/core/model/Message.scala
+  - works/iterative/claude/core/parsing/JsonParser.scala
+  - works/iterative/claude/direct/internal/parsing/JsonParser.scala
+  - test/works/iterative/claude/core/model/SDKUserMessageTest.scala
+  - test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala
+  - test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala
+  - test/works/iterative/claude/core/parsing/JsonParserTest.scala
+  - test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala
+---
+
+# Review Packet: Phase 1 - Stdin Message Format and Response Delimiting
+
+## Goals
+
+This phase establishes the stream-json protocol foundation needed for all subsequent session phases. It defines how the SDK writes messages to the Claude Code CLI's stdin, and ensures the parser handles all message types the CLI emits in session mode.
+
+Key objectives:
+
+- Define `SDKUserMessage` — the Scala representation of the JSON object written to CLI stdin when using `--input-format stream-json`
+- Provide a circe `Encoder[SDKUserMessage]` that produces the exact protocol shape the CLI expects
+- Confirm `ResultMessage` (type `"result"`) correctly signals end-of-turn in stream-json protocol
+- Add `KeepAliveMessage` and `StreamEventMessage` to the `Message` sealed hierarchy so downstream phases can pattern-match on them rather than silently losing them
+
+## Scenarios
+
+- [ ] `SDKUserMessage` case class exists with `content`, `sessionId`, and `parentToolUseId` fields
+- [ ] Encoder produces `{"type":"user","message":{"role":"user","content":"..."},"parent_tool_use_id":null,"session_id":"..."}` for a normal user message
+- [ ] Encoder renders `parent_tool_use_id` as a string when `parentToolUseId` is `Some`, and as JSON `null` when `None`
+- [ ] `"pending"` is a valid `sessionId` value (used for the first message before the session ID is known)
+- [ ] Encoded JSON is a single line with no embedded newlines (required for newline-delimited protocol)
+- [ ] `ResultMessage` correctly parses a realistic stream-json end-of-turn result, including `session_id`, `num_turns`, `total_cost_usd`, and `result` fields
+- [ ] `KeepAliveMessage` is parsed from `{"type":"keep_alive"}` messages
+- [ ] `StreamEventMessage` is parsed from `{"type":"stream_event",...}` messages, carrying all non-type fields as data
+- [ ] Round-trip integration: encode `SDKUserMessage`, pipe through mock CLI bash script, parse the stdout response correctly
+- [ ] Mock session protocol: mock CLI emits init system message, SDK reads it, writes `SDKUserMessage`, parses assistant + result response
+
+## Entry Points
+
+| File | Method/Class | Why Start Here |
+|------|--------------|----------------|
+| `works/iterative/claude/core/model/SDKUserMessage.scala` | `SDKUserMessage` / `Encoder[SDKUserMessage]` | New type: the central deliverable of this phase |
+| `works/iterative/claude/core/model/Message.scala` | `KeepAliveMessage`, `StreamEventMessage` | New Message subtypes added to the sealed hierarchy |
+| `works/iterative/claude/core/parsing/JsonParser.scala` | `parseMessage` | Parser dispatch extended with two new branches |
+| `works/iterative/claude/direct/internal/parsing/JsonParser.scala` | `extractMessageType` | Pattern match updated to cover new message types |
+
+## Diagrams
+
+### Message Hierarchy (after this phase)
+
+```
+Message (sealed)
+├── UserMessage
+├── AssistantMessage
+├── SystemMessage
+├── ResultMessage          ← end-of-turn delimiter in stream-json protocol
+├── KeepAliveMessage       ← NEW: heartbeat from CLI in session mode
+└── StreamEventMessage     ← NEW: streaming content delta events
+```
+
+### stream-json Protocol Flow (established by this phase)
+
+```
+SDK stdin                        Claude Code CLI stdout
+─────────────────────────────    ──────────────────────────────────────
+                                 SystemMessage(subtype="init", session_id=...)
+SDKUserMessage (JSON line) ───►
+                                 AssistantMessage(...)        ─┐
+                                 StreamEventMessage(...)       │ one turn
+                                 KeepAliveMessage              │
+                                 ResultMessage(type="result") ─┘ ← end-of-turn
+SDKUserMessage (next turn) ───►
+                                 ...
+```
+
+### Encoder Output Shape
+
+```
+SDKUserMessage(content, sessionId, parentToolUseId)
+        │
+        ▼  Encoder[SDKUserMessage]
+{
+  "type": "user",
+  "message": { "role": "user", "content": "<content>" },
+  "parent_tool_use_id": null | "<id>",
+  "session_id": "<sessionId>"
+}
+        │
+        ▼  + "\n"  (appended by stdin writing layer in Phase 03)
+newline-delimited JSON on stdin
+```
+
+## Test Summary
+
+| Test File | Type | Tests |
+|-----------|------|-------|
+| `test/.../core/model/SDKUserMessageTest.scala` | Unit | Encoder produces correct JSON structure; `Some(parentToolUseId)` renders as string; `None` renders as null; `"pending"` is valid session ID; no embedded newlines |
+| `test/.../core/model/SDKUserMessageRoundTripTest.scala` | Integration | Round-trip encode through mock CLI bash script and parse response; full mock session protocol (init + stdin write + assistant + result) |
+| `test/.../core/model/SDKUserMessageE2ETest.scala` | E2E | Real CLI accepts SDKUserMessage JSON via stream-json stdin (marked `.ignore` — requires live CLI and credentials) |
+| `test/.../core/parsing/JsonParserTest.scala` | Unit | `keep_alive` parses to `KeepAliveMessage`; `stream_event` parses to `StreamEventMessage` with data; realistic stream-json `ResultMessage` parses all fields correctly |
+| `test/.../direct/internal/parsing/JsonParserTest.scala` | Unit | Property-based: `extractMessageType` covers `KeepAliveMessage` and `StreamEventMessage` (existing round-trip generator extended) |
+
+**Coverage notes:**
+- Unit tests verify the exact JSON shape field-by-field, not just structural equality
+- Integration tests use real `ProcessBuilder` with bash scripts to validate stdin piping works at the OS level
+- E2E test is intentionally `.ignore` to avoid CI failures; can be run manually
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `works/iterative/claude/core/model/SDKUserMessage.scala` | New — `SDKUserMessage` case class and `Encoder[SDKUserMessage]` |
+| `works/iterative/claude/core/model/Message.scala` | Modified — added `KeepAliveMessage` (case object) and `StreamEventMessage(data)` |
+| `works/iterative/claude/core/parsing/JsonParser.scala` | Modified — added `keep_alive` and `stream_event` branches in `parseMessage`; new private `parseStreamEventMessage` |
+| `works/iterative/claude/direct/internal/parsing/JsonParser.scala` | Modified — imports and `extractMessageType` pattern match extended for new types |
+| `test/works/iterative/claude/core/model/SDKUserMessageTest.scala` | New — unit tests for `Encoder[SDKUserMessage]` |
+| `test/works/iterative/claude/core/model/SDKUserMessageRoundTripTest.scala` | New — integration tests with mock CLI bash scripts |
+| `test/works/iterative/claude/core/model/SDKUserMessageE2ETest.scala` | New — E2E test against real CLI (`.ignore` by default) |
+| `test/works/iterative/claude/core/parsing/JsonParserTest.scala` | Modified — tests for `keep_alive`, `stream_event`, and end-of-turn `ResultMessage` parsing |
+| `test/works/iterative/claude/direct/internal/parsing/JsonParserTest.scala` | Modified — property-based round-trip extended for new message types |
+| `project-management/issues/CC-15/phase-01-tasks.md` | Workflow — task tracking for this phase |
+| `project-management/issues/CC-15/review-state.json` | Workflow — review state metadata |

--- a/project-management/issues/CC-15/review-packet-phase-02.md
+++ b/project-management/issues/CC-15/review-packet-phase-02.md
@@ -1,0 +1,136 @@
+---
+generated_from: 7db6751172e0715c77b0ef37e232ad849c8b2af7
+generated_at: 2026-04-04T20:39:58Z
+branch: CC-15-phase-02
+issue_id: CC-15
+phase: 2
+files_analyzed:
+  - core/src/works/iterative/claude/core/model/SessionOptions.scala
+  - core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+  - core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala
+  - core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+---
+
+# Review Packet: Phase 2 - SessionOptions Configuration
+
+## Goals
+
+This phase establishes the configuration foundation for persistent Claude Code streaming sessions. It provides the data types and CLI argument mapping needed before any process management or session lifecycle code can be written (Phase 3 and beyond).
+
+Key objectives:
+
+- Define `SessionOptions`, a case class mirroring `QueryOptions` but without a `prompt` field, since prompts arrive per-turn in session mode rather than as a startup argument
+- Provide fluent `with*` builder methods on `SessionOptions` so callers have a familiar, ergonomic API identical in style to `QueryOptions`
+- Add `CLIArgumentBuilder.buildSessionArgs(options: SessionOptions): List[String]` that always prepends the three required streaming flags (`--print`, `--input-format stream-json`, `--output-format stream-json`) and maps all option fields to their CLI equivalents without appending a trailing prompt
+
+## Scenarios
+
+- [ ] `SessionOptions()` constructs with all fields set to `None`
+- [ ] `SessionOptions.defaults` equals `SessionOptions()` with all None fields
+- [ ] Every `with*` builder method sets only its targeted field and leaves all others unchanged
+- [ ] `SessionOptions` has no `prompt` field (enforced at compile time)
+- [ ] `buildSessionArgs` always produces `--print`, `--input-format stream-json`, `--output-format stream-json` as the first five tokens
+- [ ] `buildSessionArgs` with default options produces exactly those five tokens and nothing else
+- [ ] `maxTurns`, `model`, `allowedTools`, `disallowedTools`, `systemPrompt`, `appendSystemPrompt`, `resume`, `maxThinkingTokens` each map to the correct CLI flag
+- [ ] `continueConversation = Some(true)` maps to `--continue`; `Some(false)` produces no flag
+- [ ] `permissionMode` maps to `--permission-mode` for all three enum values (`default`, `acceptEdits`, `bypassPermissions`)
+- [ ] Multiple options combine correctly without interfering with the required flags
+- [ ] All existing `CLIArgumentBuilderTest` tests continue to pass (no regression in `buildArgs`)
+
+## Entry Points
+
+| File | Method/Class | Why Start Here |
+|------|--------------|----------------|
+| `core/src/works/iterative/claude/core/model/SessionOptions.scala` | `SessionOptions` | The new domain type — review field list and builder methods here |
+| `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` | `buildSessionArgs()` | New method added to existing builder — review the streaming flags prepend and option mapping |
+| `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` | `SessionOptionsArgsTest` | 16 tests covering every CLI flag mapping — the most complete verification of the contract |
+| `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` | `SessionOptionsTest` | 3 tests covering construction, defaults, and all 18 builder methods |
+
+## Diagrams
+
+### Data flow: SessionOptions to CLI args
+
+```
+Caller
+  │
+  ▼
+SessionOptions (case class, all fields Option[_])
+  │  withModel(), withSystemPrompt(), withPermissionMode(), ...
+  │
+  ▼
+CLIArgumentBuilder.buildSessionArgs(options)
+  │
+  ├─ Always prepend: ["--print", "--input-format", "stream-json",
+  │                   "--output-format", "stream-json"]
+  │
+  └─ Append per-field args (same mapping as buildArgs):
+       --max-turns, --model, --allowedTools, --disallowedTools,
+       --system-prompt, --append-system-prompt, --continue, --resume,
+       --permission-mode, --max-thinking-tokens
+       (no trailing prompt argument)
+  │
+  ▼
+List[String]  ──►  passed to process builder in Phase 3
+```
+
+### Relationship to existing types
+
+```
+QueryOptions (existing)            SessionOptions (new, Phase 2)
+  prompt: String          ──X──    (omitted — sent per-turn)
+  cwd, model, ...         ──=──    cwd, model, ...  (identical fields)
+       │                                │
+       ▼                                ▼
+CLIArgumentBuilder                CLIArgumentBuilder
+  .buildArgs()                      .buildSessionArgs()
+  (no prefix flags)                 (prepends --print + stream-json flags)
+  (appends prompt arg)              (no trailing prompt)
+```
+
+### Phase dependency map
+
+```
+Phase 01: Stdin message format   Phase 02: SessionOptions (this phase)
+         │                                        │
+         └──────────────┬─────────────────────────┘
+                        ▼
+              Phase 03: Process management / session lifecycle
+                        │
+              Phase 04: Multi-turn sequencing
+                        │
+              Phase 05: Effectful API
+```
+
+## Test Summary
+
+| Test File | Type | Count | Tests |
+|-----------|------|-------|-------|
+| `SessionOptionsTest` | Unit | 3 | Default construction (all None), `defaults` factory equals `SessionOptions()`, all 18 `with*` builders set only their field |
+| `SessionOptionsArgsTest` | Unit | 16 | Required flags present and first, no trailing prompt, `maxTurns`, `model`, `allowedTools`, `disallowedTools`, `systemPrompt`, `appendSystemPrompt`, `continueConversation` (true/false), `resume`, all three `permissionMode` values, `maxThinkingTokens`, None-only options, multi-option combination |
+| Integration | — | 0 | None required; pure data transformation with no I/O. Phase 3 will add integration tests that exercise the full process launch path using `SessionOptions`. |
+| E2E | — | 0 | None required for this phase. Phase 3 carries E2E coverage. |
+
+**Note on test count vs. spec:** The phase context specifies up to 18 builder tests, but the implementation consolidates all builder assertions into a single test (`each with* builder sets only its field`). This covers all 18 builders without the overhead of 18 separate test cases; the trade-off is that a failure message is slightly less precise about which builder failed.
+
+## Files Changed
+
+| File | Change | Summary |
+|------|--------|---------|
+| `core/src/works/iterative/claude/core/model/SessionOptions.scala` | New | 18-field case class with fluent builders and `defaults` companion factory |
+| `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` | Modified | Added `buildSessionArgs(options: SessionOptions)` method; updated import to include `SessionOptions` |
+| `core/test/src/works/iterative/claude/core/model/SessionOptionsTest.scala` | New | 3 unit tests for construction, defaults, and all builder methods |
+| `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` | New | 16 unit tests for `buildSessionArgs` flag mapping |
+
+<details>
+<summary>Notable implementation detail: duplication in CLIArgumentBuilder</summary>
+
+`buildSessionArgs` duplicates the per-option argument-building logic from `buildArgs` rather than extracting a shared helper. The phase context explicitly approves this approach: `QueryOptions` and `SessionOptions` are unrelated case classes, extracting a structural-type helper would add complexity, and a third call site does not yet exist. The duplication is mechanical and the field names are identical, making the two methods easy to compare side by side.
+
+</details>
+
+<details>
+<summary>Fields not translated to CLI flags</summary>
+
+The following fields are included in `SessionOptions` for use by the Phase 3 session runner but are intentionally not emitted as CLI arguments: `timeout`, `inheritEnvironment`, `environmentVariables`, `executable`, `executableArgs`, `pathToClaudeCodeExecutable`. `mcpTools` is carried but also not emitted — no corresponding CLI flag was confirmed during analysis.
+
+</details>

--- a/project-management/issues/CC-15/review-packet-phase-03.md
+++ b/project-management/issues/CC-15/review-packet-phase-03.md
@@ -1,0 +1,204 @@
+---
+generated_from: 2ab28937c7df08e34b412c5f58fe2203261d23c9
+generated_at: 2026-04-05T08:13:25Z
+branch: CC-15-phase-03
+issue_id: CC-15
+phase: 3
+files_analyzed:
+  - direct/src/works/iterative/claude/direct/Session.scala
+  - direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+  - direct/src/works/iterative/claude/direct/ClaudeCode.scala
+  - direct/src/works/iterative/claude/direct/package.scala
+  - direct/test/src/works/iterative/claude/direct/SessionTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+  - direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+---
+
+# Review Packet: Phase 3 - Direct API Basic Session Lifecycle
+
+## Goals
+
+This phase delivers the core session API for the direct module, enabling callers to open a persistent Claude Code CLI process, exchange one or more messages over its stdin/stdout, and close it cleanly when done. Prior to this phase every interaction spawned a fresh process; now the process lives for the duration of the session, eliminating per-turn startup cost.
+
+Key objectives:
+
+- Define the `Session` trait (`send`, `close`, `sessionId`) as the public contract for an active conversational session
+- Implement `SessionProcess` — the internal class that manages the long-lived CLI process, writes `SDKUserMessage` JSON to stdin, reads response lines from stdout, and terminates the process on `close`
+- Add `ClaudeCode.session(SessionOptions)` factory methods on both the class and companion object
+- Extract the `session_id` from the CLI's initial `SystemMessage(subtype="init")` and keep it current via `ResultMessage` updates
+- Re-export `Session` and `SessionOptions` in the `direct` package object so callers need only one import
+- Provide a `SessionMockCliScript` utility that generates executable shell scripts simulating the stream-json protocol for integration tests
+
+## Scenarios
+
+- [ ] A session can be opened, a single message sent, a streaming `Flow[Message]` received, and the session closed
+- [ ] The underlying CLI process starts once at session creation and remains alive after `send` completes
+- [ ] `send` writes a correctly-formatted `SDKUserMessage` JSON line to process stdin
+- [ ] `send` returns a `Flow[Message]` that emits all messages from stdout and completes after the `ResultMessage`
+- [ ] `KeepAliveMessage` and `StreamEventMessage` are passed through to the caller's Flow unchanged
+- [ ] Session ID is extracted from the CLI's initial `SystemMessage(subtype="init")`
+- [ ] Session ID defaults to `"pending"` when no init message arrives before the first `send`
+- [ ] Session ID is updated to the value carried in the `ResultMessage` after each `send` completes
+- [ ] `close()` terminates the CLI process (stdin closed, forcibly destroyed if needed)
+- [ ] `Session` and `SessionOptions` are accessible via a single `import works.iterative.claude.direct.*`
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `direct/src/works/iterative/claude/direct/Session.scala` | `Session` trait | Public API contract — defines `send`, `close`, and `sessionId` |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | `SessionProcess.start` | Factory that creates the process, captures stderr, reads init message, returns a ready `Session` |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | `SessionProcess.send` | Core send logic: stdin write, stdout read loop, Flow emission, ResultMessage boundary detection |
+| `direct/src/works/iterative/claude/direct/ClaudeCode.scala` | `ClaudeCode.session` | Public factory on both class and companion object; validates cwd and resolves executable path |
+| `direct/src/works/iterative/claude/direct/package.scala` | package object | Confirm `Session` and `SessionOptions` re-exports are present |
+
+## Diagrams
+
+### Component Relationships
+
+```
+works.iterative.claude.direct
+│
+├── Session (trait)                          ← public contract
+│     send(prompt): Flow[Message]
+│     close(): Unit
+│     sessionId: String
+│
+├── ClaudeCode (class / companion)
+│     session(SessionOptions): Session       ← factory; delegates to createSession
+│
+└── internal.cli
+      └── SessionProcess                     ← implements Session
+            - process: java.lang.Process
+            - stdinWriter: BufferedWriter
+            - stdoutReader: BufferedReader
+            - currentSessionId: AtomicReference[String]
+            start(executablePath, options)   ← factory on companion object
+```
+
+### Session Lifecycle Flow
+
+```
+Caller                  ClaudeCode            SessionProcess          CLI Process
+  │                         │                       │                      │
+  │  session(opts)          │                       │                      │
+  │────────────────────────>│                       │                      │
+  │                         │  start(path, opts)    │                      │
+  │                         │──────────────────────>│                      │
+  │                         │                       │  ProcessBuilder.start()
+  │                         │                       │─────────────────────>│
+  │                         │                       │  fork: captureStderr │
+  │                         │                       │  readInitMessages()  │
+  │                         │                       │<──── SystemMessage(init, session_id)
+  │                         │                       │  currentSessionId.set(id)
+  │<────────────────────────────────────────────────│  return SessionProcess
+  │                         │                       │                      │
+  │  send("prompt")         │                       │                      │
+  │─────────────────────────────────────────────────>                      │
+  │  stdinWriter.write(SDKUserMessage JSON + newline)│                      │
+  │                         │                       │─────────────────────>│
+  │                         │   Flow.usingEmit reads stdout line by line   │
+  │<─── AssistantMessage ───────────────────────────│<─────────────────────│
+  │<─── KeepAliveMessage ───────────────────────────│<─────────────────────│
+  │<─── StreamEventMessage ─────────────────────────│<─────────────────────│
+  │<─── ResultMessage ──────────────────────────────│<─────────────────────│
+  │     (Flow completes; sessionId updated)          │                      │
+  │                         │                       │                      │
+  │  close()                │                       │                      │
+  │─────────────────────────────────────────────────>                      │
+  │                         │  stdinWriter.close()  │                      │
+  │                         │  process.waitFor(5s)  │                      │
+  │                         │  destroyForcibly if needed                   │
+  │                         │                       │─────────────────────>│ (exit)
+```
+
+### Session ID State Machine
+
+```
+  [created]
+      │
+      │ init message arrives during readInitMessages()
+      ├──────────────────────────────────> "extracted-id"
+      │
+      │ no init message before first send
+      └──────────────────────────────────> "pending"
+                                               │
+                                               │ ResultMessage received during send
+                                               └──────────────────────> "result-session-id"
+```
+
+### stdin/stdout Protocol (stream-json)
+
+```
+stdin  (Scala → CLI):   {"type":"user","message":{"role":"user","content":"..."},"session_id":"...","parent_tool_use_id":null}\n
+
+stdout (CLI → Scala):   {"type":"system","subtype":"init","session_id":"...","tools":[],...}\n   ← startup only
+                        {"type":"keep_alive"}\n                                                    ← periodic
+                        {"type":"stream_event","data":{...}}\n                                     ← streaming deltas
+                        {"type":"assistant","message":{...}}\n                                     ← full assistant turn
+                        {"type":"result","subtype":"conversation_result","session_id":"...","is_error":false,...}\n  ← end-of-turn
+```
+
+## Test Summary
+
+### Unit Tests — `SessionTest.scala` (9 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| Session trait compiles with expected method signatures | Unit | Compile-time verification that `send`, `close`, `sessionId` have correct types |
+| SDKUserMessage is correctly encoded for stdin | Unit | Verifies JSON shape: `type=user`, nested `message.role=user`, `message.content`, `session_id` |
+| SDKUserMessage with pending session ID uses 'pending' literal | Unit | Edge case: first-send encoding before session ID is known |
+| Session ID is extracted from SystemMessage with subtype init | Unit | Pattern-matches `SystemMessage("init", data)` and reads `session_id` key |
+| Non-init SystemMessage does not provide session ID | Unit | Confirms only `"init"` subtype triggers extraction |
+| Session ID defaults to 'pending' when no init message received | Unit | Uses a `MockCliScript` that skips the init message; asserts `sessionId == "pending"` |
+| Flow completes after emitting ResultMessage | Unit | Drives a `SessionMockCliScript` with one turn; asserts exactly 2 messages (assistant + result) |
+| Session ID is updated from ResultMessage after send completes | Unit | After `runToList()`, asserts `session.sessionId == "updated-session-id-456"` |
+| close() terminates the underlying process | Unit | Calls `close()` on a session backed by a simple script; passes if no hang |
+
+### Integration Tests — `SessionIntegrationTest.scala` (5 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| full single-turn session lifecycle with mock CLI | Integration | Full open/send/close using `SessionMockCliScript`; verifies assistant text and ResultMessage fields |
+| mock CLI receives correct SDKUserMessage JSON on stdin | Integration | `captureStdinFile` option captures what the process received; parses JSON and checks `type` and `content` |
+| session extracts session ID from init SystemMessage | Integration | Script emits init with `session_id`; asserts `session.sessionId` matches before any send |
+| KeepAlive and StreamEvent messages are emitted in the Flow | Integration | Script emits `keep_alive` + `stream_event` interleaved; asserts all four message types present |
+| ClaudeCode.session factory creates a working session via instance API | Integration | Uses `ClaudeCode.concurrent` instance instead of companion object; verifies same behaviour |
+
+### E2E Tests — `SessionE2ETest.scala` (2 tests)
+
+| Test | Type | Description |
+|------|------|-------------|
+| E2E: real CLI session completes a single turn | E2E | Gated on CLI availability and credentials; sends "What is 1+1?", asserts `AssistantMessage` and `ResultMessage` present |
+| E2E: session ID is a valid non-pending value after first turn | E2E | Same gate; asserts `session.sessionId` is non-empty and not `"pending"` after a completed turn |
+
+E2E tests skip automatically when `claude` binary is absent, Node.js is unavailable, or no API credentials are found (`ANTHROPIC_API_KEY` or `~/.claude/.credentials.json`).
+
+## Files Changed
+
+| File | Status | Description |
+|------|--------|-------------|
+| `direct/src/works/iterative/claude/direct/Session.scala` | New | Public `Session` trait |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | New | `SessionProcess` class + `start` factory; full process lifecycle management |
+| `direct/src/works/iterative/claude/direct/ClaudeCode.scala` | Modified | Added `session(SessionOptions)` on class and companion; added `createSession` and `resolveSessionExecutablePath` helpers |
+| `direct/src/works/iterative/claude/direct/package.scala` | Modified | Added `Session`, `SessionOptions`, `SDKUserMessage` re-exports (note: `SessionOptions` was already present from Phase 2; `SDKUserMessage` added here) |
+| `direct/test/src/works/iterative/claude/direct/SessionTest.scala` | New | 9 unit tests |
+| `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` | New | 5 integration tests |
+| `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` | New | 2 E2E tests |
+| `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` | New | Shell script generator for stream-json session protocol simulation |
+| `project-management/issues/CC-15/phase-03-tasks.md` | Modified | Task tracking updates |
+| `project-management/issues/CC-15/review-state.json` | Modified | Review state bookkeeping |
+
+<details>
+<summary>Notable implementation details worth reviewing</summary>
+
+**Init message reading (`readInitMessages`):** Uses a 500 ms deadline with 10 ms sleep-poll between `reader.ready()` checks. This avoids blocking indefinitely if the init message is delayed, but also avoids consuming the first user-turn message from the real CLI. Review whether the deadline and poll interval are appropriate for slow CI environments.
+
+**`--verbose` flag injection:** `SessionProcess.start` prepends `--verbose` to the CLI args rather than having it in `CLIArgumentBuilder.buildSessionArgs`. The comment explains this mirrors how query mode adds `--verbose` in `ClaudeCode.buildCliArguments`. Worth verifying the two places stay in sync as the API evolves.
+
+**`configureSessionProcess` duplication:** The process configuration logic (cwd, environment) is duplicated from `ProcessManager.configureProcess` because `configureProcess` takes `QueryOptions`. The comment in the approach doc notes this trade-off. If `ProcessManager` grows, consider extracting a shared helper.
+
+**Turn sequencing:** Per the analysis decision, no client-side guard prevents calling `send` before the previous `Flow` is fully consumed. The CLI queues messages internally. This is intentional and documented in the phase context.
+
+</details>

--- a/project-management/issues/CC-15/review-packet-phase-04.md
+++ b/project-management/issues/CC-15/review-packet-phase-04.md
@@ -1,0 +1,181 @@
+---
+generated_from: 5258c10f593bb32a32070570ecf1bbc6b8ac2785
+generated_at: 2026-04-05T08:58:45Z
+branch: CC-15-phase-04
+issue_id: CC-15
+phase: 4
+files_analyzed:
+  - direct/test/src/works/iterative/claude/direct/SessionTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala
+---
+
+# Review Packet: Phase 4 - Direct API - Multi-turn conversation
+
+## Goals
+
+This phase proves that multiple sequential `send` calls within a single `Session` work correctly, with isolated message streams per turn and correct session ID propagation.
+
+Key objectives:
+
+- Verify that each `send` call returns only its own turn's messages with no bleed from adjacent turns
+- Verify that the `SDKUserMessage` for each subsequent turn carries the session ID from the previous turn's `ResultMessage`
+- Verify that `session.sessionId` is updated after each completed turn
+- Verify that real CLI context is maintained across turns (the SDK must not break it)
+- Fix any bugs in `SessionProcess.send` discovered during multi-turn testing
+
+No new public API surface was added. The mechanical multi-turn infrastructure was already in place from Phase 3; this phase comprehensively tests and validates it.
+
+## Scenarios
+
+- [ ] Two sequential sends each return only their own turn's messages (no message bleed between turns)
+- [ ] The second send's `SDKUserMessage` carries the session ID from the first turn's `ResultMessage`
+- [ ] `session.sessionId` reflects the most recent `ResultMessage` session ID after each turn
+- [ ] Three sequential sends work correctly (tests cycling beyond two turns)
+- [ ] A full two-turn session lifecycle via mock CLI produces correct per-turn responses
+- [ ] Stdin capture confirms correct session ID progression across turns (init ID for first send, turn-1 result ID for second send)
+- [ ] Turns with different message counts each emit exactly the right message count and types
+- [ ] Session ID updates across turns when `ResultMessage` carries distinct IDs per turn
+- [ ] Real two-turn conversation preserves context (second turn correctly recalls information from first turn)
+- [ ] Session ID remains non-empty and non-"pending" across multiple real turns
+
+## Entry Points
+
+| File | Method/Class | Why Start Here |
+|------|--------------|----------------|
+| `direct/test/src/works/iterative/claude/direct/SessionTest.scala` | T8-T11 (unit tests) | Start here to understand the core multi-turn contract: turn isolation and session ID propagation |
+| `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` | IT6-IT9 (integration tests) | Shows the full mock-CLI-backed lifecycle: turn responses, stdin capture, message counts |
+| `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` | E2E multi-turn tests | Proves real CLI context retention and session ID validity across turns |
+
+## Diagrams
+
+### Multi-turn session message flow
+
+```
+Caller          Session / SessionProcess          Mock/Real CLI
+  |                       |                             |
+  | session.send(p1)      |                             |
+  |---------------------->|  write SDKUserMessage(p1)   |
+  |                       |---------------------------->|
+  |                       |  <-- AssistantMessage       |
+  |                       |  <-- ResultMessage(id1)     |
+  |   Flow[Message] t1    |                             |
+  |<----------------------|                             |
+  |                       |  sessionId := id1           |
+  |                       |                             |
+  | session.send(p2)      |                             |
+  |---------------------->|  write SDKUserMessage(p2,   |
+  |                       |    session_id=id1)          |
+  |                       |---------------------------->|
+  |                       |  <-- AssistantMessage       |
+  |                       |  <-- ResultMessage(id2)     |
+  |   Flow[Message] t2    |                             |
+  |<----------------------|                             |
+  |                       |  sessionId := id2           |
+```
+
+### Session ID progression
+
+```
+Initial state:  sessionId = "pending"
+                     |
+            SystemMessage(initId) read at startup
+                     |
+                sessionId = initId
+                     |
+              send(p1) completes
+            ResultMessage(turn1Id)
+                     |
+                sessionId = turn1Id   <-- carried in next SDKUserMessage
+                     |
+              send(p2) completes
+            ResultMessage(turn2Id)
+                     |
+                sessionId = turn2Id
+```
+
+### Test coverage pyramid
+
+```
+       E2E (2 tests)
+      Real CLI, context + ID validity
+
+    Integration (4 tests, IT6-IT9)
+    Mock CLI: lifecycle, stdin IDs, message counts, ID updates
+
+  Unit (4 tests, T8-T11)
+  In-process: isolation, ID propagation, ID updates, 3-turn cycling
+```
+
+## Test Summary
+
+### Unit tests (SessionTest.scala) — 4 new tests
+
+| Test | Type | Verifies |
+|------|------|----------|
+| T8: two sequential sends return isolated message streams | Unit | No message bleed between turn 1 and turn 2 |
+| T9: session ID propagates from first turn ResultMessage to second send SDKUserMessage | Unit | Stdin capture confirms second message carries turn-1 session ID |
+| T10: session ID is updated after each turn to reflect the most recent ResultMessage | Unit | `session.sessionId` correct after turn 1 and turn 2 |
+| T11: three sequential sends each return only their own turn's messages | Unit | Cycling/indexing works beyond two turns |
+
+### Integration tests (SessionIntegrationTest.scala) — 4 new tests
+
+| Test | Type | Verifies |
+|------|------|----------|
+| IT6: full two-turn session lifecycle with mock CLI | Integration | Init ID read at startup; turn 1 and turn 2 return correct distinct content and update sessionId |
+| IT7: stdin capture shows correct session ID progression across turns | Integration | First SDKUserMessage carries init ID; second carries turn-1 result ID |
+| IT8: turns with different message counts emit exactly the right messages | Integration | Turn 1 (2 msgs: assistant + result) and turn 2 (4 msgs: keepalive + stream_event + assistant + result) are both exact |
+| IT9: session ID updates across turns when ResultMessage carries distinct IDs | Integration | `session.sessionId` tracks the most recent ResultMessage ID across turns |
+
+### E2E tests (SessionE2ETest.scala) — 2 new tests
+
+| Test | Type | Verifies |
+|------|------|----------|
+| E2E: two-turn conversation preserves context across turns | E2E | Real CLI recalls "42" in second turn; SDK does not break conversation context |
+| E2E: session ID remains valid and non-pending across multiple turns | E2E | After two real turns, sessionId is non-empty and not "pending" |
+
+All E2E tests are gated on `isClaudeCliInstalled()`, `isNodeJsAvailable()`, and `hasApiKeyOrCredentials()`.
+
+## Files Changed
+
+| File | Change Type | Summary |
+|------|-------------|---------|
+| `direct/test/src/works/iterative/claude/direct/SessionTest.scala` | Modified | Added 4 unit tests (T8-T11) covering turn isolation, session ID propagation, and 3-turn cycling |
+| `direct/test/src/works/iterative/claude/direct/SessionIntegrationTest.scala` | Modified | Added 4 integration tests (IT6-IT9) covering full lifecycle, stdin capture, message count precision, and ID tracking; also moved `import io.circe.parser` to file-level |
+| `direct/test/src/works/iterative/claude/direct/SessionE2ETest.scala` | Modified | Added 2 E2E tests for real context retention and session ID validity across turns |
+| `project-management/issues/CC-15/phase-04-tasks.md` | Modified | All tasks checked off as complete |
+| `project-management/issues/CC-15/review-state.json` | Modified | Status updated to `implementing` |
+
+<details>
+<summary>Diff summary: SessionTest.scala additions</summary>
+
+Four tests added in order T8 through T11:
+
+- **T8** uses `SessionMockCliScript.createSessionScript` with two `TurnResponse` entries, calls `send` twice, asserts each result list has exactly 2 messages and that text content is turn-specific.
+- **T9** uses `captureStdinFile`, calls `send` twice, then parses the captured JSONL to confirm the second line's `session_id` field matches the first turn's `ResultMessage` session ID.
+- **T10** calls `send` twice with distinct session IDs in each `ResultMessage` and asserts `session.sessionId` equals the correct ID after each turn.
+- **T11** iterates three turns, asserting each returns 2 messages and a `ResultMessage` with the correct per-turn session ID.
+
+</details>
+
+<details>
+<summary>Diff summary: SessionIntegrationTest.scala additions</summary>
+
+Four tests added (IT6-IT9) plus a minor cleanup (moved `import io.circe.parser` from inside a test to file scope):
+
+- **IT6** creates a mock script with an init message and two turn responses containing different text content. Verifies the session starts with the init session ID, each turn's messages match their configured content, and `session.sessionId` tracks the result ID after each turn.
+- **IT7** uses `captureStdinFile` and verifies the JSONL written to stdin: first line has the init session ID, second line has the turn-1 result session ID.
+- **IT8** configures turn 1 with 2 messages and turn 2 with 4 messages (including `keepAliveMessage` and `streamEventMessage`). Asserts exact counts and presence of specific message types per turn.
+- **IT9** configures no init messages and two turns with distinct result session IDs. Asserts `session.sessionId` is correct after each turn.
+
+</details>
+
+<details>
+<summary>Diff summary: SessionE2ETest.scala additions</summary>
+
+Two tests added:
+
+- **E2E context retention**: sends "Remember the number 42. Reply only with 'OK'." then "What number did I ask you to remember? Reply with just the number." Asserts the second response contains "42".
+- **E2E session ID stability**: sends two simple arithmetic prompts, captures `session.sessionId` after each, and asserts both are non-empty and not "pending".
+
+</details>

--- a/project-management/issues/CC-15/review-packet-phase-05.md
+++ b/project-management/issues/CC-15/review-packet-phase-05.md
@@ -1,0 +1,209 @@
+---
+generated_from: 6a4f4725166cf9b629b144aad531c87e38815cb9
+generated_at: 2026-04-05T13:24:39Z
+branch: CC-15-phase-05
+issue_id: CC-15
+phase: 5
+files_analyzed:
+  - effectful/src/works/iterative/claude/effectful/Session.scala
+  - effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+  - effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+  - effectful/src/works/iterative/claude/effectful/package.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionTest.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala
+  - effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala
+---
+
+# Review Packet: Phase 5 - Effectful API - Session lifecycle with Resource
+
+## Goals
+
+This phase delivers the cats-effect session API, enabling persistent multi-turn conversations with a single long-lived Claude Code CLI process through a `Resource[IO, Session]` lifecycle.
+
+Key objectives:
+
+- Expose a `Session` trait in the `effectful` package with CQS-split methods: `send(prompt): IO[Unit]` (writes stdin) and `stream: Stream[IO, Message]` (reads stdout until `ResultMessage`)
+- Implement `SessionProcess`, a `Resource`-based process manager that spawns the CLI once and keeps it alive across turns, using background fibers for stdin writing, stdout reading, and stderr capture
+- Add `ClaudeCode.session(SessionOptions): Resource[IO, Session]` factory to the effectful API entry point
+- Re-export `SessionOptions` in the effectful package object for single-import usage
+- Apply the CQS refactoring (R1) to the direct `Session` trait and tests to match this phase's design
+
+This phase is the effectful counterpart to the direct API session work delivered in Phases 3-4, adapted for cats-effect idioms with `Resource`, `fs2.Stream`, `IO`, `Ref`, `Queue`, and background fibers.
+
+## Scenarios
+
+- [ ] A session can be opened, a prompt sent, and a streaming response received within `Resource.use`
+- [ ] The CLI process starts once on Resource acquire and stays alive across multiple `send` / `stream` cycles
+- [ ] The process is terminated cleanly when the `Resource.use` block exits normally
+- [ ] The process is terminated cleanly when an exception is thrown inside `Resource.use`
+- [ ] `sessionId` returns `"pending"` before the CLI emits an init message
+- [ ] `sessionId` is updated from the init `SystemMessage` during Resource acquire
+- [ ] `sessionId` is updated from each turn's `ResultMessage` after `stream` completes
+- [ ] Each turn's `stream` emits exactly its own messages and terminates after `ResultMessage`
+- [ ] Messages from one turn do not bleed into the next turn's stream
+- [ ] Multiple sequential `send` / `stream` pairs work correctly within one session
+- [ ] The second `send` carries the session ID from the first turn's `ResultMessage` in its `SDKUserMessage` JSON
+- [ ] `KeepAliveMessage` and `StreamEventMessage` pass through the stream
+- [ ] `SessionOptions` is accessible via a single `effectful.*` import
+- [ ] All existing effectful query tests and direct session tests continue to pass
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `effectful/src/works/iterative/claude/effectful/Session.scala` | `Session` trait | Public API contract: defines `send`, `stream`, `sessionId` |
+| `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` | `ClaudeCode.session()` | Factory method: the user-facing entry point that returns `Resource[IO, Session]` |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `SessionProcess.start()` | Core implementation: process spawn, fiber management, queue wiring |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `SessionImpl` | Session implementation: `send` writes to stdinQueue, `stream` reads from messageQueue |
+| `effectful/src/works/iterative/claude/effectful/package.scala` | package object | Re-export: confirms `SessionOptions` is accessible from a single import |
+
+## Diagrams
+
+### Component Architecture
+
+```
+effectful package
+┌─────────────────────────────────────────────────────────┐
+│  ClaudeCode.session(SessionOptions)                      │
+│      │                                                   │
+│      └─► SessionProcess.start(executablePath, options)   │
+│              │                                           │
+│              └─► Resource[IO, Session]                   │
+│                      acquire: spawn process + fibers     │
+│                      release: cancel fibers + close stdin│
+└─────────────────────────────────────────────────────────┘
+
+SessionProcess internals
+┌──────────────────────────────────────────────────────────────────┐
+│  ProcessBuilder.spawn[IO]  ──► fs2.io.process.Process[IO]        │
+│                                                                   │
+│  Queue[IO, Option[Chunk[Byte]]]  stdinQueue                      │
+│      ▲                  │                                        │
+│  SessionImpl.send()     └──► fiber: stdinQueue → process.stdin  │
+│                                                                   │
+│  Queue[IO, Option[Message]]  messageQueue                        │
+│      │                  ▲                                        │
+│  SessionImpl.stream()   └──── fiber: process.stdout → parser     │
+│                                         → sessionIdRef update    │
+│                                         → messageQueue           │
+│                                                                   │
+│  Ref[IO, String]  sessionIdRef  ◄── init message + ResultMessage │
+│                                                                   │
+│  fiber: process.stderr → logger.debug                            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Session Lifecycle Flow
+
+```
+Resource.use { session =>
+    session.send("prompt")          // IO[Unit]
+    │  └─ encode SDKUserMessage JSON
+    │  └─ stdinQueue.offer(Some(chunk))
+    │
+    session.stream.compile.toList   // Stream[IO, Message]
+       └─ messageQueue.take (loop until ResultMessage)
+       └─ emits all messages including ResultMessage
+       └─ sessionIdRef updated by background stdout reader on ResultMessage
+}
+│
+│  acquire:
+│    spawn process
+│    start stdinWriter fiber (drains stdinQueue → process.stdin)
+│    start stdoutReader fiber (process.stdout → messageQueue, updates sessionIdRef)
+│    start stderrCapture fiber (process.stderr → logger.debug)
+│    readInitMessage (peek messageQueue, extract session_id if SystemMessage("init"))
+│
+│  release:
+│    cancel all fibers
+│    stdinQueue.offer(None) → closes process.stdin → process exits
+```
+
+### Turn Sequence (Multi-turn)
+
+```
+Turn 1:
+  send("Q1")   →  stdinQueue ← SDKUserMessage(session_id="pending")
+  stream        →  [AssistantMessage, ResultMessage(session_id="s1")]
+                   sessionIdRef updated to "s1"
+
+Turn 2:
+  send("Q2")   →  stdinQueue ← SDKUserMessage(session_id="s1")
+  stream        →  [KeepAliveMessage, AssistantMessage, ResultMessage(session_id="s2")]
+                   sessionIdRef updated to "s2"
+```
+
+## Test Summary
+
+### Unit Tests (`SessionTest.scala`) — 9 tests
+
+| # | Test | Type | Notes |
+|---|------|------|-------|
+| T1 | SDKUserMessage is correctly encoded for stdin | Unit | Verifies JSON fields: `type`, `message.role`, `message.content`, `session_id` |
+| T2 | Session ID defaults to `"pending"` before any send | Unit | Uses minimal mock script with no init message |
+| T3 | Session ID extracted from init SystemMessage during Resource acquire | Unit | Mock emits `SystemMessage("init", {"session_id": "..."})` before any send |
+| T4 | Session ID updated from ResultMessage after stream completes | Unit | Checks `sessionId` after `stream.compile.drain` |
+| T5 | `stream` completes after emitting ResultMessage | Unit | Verifies exactly 1 AssistantMessage + 1 ResultMessage, then stream ends |
+| T6 | KeepAlive and StreamEvent messages pass through | Unit | All four message types present in stream |
+| T7 | Two sequential sends return isolated streams | Unit | Turn 1 messages not in turn 2, and vice versa |
+| T8 | Session ID propagates from first turn to second send | Unit | Reads stdin capture file; second JSON line has `session_id` from turn 1 ResultMessage |
+| T9 | Three sequential send/stream cycles work correctly | Unit | Each turn has correct messages and session ID |
+
+All unit tests use `SessionMockCliScript` from the direct module (reused across modules).
+
+### Integration Tests (`SessionIntegrationTest.scala`) — 9 tests
+
+| # | Test | Notes |
+|---|------|-------|
+| IT1 | Full single-turn lifecycle with mock CLI | Verifies AssistantMessage content and ResultMessage fields |
+| IT2 | Resource cleanup on normal exit | Verifies `Resource.use` completes without hanging |
+| IT3 | Resource cleanup on error | `IO.raiseError` inside `use`; checks exception propagates and process is cleaned up |
+| IT4 | Stdin carries correct SDKUserMessage JSON | Reads captured stdin file; checks `type` and `message.content` |
+| IT5 | Session ID from init message during acquire | Checks `sessionId` before any `send` |
+| IT6 | Two-turn lifecycle | Verifies init ID, turn 1 response + ID, turn 2 response + ID |
+| IT7 | Stdin shows correct session ID progression | First send uses init ID; second send uses turn 1 ResultMessage ID |
+| IT8 | Variable message counts per turn | Turn 1: 2 messages; turn 2: 4 messages (keepalive, stream_event, assistant, result) |
+| IT9 | `ClaudeCode.session` factory produces working session | End-to-end factory method test with mock script |
+
+### E2E Tests (`SessionE2ETest.scala`) — 3 tests
+
+| # | Test | Gate |
+|---|------|------|
+| E1 | Single-turn session with real CLI | `assume` on `claude --version` exit code = 0 and API key / credentials file |
+| E2 | Two-turn context dependency (`"Remember 42"` → `"What number?"`) | Same gate |
+| E3 | Session ID is non-empty and not `"pending"` after first turn | Same gate |
+
+E2E tests skip gracefully when the CLI is not installed or credentials are absent.
+
+### Regression Test
+
+| File | Purpose |
+|------|---------|
+| `EffectfulPackageReexportTest.scala` | Confirms `SessionOptions` is accessible as `effectful.SessionOptions` (new assertion added alongside existing re-export tests) |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `effectful/src/works/iterative/claude/effectful/Session.scala` | **New** — `Session` trait with `send`, `stream`, `sessionId` |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | **New** — `SessionProcess.start` (Resource factory) and `SessionImpl` (queue-based implementation) |
+| `effectful/src/works/iterative/claude/effectful/ClaudeCode.scala` | **Modified** — added `session(SessionOptions)` factory and `discoverExecutableForSession` helper |
+| `effectful/src/works/iterative/claude/effectful/package.scala` | **Modified** — added `SessionOptions` type and value re-exports |
+| `effectful/test/src/works/iterative/claude/effectful/SessionTest.scala` | **New** — 9 unit tests |
+| `effectful/test/src/works/iterative/claude/effectful/SessionIntegrationTest.scala` | **New** — 9 integration tests |
+| `effectful/test/src/works/iterative/claude/effectful/SessionE2ETest.scala` | **New** — 3 E2E tests |
+| `effectful/test/src/works/iterative/claude/effectful/EffectfulPackageReexportTest.scala` | **Modified** — added `SessionOptions` re-export assertion |
+
+<details>
+<summary>Key design notes for reviewers</summary>
+
+**Shared stdout reader approach:** The stdout fiber continuously reads lines from the process into `messageQueue`. Each `stream` call pulls from that same queue until it sees a `ResultMessage`. This works without contention because `send` / `stream` calls are sequential — the design does not enforce this but documents that concurrent sends are delegated to the CLI's own queueing (per the resolved architectural decision).
+
+**Init message peeling:** `readInitMessage` races a `messageQueue.take` against a 1-second timeout. If the first message is a `SystemMessage("init", ...)`, the session ID is extracted and the message is consumed (not re-enqueued). If it is any other message type, it is put back into the queue so it appears in the user's first `stream`. If the timeout fires first, `sessionId` stays `"pending"`.
+
+**Stdin queue closure:** On Resource release, the fibers are cancelled and `None` is offered to `stdinQueue`. The stdin writer fiber, which uses `Stream.fromQueueNoneTerminated`, sees the `None` sentinel, terminates, and the process stdin pipe closes — causing the CLI process to exit cleanly.
+
+**Mock script reuse:** `SessionMockCliScript` lives in the `direct` test module and is reused directly by the effectful tests. This avoids duplicating test infrastructure. If the modules are published separately, this dependency will need to be revisited.
+
+</details>

--- a/project-management/issues/CC-15/review-packet-phase-06.md
+++ b/project-management/issues/CC-15/review-packet-phase-06.md
@@ -1,0 +1,197 @@
+---
+generated_from: ca775206d06d33158507ea3203808bd2df83b5b5
+generated_at: 2026-04-05T16:33:59Z
+branch: CC-15-phase-06
+issue_id: CC-15
+phase: 6
+files_analyzed:
+  - core/src/works/iterative/claude/core/CLIError.scala
+  - direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+  - direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala
+  - direct/test/src/works/iterative/claude/direct/SessionTest.scala
+  - direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala
+  - effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala
+  - effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala
+---
+
+# Review Packet: Phase 6 - Error Handling (Process Crash and Malformed JSON)
+
+## Goals
+
+This phase hardens the session API by making error conditions surface as typed
+`CLIError` values rather than raw exceptions or silent incomplete streams.
+
+Key objectives:
+
+- Add two new error types to the `CLIError` hierarchy: `SessionProcessDied`
+  (process crashed) and `SessionClosedError` (send after explicit close)
+- Direct API: detect process death before writing to stdin and detect unexpected
+  stdout EOF mid-turn (before `ResultMessage`)
+- Direct API: make `close()` idempotent
+- Effectful API: fix a bug where a single malformed JSON line would kill the
+  entire stdout reader fiber; change to log-and-skip to match the direct API
+- Effectful API: detect process death in `send` via an `aliveRef`, and surface
+  process-death errors from `stream` via a `pendingErrorRef` set by the stdout
+  reader fiber
+- Ensure all error paths carry the exit code and stderr context where available
+
+## Scenarios
+
+- [ ] `send` after `close()` throws `SessionClosedError` carrying the session ID (direct)
+- [ ] `close()` called twice does not throw (idempotent)
+- [ ] `send` to a dead process throws `SessionProcessDied` with an exit code (direct)
+- [ ] `stream` raises `SessionProcessDied` when the process exits mid-turn before `ResultMessage` (direct)
+- [ ] Malformed JSON line mid-turn is skipped; subsequent valid messages and `ResultMessage` arrive normally (direct)
+- [ ] `send` to a dead process raises `SessionProcessDied` in IO (effectful)
+- [ ] `stream` raises `SessionProcessDied` when the process exits mid-turn before `ResultMessage` (effectful)
+- [ ] Malformed JSON line is logged and skipped; valid messages in the same turn arrive (effectful)
+- [ ] Process crash between turns: second `send` raises `SessionProcessDied` carrying the exit code (both APIs)
+- [ ] Multiple malformed JSON lines do not accumulate errors; all valid messages arrive
+- [ ] Resource cleanup completes without hanging after process dies (effectful)
+
+## Entry Points
+
+| File | Method/Class | Why Start Here |
+|------|--------------|----------------|
+| `core/src/works/iterative/claude/core/CLIError.scala` | `SessionProcessDied`, `SessionClosedError` | New error types; defines what callers catch |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | `send()`, `stream()`, `close()` | All three methods changed; liveness logic is here |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `startStdoutReader`, `SessionImpl.send`, `SessionImpl.stream` | Bug fix (malformed JSON) and new liveness/error-propagation machinery |
+| `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` | `createCrashMidTurnScript`, `createCrashBetweenTurnsScript`, `createImmediateExitScript` | New script builders used by all error tests |
+
+## Diagrams
+
+### Error Type Hierarchy
+
+```
+CLIError (sealed trait)
+├── CLINotFoundError
+├── ProcessError
+├── ProcessExecutionError
+├── JsonParsingError
+├── ProcessTimeoutError
+├── ConfigurationError
+├── EnvironmentValidationError
+├── SessionProcessDied(exitCode: Option[Int], stderr: String)   ← NEW
+└── SessionClosedError(sessionId: String)                        ← NEW
+```
+
+### Direct API: Process Liveness Check Flow
+
+```
+send(prompt)
+  │
+  ├─ alive == false ──→ throw SessionClosedError(sessionId)
+  │
+  ├─ !process.isAlive ──→ alive=false → throw SessionProcessDied(exitCode, stderr)
+  │
+  └─ write to stdinWriter
+       │
+       └─ IOException ──→ alive=false → throw SessionProcessDied(exitCode, e.getMessage)
+
+stream()
+  │
+  ├─ readLine() → line     ──→ parse, emit, check for ResultMessage (resultSeen=true)
+  │
+  └─ readLine() == null (EOF)
+       │
+       ├─ resultSeen == true  ──→ normal end (process exited cleanly after turn)
+       │
+       └─ resultSeen == false ──→ alive=false → throw SessionProcessDied(exitCode, stderr)
+
+close()
+  │
+  └─ alive.compareAndSet(true→false)
+       ├─ true  ──→ close stdinWriter, waitFor(5s), close stdoutReader
+       └─ false ──→ log "already closed", return
+```
+
+### Effectful API: Error Propagation via Refs
+
+```
+SessionProcess Resource contains:
+  aliveRef:       Ref[IO, Boolean]           (true while process is running)
+  pendingErrorRef: Ref[IO, Option[CLIError]] (set by stdout reader on bad exit)
+  messageQueue:   Queue[IO, Option[Message]] (None = EOF sentinel)
+
+startStdoutReader (background fiber):
+  ┌──────────────────────────────────────────────────────┐
+  │ for each stdout line:                                │
+  │   Left(parseError) ──→ log.warn + skip (was raiseError, now fixed) │
+  │   Right(Some(msg)) ──→ queue.offer(Some(msg))        │
+  │   Right(None)      ──→ discard                       │
+  │                                                      │
+  │ on stream complete (.flatMap after .drain):          │
+  │   aliveRef.set(false)                                │
+  │   exitValue.attempt:                                 │
+  │     Right(code != 0) ──→ pendingErrorRef.set(Some(SessionProcessDied(code,""))) │
+  │     _               ──→ IO.unit                     │
+  │                                                      │
+  │ .guarantee: queue.offer(None)  ← always signals EOF │
+  └──────────────────────────────────────────────────────┘
+
+SessionImpl.send:
+  aliveRef.get
+    false ──→ pendingErrorRef.get
+               Some(err) ──→ IO.raiseError(err)
+               None      ──→ IO.raiseError(SessionProcessDied(None, ""))
+    true  ──→ offer to stdinQueue (normal path)
+
+SessionImpl.stream:
+  resultSeenRef = Ref(false)
+  fromQueueNoneTerminated(messageQueue)
+    .evalTap { ResultMessage ──→ resultSeenRef.set(true) }
+    .takeThrough(!_.isResultMessage)
+    .onFinalize:
+      resultSeenRef.get
+        true  ──→ IO.unit (normal completion)
+        false ──→ pendingErrorRef.get
+                   Some(err) ──→ IO.raiseError(err)
+                   None      ──→ IO.unit
+```
+
+## Test Summary
+
+### New Tests
+
+| Test File | Type | Scenarios Covered |
+|-----------|------|-------------------|
+| `direct/test/.../SessionErrorTest.scala` | Unit | `send` after `close()` → `SessionClosedError`; idempotent `close()`; `send` to dead process; `stream` mid-turn crash; malformed JSON skipped; session functional after bad JSON |
+| `direct/test/.../SessionErrorIntegrationTest.scala` | Integration | crash mid-turn with exit code 42 (verified in error); crash between turns; malformed JSON recovery; multiple bad JSON lines |
+| `effectful/test/.../SessionErrorTest.scala` | Unit | `send` to dead process; `stream` mid-turn crash; malformed JSON skipped; dead-process with exit code 0 (pendingError=None branch) |
+| `effectful/test/.../SessionErrorIntegrationTest.scala` | Integration | crash mid-turn; crash between turns with exit code; malformed JSON recovery; Resource cleanup without hanging |
+
+### Mock Script Builders Added
+
+| Builder | Simulates |
+|---------|-----------|
+| `createImmediateExitScript(exitCode)` | Process exits before reading any stdin |
+| `createCrashMidTurnScript(exitCode)` | Reads one stdin line, emits partial assistant message, exits without `ResultMessage` |
+| `createCrashBetweenTurnsScript(exitCode)` | Completes turn 1 with `ResultMessage`, exits before turn 2 |
+| `createMalformedJsonMidTurnScript()` | Valid assistant message, then `{bad json: not valid}`, then valid `ResultMessage` |
+
+### Existing Tests
+
+The existing `SessionTest.scala` was updated to narrow the caught exception type
+from `Exception` to `SessionClosedError` in the post-`close()` test, confirming
+the typed error replaces the previous untyped exception.
+
+No other existing tests were modified. All query-mode and session-mode tests are
+expected to continue passing.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/src/works/iterative/claude/core/CLIError.scala` | Added `SessionProcessDied` and `SessionClosedError` case classes |
+| `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala` | Liveness flag, guarded `send`/`close`, mid-turn EOF detection in `stream`, `captureRemainingStderr`, `underlyingProcess` accessor for tests |
+| `effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala` | `aliveRef`, `pendingErrorRef`, malformed JSON fix in `startStdoutReader`, liveness check in `send`, error check in `stream.onFinalize` |
+| `direct/test/src/works/iterative/claude/direct/internal/testing/SessionMockCliScript.scala` | Four new script builders for error scenarios |
+| `direct/test/src/works/iterative/claude/direct/SessionErrorTest.scala` | New — direct unit tests |
+| `direct/test/src/works/iterative/claude/direct/SessionErrorIntegrationTest.scala` | New — direct integration tests |
+| `direct/test/src/works/iterative/claude/direct/SessionTest.scala` | Narrowed caught exception type in post-close test |
+| `effectful/test/src/works/iterative/claude/effectful/SessionErrorTest.scala` | New — effectful unit tests |
+| `effectful/test/src/works/iterative/claude/effectful/SessionErrorIntegrationTest.scala` | New — effectful integration tests |
+| `project-management/issues/CC-15/phase-06-tasks.md` | All tasks marked complete |
+| `project-management/issues/CC-15/review-state.json` | Updated |

--- a/project-management/issues/CC-15/review-packet.md
+++ b/project-management/issues/CC-15/review-packet.md
@@ -1,0 +1,253 @@
+---
+generated_from: ae6aaae2e6eeb05aa1d46cc56da86d9214c111ec
+generated_at: 2026-04-05T17:05:46Z
+branch: CC-15-phase-06
+issue_id: CC-15
+phase: complete (6 of 6)
+files_analyzed:
+  - core/src/works/iterative/claude/core/CLIError.scala
+  - core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+  - core/src/works/iterative/claude/core/model/Message.scala
+  - core/src/works/iterative/claude/core/model/SDKUserMessage.scala
+  - core/src/works/iterative/claude/core/model/SessionOptions.scala
+  - core/src/works/iterative/claude/core/parsing/JsonParser.scala
+  - direct/src/works/iterative/claude/direct/ClaudeCode.scala
+  - direct/src/works/iterative/claude/direct/Session.scala
+  - direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala
+  - direct/src/works/iterative/claude/direct/package.scala
+  - effectful/src/works/iterative/claude/effectful/ClaudeCode.scala
+  - effectful/src/works/iterative/claude/effectful/Session.scala
+  - effectful/src/works/iterative/claude/effectful/internal/cli/SessionProcess.scala
+  - effectful/src/works/iterative/claude/effectful/package.scala
+---
+
+# Review Packet: CC-15 - Persistent Two-Way Conversations
+
+## Goals
+
+This feature adds persistent two-way conversation support to both the direct (Ox) and effectful (cats-effect/fs2) APIs by keeping a single Claude Code CLI process alive across multiple turns using `--input-format stream-json`.
+
+Key objectives:
+
+- Enable a single long-lived CLI subprocess to handle multiple conversational turns without restart overhead, eliminating per-turn process startup cost.
+- Implement the `--input-format stream-json` protocol: write `SDKUserMessage` JSON to stdin per turn, delimit responses via `ResultMessage` on stdout.
+- Expose `Session` as a first-class API type in both the direct API (`Session.send/stream/close`) and the effectful API (`Resource[IO, Session]` with `send: IO[Unit]` and `stream: Stream[IO, Message]`).
+- Surface typed errors (`SessionProcessDied`, `SessionClosedError`) when the underlying process crashes or the session is used after closure.
+- Add `SessionOptions` mirroring `QueryOptions` (minus `prompt`) to configure session startup: model, system prompt, tools, permission mode, cwd, and resume/continue options.
+
+The implementation is purely additive. All existing query APIs are unchanged.
+
+## Scenarios
+
+- [ ] A session can be opened with `ClaudeCode.session(options)`, a message sent, and a streaming response received
+- [ ] The underlying CLI process starts once and stays alive across multiple `send` calls
+- [ ] Process is terminated cleanly when the session is closed (direct: `close()`; effectful: Resource finalizer)
+- [ ] Multiple sequential sends within one session each return isolated message streams for their turn
+- [ ] Context is maintained across turns (the CLI handles this internally; the SDK does not need to track it)
+- [ ] `SessionOptions` supports all relevant configuration fields (model, systemPrompt, allowedTools, permissionMode, cwd, resume, continueConversation, etc.) except `prompt`
+- [ ] `CLIArgumentBuilder.buildSessionArgs` prepends the three required streaming flags (`--print --input-format stream-json --output-format stream-json`)
+- [ ] `SDKUserMessage` is encoded to the exact JSON shape the CLI protocol expects (`type: "user"`, nested `message.role`, `session_id`, `parent_tool_use_id`)
+- [ ] `session_id` is extracted from the CLI's init `SystemMessage` on session start and kept up to date from each `ResultMessage`
+- [ ] `KeepAlive` and `StreamEvent` messages pass through to callers without interrupting the stream
+- [ ] When the CLI process crashes mid-turn, the response stream raises `SessionProcessDied`
+- [ ] When the CLI process crashes between turns, the next `send` raises `SessionProcessDied`
+- [ ] Malformed JSON lines are logged and skipped; the session remains functional for subsequent turns
+- [ ] Calling `send` on a closed direct session raises `SessionClosedError`
+- [ ] Effectful `Resource` cleanup terminates the process even when an exception is thrown inside `use`
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|------|----------------|----------------|
+| `direct/src/.../direct/Session.scala` | `Session` trait | Public contract for the direct API: `send`, `stream`, `close`, `sessionId` |
+| `effectful/src/.../effectful/Session.scala` | `Session` trait | Public contract for the effectful API: `send: IO[Unit]`, `stream: Stream[IO, Message]`, `sessionId: IO[String]` |
+| `direct/src/.../direct/ClaudeCode.scala` | `ClaudeCode.session` | Factory method (both instance and companion) that creates a direct `Session` |
+| `effectful/src/.../effectful/ClaudeCode.scala` | `ClaudeCode.session` | Factory method returning `Resource[IO, Session]` |
+| `direct/src/.../internal/cli/SessionProcess.scala` | `SessionProcess.start` | Launches the process, reads the init message, and wires stdin/stdout; contains `send`, `stream`, `close`, and liveness logic |
+| `effectful/src/.../internal/cli/SessionProcess.scala` | `SessionProcess.start` | Resource-based launch with three background fibers (stdin writer, stdout reader, stderr capture) and two-ref error propagation |
+| `core/src/.../core/model/SDKUserMessage.scala` | `SDKUserMessage` | Protocol type written to CLI stdin each turn; the circe `Encoder` here defines the wire format |
+| `core/src/.../core/CLIError.scala` | `SessionProcessDied`, `SessionClosedError` | New error types added to the sealed `CLIError` hierarchy |
+| `core/src/.../core/model/SessionOptions.scala` | `SessionOptions` | Session startup configuration; mirrors `QueryOptions` minus `prompt` |
+| `core/src/.../core/cli/CLIArgumentBuilder.scala` | `buildSessionArgs` | Translates `SessionOptions` to CLI flags, always prepending the three required streaming flags |
+
+## Diagrams
+
+### Component Overview
+
+```
+                 ┌─────────────────────────────────────────────────────┐
+                 │                    Public API                        │
+                 │                                                      │
+                 │  direct.ClaudeCode.session(options)                  │
+                 │  effectful.ClaudeCode.session(options)               │
+                 └────────────────────────┬────────────────────────────┘
+                                          │ creates
+                          ┌───────────────┴───────────────┐
+                          │                               │
+              ┌───────────▼────────┐         ┌────────────▼──────────┐
+              │  direct.Session    │         │ effectful.Session      │
+              │  (trait)           │         │ (trait)                │
+              │                    │         │                        │
+              │  send(str): Unit   │         │ send(str): IO[Unit]    │
+              │  stream(): Flow[M] │         │ stream: Stream[IO,M]   │
+              │  close(): Unit     │         │ sessionId: IO[String]  │
+              │  sessionId: String │         │                        │
+              └─────────┬──────────┘         └────────────┬──────────┘
+                        │                                 │
+          ┌─────────────▼──────────┐       ┌─────────────▼────────────┐
+          │  direct.SessionProcess │       │ effectful.SessionProcess  │
+          │  (impl)                │       │ (impl)                   │
+          │                        │       │                          │
+          │  AtomicBoolean alive   │       │  Ref[IO, Boolean] alive  │
+          │  AtomicRef sessionId   │       │  Ref[IO, Option[Err]]    │
+          │  BufferedWriter stdin  │       │  Queue stdin             │
+          │  BufferedReader stdout │       │  Queue messages          │
+          │  fork: captureStderr   │       │  3 background fibers     │
+          └──────────┬─────────────┘       └─────────────┬────────────┘
+                     │                                    │
+                     └────────────────┬───────────────────┘
+                                      │ spawns
+                         ┌────────────▼────────────────┐
+                         │   Claude Code CLI process    │
+                         │                             │
+                         │  stdin ← SDKUserMessage JSON │
+                         │  stdout → stream-json msgs   │
+                         │  stderr → logger.debug       │
+                         └─────────────────────────────┘
+```
+
+### Session Turn Flow (Direct API)
+
+```
+Caller                  SessionProcess                  CLI Process
+  │                           │                              │
+  │  send("prompt")           │                              │
+  ├──────────────────────────►│                              │
+  │                           │  write SDKUserMessage JSON   │
+  │                           ├─────────────────────────────►│
+  │                           │  flush stdin                 │
+  │  stream(): Flow[Message]  │                              │
+  ├──────────────────────────►│                              │
+  │                           │◄────────── AssistantMessage ─┤
+  │◄── emit AssistantMessage ─┤                              │
+  │                           │◄──────── StreamEventMessage ─┤
+  │◄─ emit StreamEventMessage ┤                              │
+  │                           │◄────────── KeepAliveMessage ─┤
+  │◄── emit KeepAliveMessage ─┤                              │
+  │                           │◄─────────── ResultMessage ───┤
+  │◄─── emit ResultMessage ───┤  update sessionId            │
+  │     (Flow completes)      │                              │
+  │                           │                              │
+  │  (next turn starts here)  │                              │
+```
+
+### Effectful Error Propagation
+
+```
+startStdoutReader fiber
+  │  reads stdout lines
+  │  parses messages → messageQueue.offer(Some(msg))
+  │  on malformed JSON: log + skip (IO.unit)
+  │  on stdout EOF:
+  │    aliveRef.set(false)
+  │    if exitCode != 0: pendingErrorRef.set(Some(SessionProcessDied(...)))
+  └──► messageQueue.offer(None)  ← signals EOF to stream consumers
+
+SessionImpl.stream
+  │  Stream.fromQueueNoneTerminated(messageQueue)
+  │  .takeThrough(!_.isInstanceOf[ResultMessage])
+  │  .onFinalize:
+  │      if !resultSeen:
+  │          pendingErrorRef.get → raise error if present
+  └──► raises SessionProcessDied to caller when process died mid-turn
+```
+
+## Test Summary
+
+### Core Module
+
+| Type | File | Tests |
+|------|------|-------|
+| Unit | `SDKUserMessageTest` | Encoder produces correct JSON structure; `parentToolUseId` as null/string; `pending` session ID; no embedded newlines |
+| Property | `SDKUserMessageRoundTripTest` | Round-trip property tests including `KeepAliveMessage` and `StreamEventMessage` generators |
+| E2E | `SDKUserMessageE2ETest` | Real CLI accepts the stdin format (gated on CLI availability) |
+| Unit | `SessionOptionsTest` | All fields default to None; `defaults` equals `SessionOptions()`; each `with*` builder sets only its own field |
+| Unit | `SessionOptionsArgsTest` | Required flags appear first; no trailing prompt; each of 16 option fields maps to the correct CLI flag; None values produce no extra args |
+| Unit | `JsonParserTest` | Parses `keep_alive` and `stream_event` message types; realistic `ResultMessage` as end-of-turn delimiter |
+
+### Direct Module
+
+| Type | File | Tests |
+|------|------|-------|
+| Unit | `SessionTest` | `SDKUserMessage` encoding; session ID extraction from `SystemMessage(init)`; non-init does not set ID; defaults to `"pending"`; `Flow` completes after `ResultMessage`; session ID updated from `ResultMessage`; two sequential sends return isolated streams; session ID propagates across turns; three-turn cycling; `close()` terminates process |
+| Unit | `SessionErrorTest` | `send` after `close()` raises `SessionClosedError`; `close()` is idempotent; `send` to dead process raises `SessionProcessDied`; crash mid-turn stream raises `SessionProcessDied`; malformed JSON lines are skipped (session remains functional) |
+| Integration | `SessionIntegrationTest` | Full single-turn lifecycle with mock CLI; stdin receives correct `SDKUserMessage` JSON; session ID extracted from init message; `KeepAlive`/`StreamEvent` pass through; `ClaudeCode.session` factory; full two-turn lifecycle; stdin shows correct session ID progression; turns with different message counts |
+| Integration | `SessionErrorIntegrationTest` | Crash mid-turn; crash between turns; malformed JSON recovery; multiple malformed lines |
+| E2E | `SessionE2ETest` | Real CLI single-turn; two-turn context preservation; session ID is valid after first turn; SDKUserMessage E2E (stdin format validated) |
+
+### Effectful Module
+
+| Type | File | Tests |
+|------|------|-------|
+| Unit | `SessionTest` | `SDKUserMessage` encoding; session ID defaults to `"pending"`; session ID extracted from init; session ID updated from `ResultMessage`; stream completes after `ResultMessage`; `KeepAlive`/`StreamEvent` pass through; two sequential sends isolated; session ID propagates to second send; three-turn cycling |
+| Unit | `SessionErrorTest` | `send` to dead process raises `SessionProcessDied` in IO; crash mid-turn stream raises error; malformed JSON is skipped; `send` after death with no pending error raises generic `SessionProcessDied` |
+| Integration | `SessionIntegrationTest` | Full single-turn lifecycle; `Resource` cleanup on normal exit; `Resource` cleanup when exception thrown inside `use`; stdin carries correct JSON; session ID from init message; two-turn lifecycle; stdin session ID progression; variable message counts; `ClaudeCode.session` factory |
+| Integration | `SessionErrorIntegrationTest` | Crash mid-turn; crash between turns; malformed JSON; Resource cleanup after crash does not hang |
+| E2E | `SessionE2ETest` | Real CLI single-turn; two-turn context preservation; session ID valid after first turn |
+| Unit | `EffectfulPackageReexportTest` | `SessionOptions` re-exported from effectful package |
+
+## Files Changed
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `core/src/.../core/model/SDKUserMessage.scala` | Protocol type for stdin messages with circe Encoder |
+| `core/src/.../core/model/SessionOptions.scala` | Session startup configuration (18 fields, fluent builder) |
+| `direct/src/.../direct/Session.scala` | Public Session trait for direct API |
+| `direct/src/.../internal/cli/SessionProcess.scala` | Direct API session implementation (AtomicBoolean liveness, stdin/stdout lifecycle) |
+| `effectful/src/.../effectful/Session.scala` | Public Session trait for effectful API |
+| `effectful/src/.../internal/cli/SessionProcess.scala` | Effectful API session implementation (Resource, 3 fibers, two-ref error propagation) |
+| `direct/test/.../testing/SessionMockCliScript.scala` | Mock CLI script builder for integration tests (normal, crash, malformed JSON scenarios) |
+| `direct/test/.../testing/MockLogger.scala` | Shared mock logger for direct test suites |
+| `core/test/.../model/SDKUserMessageTest.scala` | Unit tests for `SDKUserMessage` Encoder |
+| `core/test/.../model/SDKUserMessageRoundTripTest.scala` | Property tests including new message type generators |
+| `core/test/.../model/SDKUserMessageE2ETest.scala` | E2E validation of stdin format against real CLI |
+| `core/test/.../model/SessionOptionsTest.scala` | Unit tests for `SessionOptions` construction and builders |
+| `core/test/.../cli/SessionOptionsArgsTest.scala` | Unit tests for `CLIArgumentBuilder.buildSessionArgs` |
+| `direct/test/.../SessionTest.scala` | Unit tests for direct Session behavior |
+| `direct/test/.../SessionIntegrationTest.scala` | Integration tests for direct Session with mock CLI |
+| `direct/test/.../SessionE2ETest.scala` | E2E tests for direct Session against real CLI |
+| `direct/test/.../SessionErrorTest.scala` | Unit tests for direct Session error handling |
+| `direct/test/.../SessionErrorIntegrationTest.scala` | Integration tests for direct Session error scenarios |
+| `effectful/test/.../SessionTest.scala` | Unit tests for effectful Session behavior |
+| `effectful/test/.../SessionIntegrationTest.scala` | Integration tests for effectful Session with mock CLI |
+| `effectful/test/.../SessionE2ETest.scala` | E2E tests for effectful Session against real CLI |
+| `effectful/test/.../SessionErrorTest.scala` | Unit tests for effectful Session error handling |
+| `effectful/test/.../SessionErrorIntegrationTest.scala` | Integration tests for effectful Session error scenarios |
+
+### Modified Files
+
+| File | What Changed |
+|------|-------------|
+| `core/src/.../core/CLIError.scala` | Added `SessionProcessDied(exitCode, stderr)` and `SessionClosedError(sessionId)` to the sealed hierarchy |
+| `core/src/.../core/model/Message.scala` | Added `KeepAliveMessage` (case object) and `StreamEventMessage(data: Map[String, Any])` |
+| `core/src/.../core/parsing/JsonParser.scala` | Added parsing branches for `keep_alive` and `stream_event` message types |
+| `core/src/.../core/cli/CLIArgumentBuilder.scala` | Added `buildSessionArgs(options: SessionOptions): List[String]` |
+| `direct/src/.../direct/ClaudeCode.scala` | Added `session(SessionOptions): Session` to both class and companion; extracted `resolveExecutablePath` helper |
+| `direct/src/.../direct/package.scala` | Re-exported `SessionOptions` |
+| `effectful/src/.../effectful/ClaudeCode.scala` | Added `session(SessionOptions): Resource[IO, Session]`; extracted shared `resolveExecutable` helper |
+| `effectful/src/.../effectful/package.scala` | Re-exported `SessionOptions` |
+| `direct/internal/parsing/JsonParser.scala` | Added exhaustive match cases for `KeepAliveMessage` and `StreamEventMessage` |
+| `effectful/test/.../EffectfulPackageReexportTest.scala` | Added `SessionOptions` re-export assertion |
+
+<details>
+<summary>Refactoring: Session.send CQS split (between Phase 4 and 5)</summary>
+
+After Phase 4, the direct `Session.send(prompt): Flow[Message]` was split into:
+- `send(prompt: String): Unit` — command (writes to stdin, returns nothing)
+- `stream(): Flow[Message]` — query (reads stdout until ResultMessage)
+
+This follows Command-Query Separation and aligns with the V2 Claude Agent SDK. The effectful API was designed with CQS from the start (`send: IO[Unit]`, `stream: Stream[IO, Message]`). All 15 call sites in direct tests were updated; no production behavior changed.
+
+</details>

--- a/project-management/issues/CC-15/review-phase-02-20260404-224208.md
+++ b/project-management/issues/CC-15/review-phase-02-20260404-224208.md
@@ -1,0 +1,78 @@
+# Code Review Results
+
+**Review Context:** Phase 2: SessionOptions configuration for issue CC-15 (Iteration 1/3)
+**Files Reviewed:** 4
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-04-04T22:42:08
+**Git Context:** git diff 8c6033dd4a80ef511fadd5a21c39c0c7b96722a7
+
+---
+
+## Style Review
+
+### Critical Issues
+None
+
+### Warnings
+1. Redundant self-import in `SessionOptions.scala` — `PermissionMode` is in the same package → **Fixed: import removed**
+2. Scaladoc in `buildSessionArgs` describes implementation detail (specific flag names) rather than contract
+
+### Suggestions
+1. Test files use `CatsEffectSuite` for synchronous data model — **Not applicable**: matches existing codebase convention
+2. `"no trailing prompt argument"` test uses magic number `5` → **Fixed: uses `requiredFlags.length`**
+3. `args.take(5)` uses magic number → **Fixed: uses `requiredFlags.length`**
+
+---
+
+## Testing Review
+
+### Critical Issues
+1. Wrong test framework (`CatsEffectSuite` vs ZIO) — **Not applicable**: existing tests all use `munit.CatsEffectSuite`
+
+### Warnings
+1. Builder isolation tests only spot-check one sibling field → **Fixed: uses `assertEquals(built, base.copy(...))` for full structural equality**
+2. `args.contains` assertions don't verify adjacency of flag and value — **Acknowledged**: acceptable for this test granularity; the combined test covers multi-field interactions
+
+### Suggestions
+1. Test name says "three required session flags" but there are five tokens — naming imprecision
+2. No tests for process-level fields producing no CLI flags — valid suggestion for future enhancement
+3. Builder test uses single large function — deliberate trade-off per task plan
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+None
+
+### Warnings
+1. Redundant self-import — **Fixed** (same as style finding)
+2. Option-match boilerplate could use `fold`/`toList.flatMap` — stylistic preference, matches existing `buildArgs` pattern
+
+### Suggestions
+1. `continueConversation` wildcard match hides `Some(false)` — acceptable, matches existing pattern
+
+---
+
+## Composition Review
+
+### Critical Issues
+1. Duplicated argument-building logic between `buildArgs` and `buildSessionArgs` — **Acknowledged, deliberate**: phase context explicitly defers extraction to future refactor when a third call site appears
+2. `SessionOptions` and `QueryOptions` share near-identical structure — **Acknowledged, deliberate**: same rationale as above; shared abstraction deferred
+
+### Warnings
+1. Test comment states incorrect count — minor, the test itself is authoritative
+2. Test names use imprecise flag count language
+
+### Suggestions
+1. Extract `optArg`/`flagArg` private helpers — deferred with the shared mapper refactor
+
+---
+
+## Summary
+
+- **Critical issues:** 0 (2 flagged were either incorrect or deliberate design decisions)
+- **Warnings:** 3 fixed, 2 acknowledged
+- **Suggestions:** 5 noted for future consideration
+
+All fixes applied and verified — 139/139 core tests pass.

--- a/project-management/issues/CC-15/review-phase-03-20260405-101513.md
+++ b/project-management/issues/CC-15/review-phase-03-20260405-101513.md
@@ -1,0 +1,216 @@
+# Code Review Results
+
+**Review Context:** Phase 3: Direct API - Basic session lifecycle for issue CC-15 (Iteration 1/3)
+**Files Reviewed:** 8
+**Skills Applied:** architecture, scala3, composition, testing, style
+**Timestamp:** 2026-04-05T10:15:13
+**Git Context:** git diff 61d41b4
+
+---
+
+<review skill="architecture">
+
+## Architecture Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `stderrBuffer` is captured but never consumed
+**Location:** `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala:126-128`
+**Problem:** `stderrBuffer` is allocated, passed to `captureStderr`, and written to inside the background fork, but nothing ever reads it. The buffer is a local val that goes out of scope when `start` returns.
+**Impact:** Dead state that misleads readers into thinking stderr diagnostics are accessible to callers.
+**Recommendation:** Either expose the buffer through `Session` (e.g., a `lastError: Option[String]` method), or remove the buffer entirely and log directly inside `captureStderr` without accumulating.
+
+#### `readInitMessages` reaches into `SessionProcess` internals via package-private field
+**Location:** `direct/src/works/iterative/claude/direct/internal/cli/SessionProcess.scala:155-185`
+**Problem:** `readInitMessages` accepts the concrete `SessionProcess` and directly mutates `session.currentSessionId`, bypassing the trait abstraction.
+**Recommendation:** Move `readInitMessages` into the `SessionProcess` class itself as a private method, or have it return `Option[String]` and let the caller set the ID.
+
+#### `resolveSessionExecutablePath` duplicates `discoverClaudeExecutablePath` logic
+**Location:** `direct/src/works/iterative/claude/direct/ClaudeCode.scala:175-180`
+**Problem:** Structurally identical to `discoverClaudeExecutablePath` apart from the options type.
+**Recommendation:** Extract a shared private helper that takes `Option[String]` and handles CLI discovery.
+
+### Suggestions
+
+#### `SDKUserMessage` re-exported in `package.scala` but is an internal protocol detail
+**Location:** `direct/src/works/iterative/claude/direct/package.scala:13-14`
+**Recommendation:** Remove the re-export; import directly from `core.model` where needed.
+
+#### `Session.close()` returns `Unit` with no way to signal failure
+**Location:** `direct/src/works/iterative/claude/direct/Session.scala:30`
+**Recommendation:** Consider `Try[Unit]` or document best-effort semantics.
+
+</review>
+
+---
+
+<review skill="scala3">
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `package object` should be replaced with top-level definitions
+**Location:** `direct/src/works/iterative/claude/direct/package.scala:6`
+**Problem:** Uses `package object direct` which is a Scala 2 construct. In Scala 3, top-level type aliases and val definitions can be placed directly without wrapping.
+**Note:** This is pre-existing code, not introduced by this phase. Defer to a separate refactoring.
+
+#### `MockLogger` duplicated across all three test files
+**Location:** `SessionTest.scala`, `SessionIntegrationTest.scala`, `SessionE2ETest.scala`
+**Problem:** Identical `MockLogger` inner class copy-pasted into each test file.
+**Recommendation:** Extract to `internal/testing/MockLogger.scala`.
+
+### Suggestions
+
+#### `var` + `while` loop in `send` could use `boundary`/`break`
+**Location:** `SessionProcess.scala:166`
+**Note:** Minor given the `Flow.usingEmit` constraint. Current code is readable.
+
+#### `sessionId` typed as `String` — consider opaque type
+**Location:** `Session.scala:38`
+**Note:** Suggestion for follow-up, not a blocker.
+
+</review>
+
+---
+
+<review skill="composition">
+
+## Composition Patterns Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `readInitMessages` mutates `SessionProcess` internals directly
+**Location:** `SessionProcess.scala:155-185`
+**Problem:** Factory method directly mutates private state of the class it constructs.
+**Recommendation:** Have `readInitMessages` return `Option[String]` and let `start` apply the value.
+
+#### Two parallel `resolveExecutablePath` methods with near-identical logic
+**Location:** `ClaudeCode.scala:121-123` and `:175-179`
+**Recommendation:** Extract shared helper taking `Option[String]`.
+
+#### `stderrBuffer` is created but never read
+**Location:** `SessionProcess.scala:126-129`
+**Recommendation:** Remove buffer, simplify to logging-only.
+
+### Suggestions
+
+#### `send` mixes I/O writing with Flow construction
+**Note:** Minor — method is short enough. Consider extracting `writeMessage` if it grows.
+
+#### `configureSessionProcess` and `buildCliArguments` follow same pattern
+**Note:** No immediate action. Flag for review in next phase.
+
+</review>
+
+---
+
+<review skill="testing">
+
+## Testing Review
+
+### Critical Issues
+
+#### T1 is not a real test
+**Location:** `SessionTest.scala:455`
+**Problem:** The "Session trait compiles with expected method signatures" test creates `classOf[?]` values and asserts they are non-null, which always passes. It does not verify the Session trait has the right signatures.
+**Recommendation:** Either delete this test (compile-time check is sufficient) or replace with a test that exercises the trait through a real implementation.
+
+#### T7 close test asserts nothing meaningful
+**Location:** `SessionTest.scala:640`
+**Problem:** Test ends with `assert(true)`. The script used emits a result and exits — it is not a hanging script. The test does not verify close behavior.
+**Recommendation:** Use a hanging process script and add a deadline around `close()`. Assert the process is no longer alive.
+
+#### MockLogger duplicated across three test files
+**Location:** `SessionTest.scala:783`, `SessionIntegrationTest.scala:481`, `SessionE2ETest.scala:375`
+**Recommendation:** Extract to `internal/testing/MockLogger.scala`.
+
+### Warnings
+
+#### `Thread.sleep` inside integration test
+**Location:** `SessionIntegrationTest.scala:238`
+**Problem:** `Thread.sleep(50)` used for "file flush" timing. Coupling test correctness to wall-clock time.
+**Recommendation:** Ensure `close()` contract guarantees process exit. Remove sleep.
+
+#### IT3: Session ID extraction test does not exercise the session
+**Location:** `SessionIntegrationTest.scala:274`
+**Problem:** Checks `session.sessionId` without calling `send`. Unclear if init messages are consumed eagerly.
+**Recommendation:** Document the contract. If init is eager, add a comment. If lazy, call `send` first.
+
+#### Parallel cleanup calls on same path in `afterEach`
+**Location:** `SessionTest.scala:443`
+**Problem:** Both `MockCliScript.cleanup` and `SessionMockCliScript.cleanup` called on every path.
+**Recommendation:** Track which factory created each path, or use a single cleanup utility.
+
+#### No coverage for error paths
+**Problem:** No tests for non-zero exit, malformed JSON, error ResultMessage, or concurrent sends.
+**Recommendation:** Add at minimum one test for CLI process failure and one for error ResultMessage.
+
+### Suggestions
+
+#### `singleTurnSession` helper in `CommonResponses` is unused
+#### E2E tests duplicate CLI availability checks
+
+</review>
+
+---
+
+<review skill="style">
+
+## Code Style & Documentation Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+#### `sessionId` uses magic string sentinel instead of `Option`
+**Location:** `Session.scala:109`, `SessionProcess.scala:152`
+**Problem:** `"pending"` is used as a sentinel value. Callers cannot distinguish from a real value.
+**Recommendation:** Change return type to `Option[String]`.
+
+#### Instance method Scaladoc mentions "provided Ox scope" but it's from constructor
+**Location:** `ClaudeCode.scala:27-28`
+**Recommendation:** Adjust Scaladoc to say "Ox scope provided at construction."
+
+### Suggestions
+
+#### Test T1 tests nothing at runtime
+#### Scaladoc references string literal "pending" as part of contract
+#### Generated bash comment says "Auto-generated" — use descriptive comment instead
+
+</review>
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 3 |
+| Warnings | 10 |
+| Suggestions | 8 |
+
+**Critical issues** are all in test code (T1 vacuous test, T7 vacuous assertion, MockLogger duplication). No critical issues in production code.
+
+**Key warnings** cluster around:
+1. Dead `stderrBuffer` state (2 reviewers)
+2. `readInitMessages` mutation pattern (2 reviewers)
+3. Executable path resolution duplication (2 reviewers)
+4. Missing error path test coverage
+5. `sessionId` magic string vs `Option`
+
+**Recommendation:** Fix the 3 critical test issues and the top warnings (stderrBuffer removal, readInitMessages encapsulation, MockLogger extraction, error path tests). The remaining warnings and suggestions can be deferred.

--- a/project-management/issues/CC-15/review-phase-05-20260405-152422.md
+++ b/project-management/issues/CC-15/review-phase-05-20260405-152422.md
@@ -1,0 +1,57 @@
+# Code Review Results
+
+**Review Context:** Phase 5: Effectful API - Session lifecycle with Resource for issue CC-15 (Iteration 1/3)
+**Files Reviewed:** 8
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition, code-review-architecture
+**Timestamp:** 2026-04-05T15:24:22
+**Git Context:** git diff 16f38ed126cdd86d438472db9a336e85fbf230a5
+
+---
+
+## Critical Issues (2 — both fixed)
+
+### 1. Recursive stream accumulates stack (composition)
+**Location:** SessionProcess.scala — `SessionImpl.stream`
+**Problem:** `Stream.emit(msg) ++ stream` builds unbounded chain of continuations.
+**Fix:** Replaced with `Stream.fromQueueNoneTerminated(messageQueue).takeThrough(!_.isInstanceOf[ResultMessage])`.
+
+### 2. Duplicated executable discovery (composition, architecture)
+**Location:** ClaudeCode.scala — `discoverExecutableForSession` and `discoverExecutablePath`
+**Problem:** Identical CLI discovery logic in two methods with different wrapper types.
+**Fix:** Extracted shared `resolveExecutable(path: Option[String]): IO[String]` helper.
+
+---
+
+## Warnings Addressed (3)
+
+- **FiniteDuration string constructor:** `FiniteDuration(1000, "ms")` → `1.second`
+- **PURPOSE comment:** Removed implementation details, now describes responsibility
+- **T1 pure test in IO:** Removed unnecessary `IO { ... }` wrapper for pure assertions
+
+---
+
+## Warnings Deferred
+
+- **Cross-module test dependency** (`direct.internal.testing.SessionMockCliScript`): Would require build restructuring; acceptable for now, consider extracting to shared test-support module later
+- **Unbounded queues:** Back-pressure not needed for sequential CLI protocol; bounded queue is an optimization that can be added if memory issues arise
+- **`"pending"` sentinel vs Option[String]:** Matches direct API convention; changing to `Option` would be a cross-module API change
+- **IT9 duplicates IT1:** Minor maintenance cost; both tests document different concerns (factory vs lifecycle)
+- **Temp file cleanup not fully effect-safe:** Minor; files cleaned in guarantee block for scripts, capture files are small
+
+---
+
+## Suggestions Noted
+
+- Section divider comments in test files (visual noise)
+- Inline comments on queue semantics (redundant for fs2 idiom)
+- `package object` vs top-level definitions (pre-existing pattern)
+- `CLIDiscovery.findClaude` could use `using` for logger
+- `SessionImpl` could take `writeLine: String => IO[Unit]` instead of `Queue`
+
+---
+
+## Summary
+
+- **Critical Issues:** 2 (both fixed)
+- **Warnings:** 8 (3 fixed, 5 deferred with rationale)
+- **Suggestions:** 5 (noted, not blocking)

--- a/project-management/issues/CC-15/review-refactor-05-R1-20260405-144725.md
+++ b/project-management/issues/CC-15/review-refactor-05-R1-20260405-144725.md
@@ -1,0 +1,27 @@
+# Code Review Results
+
+**Review Context:** Phase 5: Effectful API - Session lifecycle with Resource for issue CC-15 - Refactoring R1 (Iteration 1/3)
+**Files Reviewed:** 5
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-04-05T14:47:25
+**Git Context:** git diff f9a14123514bd8e6101ad7a8e853f29a57a924c2
+
+---
+
+## Summary
+
+- **Critical Issues:** 3 (all triaged as out-of-scope or deliberate decisions)
+  - Composition: CQS split breaks composition → deliberate design decision per refactor-phase-05-R1.md, aligning with V2 SDK
+  - Testing: `stream()` without `send()` untested → new edge case, Phase 6 scope (error handling)
+  - Testing: `close()` without consuming stream untested → new edge case, Phase 6 scope
+- **Warnings:** 5 (3 addressed, 2 deferred)
+  - Duplicate Scaladoc on `readInitMessages` → **fixed**
+  - `caught != null` dead assertion in T7 → **fixed**
+  - PURPOSE comment stale → **fixed**
+  - `stream()` doc doesn't document violation behavior → deferred to Phase 6
+  - No guard on `stream()` without `send()` → deferred to Phase 6
+- **Suggestions:** 6 (all noted, none blocking)
+
+## Disposition
+
+No blocking critical issues. Three warnings addressed. Refactoring passes review.

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -32,12 +32,12 @@
       "path": "project-management/issues/CC-15/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-04T20:34:15.658050061Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-04T20:44:00.099486323Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 02: Tasks Ready",
+    "text": "Phase 02: Awaiting Review",
     "subtext": "SessionOptions configuration",
-    "type": "success"
+    "type": "warning"
   },
   "badges": [
     {
@@ -47,9 +47,17 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 02 tasks ready",
+  "message": "Phase 02 implementation started",
   "available_actions": [
     {
       "id": "implement",
@@ -60,6 +68,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "e68cf43",
@@ -71,6 +84,7 @@
       "context_sha": "e68cf43"
     }
   },
-  "needs_attention": false,
-  "activity": "waiting"
+  "needs_attention": true,
+  "activity": "waiting",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -66,14 +66,18 @@
     {
       "label": "Phase 6 Context",
       "path": "project-management/issues/CC-15/phase-06-context.md"
+    },
+    {
+      "label": "Phase 6 Tasks",
+      "path": "project-management/issues/CC-15/phase-06-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T14:05:09.383526851Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-05T14:06:36.655289737Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 6: Context Ready",
+    "text": "Phase 6: Tasks Ready",
     "subtext": "Error handling - process crash and malformed JSON",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -85,12 +89,17 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 6 context ready for review",
+  "message": "Phase 6 tasks ready",
   "available_actions": [
     {
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "ag-implement"
     }
   ],
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/27",
@@ -101,5 +110,5 @@
     }
   },
   "needs_attention": true,
-  "activity": "working"
+  "activity": "waiting"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -42,14 +42,18 @@
     {
       "label": "Phase 4 Context",
       "path": "project-management/issues/CC-15/phase-04-context.md"
+    },
+    {
+      "label": "Phase 4 Tasks",
+      "path": "project-management/issues/CC-15/phase-04-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T08:47:10.589926530Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-05T08:48:32.598944499Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 4: Context Ready",
+    "text": "Phase 4: Tasks Ready",
     "subtext": "Direct API - Multi-turn conversation",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -69,7 +73,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 4 context ready for review",
+  "message": "Phase 4 tasks ready",
   "available_actions": [
     {
       "id": "implement",
@@ -85,6 +89,11 @@
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "ag-implement"
     }
   ],
   "git_sha": "84ba56e",
@@ -94,6 +103,6 @@
     }
   },
   "needs_attention": true,
-  "activity": "working",
+  "activity": "waiting",
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/25"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -48,12 +48,12 @@
       "path": "project-management/issues/CC-15/phase-04-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T08:48:32.598944499Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-05T09:06:52.864139249Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 4: Tasks Ready",
+    "text": "Phase 04: Awaiting Review",
     "subtext": "Direct API - Multi-turn conversation",
-    "type": "success"
+    "type": "warning"
   },
   "badges": [
     {
@@ -71,9 +71,17 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 4 tasks ready",
+  "message": "Phase 04 implementation started",
   "available_actions": [
     {
       "id": "implement",
@@ -94,6 +102,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "84ba56e",
@@ -104,5 +117,5 @@
   },
   "needs_attention": true,
   "activity": "waiting",
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/25"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/26"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -11,14 +11,19 @@
       "label": "Tasks",
       "path": "project-management/issues/CC-15/tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Context",
+      "path": "project-management/issues/CC-15/phase-01-context.md",
+      "category": "output"
     }
   ],
-  "last_updated": "2026-04-04T16:05:26.013171675Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-04T18:02:55.007474+00:00",
+  "status": "context_ready",
   "display": {
-    "text": "Tasks Ready",
-    "type": "success",
-    "subtext": "6 phases identified"
+    "text": "Phase 1: Context Ready",
+    "subtext": "Stdin message format and response delimiting",
+    "type": "info"
   },
   "badges": [
     {
@@ -26,13 +31,18 @@
       "type": "info"
     }
   ],
-  "message": "Task breakdown complete. Ready to begin implementation.",
+  "message": "Phase 1 context ready for review",
   "available_actions": [
     {
       "id": "implement",
-      "label": "Start Implementation",
+      "label": "Continue",
       "skill": "ag-implement"
     }
   ],
-  "git_sha": "d7fa4b1"
+  "git_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567",
+  "phase_checkpoints": {
+    "1": {
+      "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"
+    }
+  }
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -16,14 +16,19 @@
       "label": "Phase 1 Context",
       "path": "project-management/issues/CC-15/phase-01-context.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Tasks",
+      "path": "project-management/issues/CC-15/phase-01-tasks.md",
+      "category": "output"
     }
   ],
-  "last_updated": "2026-04-04T18:02:55.007474+00:00",
-  "status": "context_ready",
+  "last_updated": "2026-04-04T18:04:37.957011+00:00",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 1: Context Ready",
+    "text": "Phase 1: Tasks Ready",
     "subtext": "Stdin message format and response delimiting",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -31,7 +36,7 @@
       "type": "info"
     }
   ],
-  "message": "Phase 1 context ready for review",
+  "message": "Phase 1 tasks ready",
   "available_actions": [
     {
       "id": "implement",
@@ -39,7 +44,7 @@
       "skill": "ag-implement"
     }
   ],
-  "git_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567",
+  "git_sha": "9d2559e7ce400a2863b74af28e3638e0fa5a34fa",
   "phase_checkpoints": {
     "1": {
       "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -21,14 +21,19 @@
       "label": "Phase 1 Tasks",
       "path": "project-management/issues/CC-15/phase-01-tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 2 Context",
+      "path": "project-management/issues/CC-15/phase-02-context.md",
+      "category": "output"
     }
   ],
-  "last_updated": "2026-04-04T18:34:34.967987359Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-04T21:00:00Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 01: Awaiting Review",
-    "subtext": "Stdin message format and response delimiting",
-    "type": "warning"
+    "text": "Phase 02: Context Ready",
+    "subtext": "SessionOptions configuration",
+    "type": "info"
   },
   "badges": [
     {
@@ -38,31 +43,25 @@
     {
       "label": "In Progress",
       "type": "info"
-    },
-    {
-      "label": "Review Needed",
-      "type": "warning"
     }
   ],
-  "message": "Phase 01 implementation started",
+  "message": "Phase 02 context ready for review",
   "available_actions": [
     {
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
-    },
-    {
-      "id": "view-pr",
-      "label": "View Pull Request",
-      "skill": "external-link"
     }
   ],
-  "git_sha": "9d2559e7ce400a2863b74af28e3638e0fa5a34fa",
+  "git_sha": "e68cf43",
   "phase_checkpoints": {
     "1": {
       "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"
+    },
+    "2": {
+      "context_sha": "e68cf43"
     }
   },
-  "needs_attention": true,
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/22"
+  "needs_attention": false,
+  "activity": "working"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -72,12 +72,12 @@
       "path": "project-management/issues/CC-15/phase-06-tasks.md"
     }
   ],
-  "last_updated": "2026-04-05T14:06:36.655289737Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-05T16:36:43.675517045Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 6: Tasks Ready",
+    "text": "Phase 06: Awaiting Review",
     "subtext": "Error handling - process crash and malformed JSON",
-    "type": "success"
+    "type": "warning"
   },
   "badges": [
     {
@@ -87,9 +87,17 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 6 tasks ready",
+  "message": "Phase 06 implementation started",
   "available_actions": [
     {
       "id": "view-pr",
@@ -100,9 +108,14 @@
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/27",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/28",
   "git_sha": "5aaabb3",
   "phase_checkpoints": {
     "6": {

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -46,13 +46,29 @@
     {
       "label": "Phase 4 Tasks",
       "path": "project-management/issues/CC-15/phase-04-tasks.md"
+    },
+    {
+      "label": "Phase 5 Context",
+      "path": "project-management/issues/CC-15/phase-05-context.md"
+    },
+    {
+      "label": "Phase 5 Tasks",
+      "path": "project-management/issues/CC-15/phase-05-tasks.md"
+    },
+    {
+      "label": "Review Packet Phase 5",
+      "path": "project-management/issues/CC-15/review-packet-phase-05.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-15/implementation-log.md"
     }
   ],
-  "last_updated": "2026-04-05T09:06:52.864139249Z",
+  "last_updated": "2026-04-05T15:35:00.000000000Z",
   "status": "awaiting_review",
   "display": {
-    "text": "Phase 04: Awaiting Review",
-    "subtext": "Direct API - Multi-turn conversation",
+    "text": "Phase 5: Awaiting Review",
+    "subtext": "Effectful API - Session lifecycle with Resource",
     "type": "warning"
   },
   "badges": [
@@ -61,61 +77,28 @@
       "type": "info"
     },
     {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
-      "label": "Review Needed",
-      "type": "warning"
-    },
-    {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
       "label": "Review Needed",
       "type": "warning"
     }
   ],
-  "message": "Phase 04 implementation started",
+  "message": "Phase 5 implementation complete - PR awaiting review",
   "available_actions": [
     {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
-      "id": "view-pr",
-      "label": "View Pull Request",
-      "skill": "external-link"
-    },
-    {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
     }
   ],
-  "git_sha": "84ba56e",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/27",
+  "git_sha": "5aaabb3",
   "phase_checkpoints": {
     "4": {
       "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
+    },
+    "5": {
+      "context_sha": "879e48a"
     }
   },
   "needs_attention": true,
-  "activity": "waiting",
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/26"
+  "activity": "waiting"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -13,71 +13,23 @@
       "category": "output"
     },
     {
-      "label": "Phase 1 Context",
-      "path": "project-management/issues/CC-15/phase-01-context.md",
-      "category": "output"
-    },
-    {
-      "label": "Phase 1 Tasks",
-      "path": "project-management/issues/CC-15/phase-01-tasks.md",
-      "category": "output"
-    },
-    {
-      "label": "Phase 2 Context",
-      "path": "project-management/issues/CC-15/phase-02-context.md",
-      "category": "output"
-    },
-    {
-      "label": "Phase 2 Tasks",
-      "path": "project-management/issues/CC-15/phase-02-tasks.md"
-    },
-    {
-      "label": "Phase 3 Context",
-      "path": "project-management/issues/CC-15/phase-03-context.md"
-    },
-    {
-      "label": "Phase 3 Tasks",
-      "path": "project-management/issues/CC-15/phase-03-tasks.md"
-    },
-    {
-      "label": "Phase 4 Context",
-      "path": "project-management/issues/CC-15/phase-04-context.md"
-    },
-    {
-      "label": "Phase 4 Tasks",
-      "path": "project-management/issues/CC-15/phase-04-tasks.md"
-    },
-    {
-      "label": "Phase 5 Context",
-      "path": "project-management/issues/CC-15/phase-05-context.md"
-    },
-    {
-      "label": "Phase 5 Tasks",
-      "path": "project-management/issues/CC-15/phase-05-tasks.md"
-    },
-    {
-      "label": "Review Packet Phase 5",
-      "path": "project-management/issues/CC-15/review-packet-phase-05.md"
-    },
-    {
       "label": "Implementation Log",
       "path": "project-management/issues/CC-15/implementation-log.md"
     },
     {
-      "label": "Phase 6 Context",
-      "path": "project-management/issues/CC-15/phase-06-context.md"
+      "label": "Release Notes",
+      "path": "project-management/issues/CC-15/release-notes.md"
     },
     {
-      "label": "Phase 6 Tasks",
-      "path": "project-management/issues/CC-15/phase-06-tasks.md"
+      "label": "Review Packet",
+      "path": "project-management/issues/CC-15/review-packet.md"
     }
   ],
-  "last_updated": "2026-04-05T16:36:43.675517045Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-05T17:09:32.020167486Z",
+  "status": "all_complete",
   "display": {
-    "text": "Phase 06: Awaiting Review",
-    "subtext": "Error handling - process crash and malformed JSON",
-    "type": "warning"
+    "text": "Ready for Final Review",
+    "type": "success"
   },
   "badges": [
     {
@@ -85,38 +37,20 @@
       "type": "info"
     },
     {
-      "label": "Review Needed",
-      "type": "warning"
-    },
-    {
-      "label": "In Progress",
-      "type": "info"
-    },
-    {
-      "label": "Review Needed",
-      "type": "warning"
+      "label": "All Phases Complete",
+      "type": "success"
     }
   ],
-  "message": "Phase 06 implementation started",
+  "message": "All phases complete - final PR created",
   "available_actions": [
     {
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
-    },
-    {
-      "id": "implement",
-      "label": "Continue",
-      "skill": "ag-implement"
-    },
-    {
-      "id": "view-pr",
-      "label": "View Pull Request",
-      "skill": "external-link"
     }
   ],
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/28",
-  "git_sha": "5aaabb3",
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/29",
+  "git_sha": "d48b24b",
   "phase_checkpoints": {
     "6": {
       "context_sha": "context_sha=8dec061ed906fd118124affbd3a634544ebe3915"

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -23,25 +23,38 @@
       "category": "output"
     }
   ],
-  "last_updated": "2026-04-04T18:04:37.957011+00:00",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-04T18:34:34.967987359Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 1: Tasks Ready",
+    "text": "Phase 01: Awaiting Review",
     "subtext": "Stdin message format and response delimiting",
-    "type": "success"
+    "type": "warning"
   },
   "badges": [
     {
       "label": "Feature",
       "type": "info"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 1 tasks ready",
+  "message": "Phase 01 implementation started",
   "available_actions": [
     {
       "id": "implement",
       "label": "Continue",
       "skill": "ag-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "9d2559e7ce400a2863b74af28e3638e0fa5a34fa",
@@ -49,5 +62,7 @@
     "1": {
       "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"
     }
-  }
+  },
+  "needs_attention": true,
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/22"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -1,0 +1,40 @@
+{
+  "version": 2,
+  "issue_id": "CC-15",
+  "artifacts": [
+    {
+      "label": "Analysis",
+      "path": "project-management/issues/CC-15/analysis.md",
+      "category": "input"
+    }
+  ],
+  "last_updated": "2026-04-02T20:59:51.806458551Z",
+  "status": "analysis_ready",
+  "display": {
+    "text": "Analysis Ready",
+    "type": "success",
+    "subtext": "6 stories across 3 iterations"
+  },
+  "badges": [
+    {
+      "label": "Feature",
+      "type": "info"
+    }
+  ],
+  "message": "Analysis complete - ready for task generation",
+  "activity": "waiting",
+  "workflow_type": "agile",
+  "available_actions": [
+    {
+      "id": "create-tasks",
+      "label": "Generate Tasks",
+      "skill": "ag-create-tasks"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "ag-implement"
+    }
+  ],
+  "git_sha": "77b116b"
+}

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -26,14 +26,18 @@
       "label": "Phase 2 Context",
       "path": "project-management/issues/CC-15/phase-02-context.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 2 Tasks",
+      "path": "project-management/issues/CC-15/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-04T21:00:00Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-04T20:34:15.658050061Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 02: Context Ready",
+    "text": "Phase 02: Tasks Ready",
     "subtext": "SessionOptions configuration",
-    "type": "info"
+    "type": "success"
   },
   "badges": [
     {
@@ -45,8 +49,13 @@
       "type": "info"
     }
   ],
-  "message": "Phase 02 context ready for review",
+  "message": "Phase 02 tasks ready",
   "available_actions": [
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "ag-implement"
+    },
     {
       "id": "implement",
       "label": "Continue",
@@ -63,5 +72,5 @@
     }
   },
   "needs_attention": false,
-  "activity": "working"
+  "activity": "waiting"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -62,14 +62,18 @@
     {
       "label": "Implementation Log",
       "path": "project-management/issues/CC-15/implementation-log.md"
+    },
+    {
+      "label": "Phase 6 Context",
+      "path": "project-management/issues/CC-15/phase-06-context.md"
     }
   ],
-  "last_updated": "2026-04-05T15:35:00.000000000Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-05T14:05:09.383526851Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 5: Awaiting Review",
-    "subtext": "Effectful API - Session lifecycle with Resource",
-    "type": "warning"
+    "text": "Phase 6: Context Ready",
+    "subtext": "Error handling - process crash and malformed JSON",
+    "type": "info"
   },
   "badges": [
     {
@@ -81,7 +85,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 5 implementation complete - PR awaiting review",
+  "message": "Phase 6 context ready for review",
   "available_actions": [
     {
       "id": "view-pr",
@@ -92,13 +96,10 @@
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/27",
   "git_sha": "5aaabb3",
   "phase_checkpoints": {
-    "4": {
-      "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
-    },
-    "5": {
-      "context_sha": "879e48a"
+    "6": {
+      "context_sha": "context_sha=8dec061ed906fd118124affbd3a634544ebe3915"
     }
   },
   "needs_attention": true,
-  "activity": "waiting"
+  "activity": "working"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -38,14 +38,18 @@
     {
       "label": "Phase 3 Tasks",
       "path": "project-management/issues/CC-15/phase-03-tasks.md"
+    },
+    {
+      "label": "Phase 4 Context",
+      "path": "project-management/issues/CC-15/phase-04-context.md"
     }
   ],
-  "last_updated": "2026-04-05T08:30:22.066627466Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-05T08:47:10.589926530Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 3: Awaiting Review",
-    "subtext": "Direct API - Basic session lifecycle",
-    "type": "warning"
+    "text": "Phase 4: Context Ready",
+    "subtext": "Direct API - Multi-turn conversation",
+    "type": "info"
   },
   "badges": [
     {
@@ -65,7 +69,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 3 PR awaiting review",
+  "message": "Phase 4 context ready for review",
   "available_actions": [
     {
       "id": "implement",
@@ -85,11 +89,11 @@
   ],
   "git_sha": "84ba56e",
   "phase_checkpoints": {
-    "3": {
-      "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
+    "4": {
+      "context_sha": "context_sha=3d291086f8fee0db86398641a747b6a1eedc6cd0"
     }
   },
   "needs_attention": true,
-  "activity": "waiting",
+  "activity": "working",
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/25"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -30,13 +30,21 @@
     {
       "label": "Phase 2 Tasks",
       "path": "project-management/issues/CC-15/phase-02-tasks.md"
+    },
+    {
+      "label": "Phase 3 Context",
+      "path": "project-management/issues/CC-15/phase-03-context.md"
+    },
+    {
+      "label": "Phase 3 Tasks",
+      "path": "project-management/issues/CC-15/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-04T20:44:00.099486323Z",
+  "last_updated": "2026-04-05T08:30:22.066627466Z",
   "status": "awaiting_review",
   "display": {
-    "text": "Phase 02: Awaiting Review",
-    "subtext": "SessionOptions configuration",
+    "text": "Phase 3: Awaiting Review",
+    "subtext": "Direct API - Basic session lifecycle",
     "type": "warning"
   },
   "badges": [
@@ -57,7 +65,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 02 implementation started",
+  "message": "Phase 3 PR awaiting review",
   "available_actions": [
     {
       "id": "implement",
@@ -75,16 +83,13 @@
       "skill": "external-link"
     }
   ],
-  "git_sha": "e68cf43",
+  "git_sha": "84ba56e",
   "phase_checkpoints": {
-    "1": {
-      "context_sha": "520a5bf5a3502155be2bae1e8152fa2e4b551567"
-    },
-    "2": {
-      "context_sha": "e68cf43"
+    "3": {
+      "context_sha": "context_sha=a57d892d9b461489e2e67059bfd6d4859f2d8376"
     }
   },
   "needs_attention": true,
   "activity": "waiting",
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/24"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/25"
 }

--- a/project-management/issues/CC-15/review-state.json
+++ b/project-management/issues/CC-15/review-state.json
@@ -6,14 +6,19 @@
       "label": "Analysis",
       "path": "project-management/issues/CC-15/analysis.md",
       "category": "input"
+    },
+    {
+      "label": "Tasks",
+      "path": "project-management/issues/CC-15/tasks.md",
+      "category": "output"
     }
   ],
-  "last_updated": "2026-04-02T20:59:51.806458551Z",
-  "status": "analysis_ready",
+  "last_updated": "2026-04-04T16:05:26.013171675Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Analysis Ready",
+    "text": "Tasks Ready",
     "type": "success",
-    "subtext": "6 stories across 3 iterations"
+    "subtext": "6 phases identified"
   },
   "badges": [
     {
@@ -21,20 +26,13 @@
       "type": "info"
     }
   ],
-  "message": "Analysis complete - ready for task generation",
-  "activity": "waiting",
-  "workflow_type": "agile",
+  "message": "Task breakdown complete. Ready to begin implementation.",
   "available_actions": [
-    {
-      "id": "create-tasks",
-      "label": "Generate Tasks",
-      "skill": "ag-create-tasks"
-    },
     {
       "id": "implement",
       "label": "Start Implementation",
       "skill": "ag-implement"
     }
   ],
-  "git_sha": "77b116b"
+  "git_sha": "d7fa4b1"
 }

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Tasks: Support persistent two-way conversations with a single Claude Code session
+
+**Issue:** CC-15
+**Created:** 2026-04-04
+**Status:** 0/6 phases complete (0%)
+
+## Phase Index
+
+- [ ] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
+- [ ] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
+- [ ] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
+- [ ] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
+- [ ] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
+- [ ] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
+
+## Progress Tracker
+
+**Completed:** 0/6 phases
+**Estimated Total:** 40-56 hours
+**Time Spent:** 0 hours
+
+## Notes
+
+- Phase context files generated just-in-time during implementation
+- Use ag-implement to start next phase automatically
+- Estimates are rough and will be refined during implementation
+- Phase 01 establishes the stream-json protocol types (SDKUserMessage, response delimiting via ResultMessage)
+- Phases 01 and 02 can proceed in parallel (independent foundations)
+- Phase 03 depends on Phases 01 and 02
+- Phase 04 depends on Phase 03
+- Phase 05 depends on Phases 01 and 02 (parallel to Phases 03-04)
+- Phase 06 depends on Phases 03 and 05

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,20 +2,20 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 2/6 phases complete (33%)
+**Status:** 3/6 phases complete (50%)
 
 ## Phase Index
 
 - [x] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
 - [x] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
-- [ ] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
+- [x] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
 - [ ] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
 - [ ] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
 - [ ] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
 
 ## Progress Tracker
 
-**Completed:** 2/6 phases
+**Completed:** 3/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,12 +2,12 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 1/6 phases complete (17%)
+**Status:** 2/6 phases complete (33%)
 
 ## Phase Index
 
 - [x] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
-- [ ] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
+- [x] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
 - [ ] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
 - [ ] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
 - [ ] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
@@ -15,7 +15,7 @@
 
 ## Progress Tracker
 
-**Completed:** 1/6 phases
+**Completed:** 2/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,7 +2,7 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 4/6 phases complete (67%)
+**Status:** 5/6 phases complete (83%)
 
 ## Phase Index
 
@@ -10,12 +10,12 @@
 - [x] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
 - [x] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
 - [x] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
-- [ ] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
+- [x] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
 - [ ] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
 
 ## Progress Tracker
 
-**Completed:** 4/6 phases
+**Completed:** 5/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,11 +2,11 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 0/6 phases complete (0%)
+**Status:** 1/6 phases complete (17%)
 
 ## Phase Index
 
-- [ ] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
+- [x] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
 - [ ] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
 - [ ] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
 - [ ] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
@@ -15,7 +15,7 @@
 
 ## Progress Tracker
 
-**Completed:** 0/6 phases
+**Completed:** 1/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,20 +2,20 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 3/6 phases complete (50%)
+**Status:** 4/6 phases complete (67%)
 
 ## Phase Index
 
 - [x] Phase 01: Stdin message format and response delimiting (Est: 6-8h) → `phase-01-context.md`
 - [x] Phase 02: SessionOptions configuration (Est: 4-6h) → `phase-02-context.md`
 - [x] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
-- [ ] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
+- [x] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
 - [ ] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
 - [ ] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
 
 ## Progress Tracker
 
-**Completed:** 3/6 phases
+**Completed:** 4/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-15/tasks.md
+++ b/project-management/issues/CC-15/tasks.md
@@ -2,7 +2,7 @@
 
 **Issue:** CC-15
 **Created:** 2026-04-04
-**Status:** 5/6 phases complete (83%)
+**Status:** 6/6 phases complete (100%)
 
 ## Phase Index
 
@@ -11,11 +11,11 @@
 - [x] Phase 03: Direct API - Basic session lifecycle (Est: 12-16h) → `phase-03-context.md`
 - [x] Phase 04: Direct API - Multi-turn conversation (Est: 4-6h) → `phase-04-context.md`
 - [x] Phase 05: Effectful API - Session lifecycle with Resource (Est: 8-12h) → `phase-05-context.md`
-- [ ] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
+- [x] Phase 06: Error handling - process crash and malformed JSON (Est: 6-8h) → `phase-06-context.md`
 
 ## Progress Tracker
 
-**Completed:** 5/6 phases
+**Completed:** 6/6 phases
 **Estimated Total:** 40-56 hours
 **Time Spent:** 0 hours
 


### PR DESCRIPTION
## Summary

- Adds persistent session support for the Claude Code CLI via `--input-format stream-json` protocol
- Both Direct (Ox) and Effectful (cats-effect/fs2) APIs now expose `ClaudeCode.session(SessionOptions)` factory methods
- Sessions support multi-turn conversations, typed error handling (process crash, closed session, malformed JSON recovery), and automatic process lifecycle management

## Implementation

Implemented in 6 phases:

1. **Stdin message format** — `SDKUserMessage` encoder, `KeepAlive`/`StreamEvent` message types, `JsonParser` extensions
2. **SessionOptions** — Configuration case class with 18 fields, `CLIArgumentBuilder.buildSessionArgs`
3. **Direct API session lifecycle** — `Session` trait with `send`/`stream` (CQS), `SessionProcess` implementation
4. **Multi-turn conversation** — Validated multi-turn works correctly (test-only phase)
5. **Effectful API session lifecycle** — `Resource[IO, Session]`, `Queue`-based stdin bridge, fs2 `Stream`s
6. **Error handling** — `SessionProcessDied`, `SessionClosedError`, liveness tracking, malformed JSON recovery

Mid-phase refactoring R1 split `Session.send` into `send` + `stream` (command-query separation, matching Claude Agent SDK V2).

## Stats

- 63 files changed, ~8480 lines added
- 23 new source/test files, 10 modified
- Comprehensive test coverage: unit, integration (mock CLI scripts), and E2E (real CLI)

## Backward Compatibility

Purely additive — existing `query`/`querySync`/`queryResult` APIs unchanged.

## Test plan

- [x] All unit tests pass (`./mill __.test`)
- [x] Integration tests use mock CLI scripts simulating stream-json protocol
- [x] E2E tests validate against real Claude Code CLI (gated on CLI availability)
- [x] Error scenarios: process crash mid-turn, crash between turns, malformed JSON, closed session
- [ ] Manual review of review packet: `project-management/issues/CC-15/review-packet.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)