### PR TITLE
Phase 1: Fix entry type name mismatches

### DIFF
--- a/core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
+++ b/core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
@@ -42,6 +42,14 @@ case class LastPromptLogEntry(
     data: Map[String, Any]
 ) extends LogEntryPayload
 
+case class PermissionModeLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
+case class AttachmentLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
 case class RawLogEntry(
     entryType: String,
     json: Json

--- a/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
@@ -66,15 +66,19 @@ object ConversationLogParser:
       json: Json
   ): Option[LogEntryPayload] =
     entryType match
-      case "human"                 => parseUserPayload(cursor)
+      case "user"                  => parseUserPayload(cursor)
       case "assistant"             => parseAssistantPayload(cursor)
       case "system"                => parseSystemPayload(cursor, json)
       case "progress"              => Some(parseProgressPayload(cursor, json))
-      case "queue_operation"       => parseQueueOperationPayload(cursor)
-      case "file_history_snapshot" =>
+      case "queue-operation"       => parseQueueOperationPayload(cursor)
+      case "file-history-snapshot" =>
         Some(parseDataOnlyPayload(json, FileHistorySnapshotLogEntry.apply))
       case "last_prompt" =>
         Some(parseDataOnlyPayload(json, LastPromptLogEntry.apply))
+      case "permission-mode" =>
+        Some(parseDataOnlyPayload(json, PermissionModeLogEntry.apply))
+      case "attachment" =>
+        Some(parseDataOnlyPayload(json, AttachmentLogEntry.apply))
       case _ => Some(RawLogEntry(entryType, json))
 
   private def parseContentBlocks(cursor: HCursor): List[ContentBlock] =

--- a/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
@@ -15,7 +15,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parseLogLine with valid JSONL line returns Some(ConversationLogEntry)"):
     val line =
-      """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+      """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     assert(
       result.isDefined,
@@ -30,19 +30,19 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parseLogLine with invalid JSON returns None"):
     assertEquals(
-      ConversationLogParser.parseLogLine("""{"type": "human", malformed}"""),
+      ConversationLogParser.parseLogLine("""{"type": "user", malformed}"""),
       None
     )
 
   test("parseLogEntry with missing required uuid field returns None"):
     val json = parser
-      .parse("""{"type":"human","sessionId":"s1","message":{"content":"hi"}}""")
+      .parse("""{"type":"user","sessionId":"s1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
     assertEquals(ConversationLogParser.parseLogEntry(json), None)
 
   test("parseLogEntry with missing required sessionId field returns None"):
     val json = parser
-      .parse("""{"type":"human","uuid":"u1","message":{"content":"hi"}}""")
+      .parse("""{"type":"user","uuid":"u1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
     assertEquals(ConversationLogParser.parseLogEntry(json), None)
 
@@ -51,7 +51,7 @@ class ConversationLogParserTest extends FunSuite:
   test("parses all envelope metadata fields"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"uuid-001",
         "parentUuid":"parent-uuid-000",
         "timestamp":"2024-01-15T10:30:00Z",
@@ -78,7 +78,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parses with optional fields absent"):
     val line =
-      """{"type":"human","uuid":"u2","sessionId":"s2","message":{"content":"hi"}}"""
+      """{"type":"user","uuid":"u2","sessionId":"s2","message":{"content":"hi"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) =>
@@ -91,7 +91,7 @@ class ConversationLogParserTest extends FunSuite:
   test("parses ISO-8601 timestamp string to Instant"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u3",
         "sessionId":"s3",
         "timestamp":"2025-06-01T12:00:00.000Z",
@@ -108,7 +108,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("isSidechain defaults to false when absent"):
     val line =
-      """{"type":"human","uuid":"u4","sessionId":"s4","message":{"content":"x"}}"""
+      """{"type":"user","uuid":"u4","sessionId":"s4","message":{"content":"x"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) => assertEquals(entry.isSidechain, false)
@@ -117,10 +117,10 @@ class ConversationLogParserTest extends FunSuite:
   // --- Payload type tests ---
 
   test(
-    """"human" type with string content produces UserLogEntry with List(TextBlock)"""
+    """"user" type with string content produces UserLogEntry with List(TextBlock)"""
   ):
     val line =
-      """{"type":"human","uuid":"u5","sessionId":"s5","message":{"content":"hello world"}}"""
+      """{"type":"user","uuid":"u5","sessionId":"s5","message":{"content":"hello world"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(
@@ -131,11 +131,11 @@ class ConversationLogParserTest extends FunSuite:
       case None        => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"human" type with array content produces UserLogEntry with parsed content blocks"""
+    """"user" type with array content produces UserLogEntry with parsed content blocks"""
   ):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u6",
         "sessionId":"s6",
         "message":{
@@ -305,11 +305,11 @@ class ConversationLogParserTest extends FunSuite:
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"queue_operation" type with operation and content produces QueueOperationLogEntry"""
+    """"queue-operation" type with operation and content produces QueueOperationLogEntry"""
   ):
     val line =
       """{
-        "type":"queue_operation",
+        "type":"queue-operation",
         "uuid":"u11",
         "sessionId":"s11",
         "operation":"enqueue",
@@ -337,11 +337,11 @@ class ConversationLogParserTest extends FunSuite:
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"file_history_snapshot" type with data produces FileHistorySnapshotLogEntry"""
+    """"file-history-snapshot" type with data produces FileHistorySnapshotLogEntry"""
   ):
     val line =
       """{
-        "type":"file_history_snapshot",
+        "type":"file-history-snapshot",
         "uuid":"u12",
         "sessionId":"s12",
         "files":["/a.txt","/b.txt"]
@@ -382,6 +382,66 @@ class ConversationLogParserTest extends FunSuite:
         assertEquals(data("promptText"), "what is 2+2?")
       case Some(entry) =>
         fail(s"Expected LastPromptLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"permission-mode" type with data produces PermissionModeLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"permission-mode",
+        "uuid":"u43",
+        "sessionId":"s43",
+        "permissionMode":"default"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              PermissionModeLogEntry(data),
+              _
+            )
+          ) =>
+        assertEquals(data("permissionMode"), "default")
+      case Some(entry) =>
+        fail(s"Expected PermissionModeLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"attachment" type with data produces AttachmentLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"attachment",
+        "uuid":"u44",
+        "sessionId":"s44",
+        "fileName":"foo.txt"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AttachmentLogEntry(data),
+              _
+            )
+          ) =>
+        assertEquals(data("fileName"), "foo.txt")
+      case Some(entry) =>
+        fail(s"Expected AttachmentLogEntry, got: ${entry.payload}")
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test("unknown type produces RawLogEntry with preserved JSON"):
@@ -501,21 +561,33 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"queue_operation\" type without operation returns None"):
+  test("\"queue-operation\" type without operation returns None"):
     val line =
-      """{"type":"queue_operation","uuid":"u21","sessionId":"s21","content":"msg"}"""
+      """{"type":"queue-operation","uuid":"u21","sessionId":"s21","content":"msg"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"human\" type without message field returns None"):
+  test("\"user\" type without message field returns None"):
     val line =
-      """{"type":"human","uuid":"u22","sessionId":"s22"}"""
+      """{"type":"user","uuid":"u22","sessionId":"s22"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
   test("\"assistant\" type without message field returns None"):
     val line =
       """{"type":"assistant","uuid":"u23","sessionId":"s23"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"permission-mode\" type without uuid returns None"):
+    val line =
+      """{"type":"permission-mode","sessionId":"s43","permissionMode":"default"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"attachment\" type without uuid returns None"):
+    val line =
+      """{"type":"attachment","sessionId":"s44","fileName":"foo.txt"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
@@ -530,7 +602,7 @@ class ConversationLogParserTest extends FunSuite:
   test("JSONL line with agentId field extracts Some(agentId)"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u30",
         "sessionId":"s30",
         "agentId":"agent-abc-123",
@@ -543,7 +615,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("JSONL line without agentId field extracts None"):
     val line =
-      """{"type":"human","uuid":"u31","sessionId":"s31","message":{"content":"hi"}}"""
+      """{"type":"user","uuid":"u31","sessionId":"s31","message":{"content":"hi"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) => assertEquals(entry.agentId, None)
@@ -587,7 +659,7 @@ class ConversationLogParserTest extends FunSuite:
   test("malformed timestamp string results in None timestamp"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u25",
         "sessionId":"s25",
         "timestamp":"not-a-date",
@@ -597,3 +669,4 @@ class ConversationLogParserTest extends FunSuite:
     result match
       case Some(entry) => assertEquals(entry.timestamp, None)
       case None        => fail("Expected Some(ConversationLogEntry)")
+

--- a/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
@@ -11,8 +11,8 @@ class DirectConversationLogReaderTest extends FunSuite:
 
   private val reader = DirectConversationLogReader()
 
-  private val humanLine =
-    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val userLine =
+    """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
   private val assistantLine =
     """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
   private val systemLine =
@@ -38,8 +38,8 @@ class DirectConversationLogReaderTest extends FunSuite:
       val result = reader.readAll(path)
       assertEquals(result, List.empty[ConversationLogEntry])
 
-  test("readAll parses a single human entry"):
-    withLogFile(List(humanLine)): path =>
+  test("readAll parses a single user entry"):
+    withLogFile(List(userLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 1)
       assertEquals(result.head.sessionId, "s1")
@@ -49,29 +49,29 @@ class DirectConversationLogReaderTest extends FunSuite:
       )
 
   test("readAll parses multiple entries of different types"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 3)
 
   test("readAll preserves order of entries"):
-    withLogFile(List(humanLine, assistantLine)): path =>
+    withLogFile(List(userLine, assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
       assert(result(0).payload.isInstanceOf[UserLogEntry])
       assert(result(1).payload.isInstanceOf[AssistantLogEntry])
 
   test("readAll skips malformed JSON lines silently"):
-    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+    withLogFile(List(userLine, "{bad json}", assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
 
   test("readAll handles mixed blank and valid lines"):
-    withLogFile(List(emptyLine, humanLine, blankLine, assistantLine)): path =>
+    withLogFile(List(emptyLine, userLine, blankLine, assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
 
   test("stream produces same entries as readAll"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       val fromReadAll = reader.readAll(path)
       val fromStream = supervised:
         reader.stream(path).runToList()
@@ -85,7 +85,7 @@ class DirectConversationLogReaderTest extends FunSuite:
 
   test("stream skips blank and malformed lines"):
     withLogFile(
-      List(emptyLine, humanLine, "{not json}", blankLine, assistantLine)
+      List(emptyLine, userLine, "{not json}", blankLine, assistantLine)
     ): path =>
       val result = supervised:
         reader.stream(path).runToList()

--- a/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
@@ -11,8 +11,8 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
 
   private val reader = EffectfulConversationLogReader()
 
-  private val humanLine =
-    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val userLine =
+    """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
   private val assistantLine =
     """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
   private val systemLine =
@@ -40,8 +40,8 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
         .map: result =>
           assertEquals(result, List.empty[ConversationLogEntry])
 
-  test("readAll parses a single human entry"):
-    withLogFile(List(humanLine)): path =>
+  test("readAll parses a single user entry"):
+    withLogFile(List(userLine)): path =>
       reader
         .readAll(path)
         .map: result =>
@@ -53,14 +53,14 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           )
 
   test("readAll parses multiple entries of different types"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       reader
         .readAll(path)
         .map: result =>
           assertEquals(result.length, 3)
 
   test("readAll preserves order of entries"):
-    withLogFile(List(humanLine, assistantLine)): path =>
+    withLogFile(List(userLine, assistantLine)): path =>
       reader
         .readAll(path)
         .map: result =>
@@ -69,14 +69,14 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           assert(result(1).payload.isInstanceOf[AssistantLogEntry])
 
   test("readAll skips malformed JSON lines silently"):
-    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+    withLogFile(List(userLine, "{bad json}", assistantLine)): path =>
       reader
         .readAll(path)
         .map: result =>
           assertEquals(result.length, 2)
 
   test("stream produces same entries as readAll"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       for
         fromReadAll <- reader.readAll(path)
         fromStream <- reader.stream(path).compile.toList
@@ -92,7 +92,7 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           assertEquals(result, List.empty[ConversationLogEntry])
 
   test("stream skips blank and malformed lines"):
-    withLogFile(List("", humanLine, "{not json}", "   ", assistantLine)):
+    withLogFile(List("", userLine, "{not json}", "   ", assistantLine)):
       path =>
         reader
           .stream(path)

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -1,0 +1,35 @@
+# Implementation Log: Parser mismatches
+
+Issue: CC-41
+
+This log tracks the evolution of investigation and fixes across phases.
+
+---
+
+## Phase 1: Fix entry type name mismatches in ConversationLogParser (2026-04-10)
+
+**Root cause:** The type name strings in `parsePayload` match expression were written using assumed Anthropic API conventions (`"human"`, underscores) rather than actual Claude Code CLI format (`"user"`, hyphens). Test fixtures used the same wrong names, so tests passed but didn't reflect real data.
+
+**Fix applied:**
+- `ConversationLogParser.scala` — fixed 3 type name strings (`"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`), added 2 new match cases for `"permission-mode"` and `"attachment"` using existing `parseDataOnlyPayload` helper
+- `LogEntryPayload.scala` — added `PermissionModeLogEntry` and `AttachmentLogEntry` case classes with `data: Map[String, Any]`
+- `ConversationLogParserTest.scala` — updated all fixtures to correct type names, added tests for new types with data assertions and error path coverage
+
+**Regression tests added:**
+- 4 new tests (2 happy path with data assertions, 2 error path for missing uuid)
+
+**Code review:**
+- Iterations: 1 (critical issues fixed: removed duplicate tests, added data assertions, added error path tests)
+- Review file: review-phase-01-20260410-205956.md
+
+**Notes:**
+- `last_prompt` match case still uses underscore — reviewers flagged as potential same-class bug but out of scope for this phase (needs verification against real data)
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
+M	core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -14,6 +14,8 @@ This log tracks the evolution of investigation and fixes across phases.
 - `ConversationLogParser.scala` — fixed 3 type name strings (`"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`), added 2 new match cases for `"permission-mode"` and `"attachment"` using existing `parseDataOnlyPayload` helper
 - `LogEntryPayload.scala` — added `PermissionModeLogEntry` and `AttachmentLogEntry` case classes with `data: Map[String, Any]`
 - `ConversationLogParserTest.scala` — updated all fixtures to correct type names, added tests for new types with data assertions and error path coverage
+- `DirectConversationLogReaderTest.scala` — updated fixture from `"human"` to `"user"`
+- `EffectfulConversationLogReaderTest.scala` — updated fixture from `"human"` to `"user"`
 
 **Regression tests added:**
 - 4 new tests (2 happy path with data assertions, 2 error path for missing uuid)
@@ -30,6 +32,8 @@ This log tracks the evolution of investigation and fixes across phases.
 M	core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
 M	core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
 M	core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+M	direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
 ```
 
 ---

--- a/project-management/issues/CC-41/phase-01-tasks.md
+++ b/project-management/issues/CC-41/phase-01-tasks.md
@@ -2,10 +2,11 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing tests reproducing the type name mismatches (`"user"` → `RawLogEntry` instead of `UserLogEntry`, `"queue-operation"` → `RawLogEntry` instead of `QueueOperationLogEntry`, `"file-history-snapshot"` → `RawLogEntry` instead of `FileHistorySnapshotLogEntry`)
-- [ ] [impl] [ ] [reviewed] Write failing tests for unhandled entry types (`"permission-mode"` and `"attachment"` fall through to `RawLogEntry`)
-- [ ] [impl] [ ] [reviewed] Fix type name strings in `ConversationLogParser.parsePayload`: `"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`
-- [ ] [impl] [ ] [reviewed] Add model types for `PermissionModeLogEntry` and `AttachmentLogEntry` in `LogEntryPayload.scala`
-- [ ] [impl] [ ] [reviewed] Add match cases for `"permission-mode"` and `"attachment"` in `parsePayload`
-- [ ] [impl] [ ] [reviewed] Update all existing test fixtures to use correct type names (`"user"`, `"queue-operation"`, `"file-history-snapshot"`) and update test descriptions
-- [ ] [impl] [ ] [reviewed] Verify all tests pass and no compilation warnings (`./mill core.compile` and `./mill core.test`)
+- [x] [impl] [x] [reviewed] Write failing tests reproducing the type name mismatches (`"user"` → `RawLogEntry` instead of `UserLogEntry`, `"queue-operation"` → `RawLogEntry` instead of `QueueOperationLogEntry`, `"file-history-snapshot"` → `RawLogEntry` instead of `FileHistorySnapshotLogEntry`)
+- [x] [impl] [x] [reviewed] Write failing tests for unhandled entry types (`"permission-mode"` and `"attachment"` fall through to `RawLogEntry`)
+- [x] [impl] [x] [reviewed] Fix type name strings in `ConversationLogParser.parsePayload`: `"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`
+- [x] [impl] [x] [reviewed] Add model types for `PermissionModeLogEntry` and `AttachmentLogEntry` in `LogEntryPayload.scala`
+- [x] [impl] [x] [reviewed] Add match cases for `"permission-mode"` and `"attachment"` in `parsePayload`
+- [x] [impl] [x] [reviewed] Update all existing test fixtures to use correct type names (`"user"`, `"queue-operation"`, `"file-history-snapshot"`) and update test descriptions
+- [x] [impl] [x] [reviewed] Verify all tests pass and no compilation warnings (`./mill core.compile` and `./mill core.test`)
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/review-phase-01-20260410-205956.md
+++ b/project-management/issues/CC-41/review-phase-01-20260410-205956.md
@@ -1,0 +1,75 @@
+# Code Review Results
+
+**Review Context:** Phase 1: Fix entry type name mismatches in ConversationLogParser for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 3
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-architecture
+**Timestamp:** 2026-04-10T20:59:56Z
+**Git Context:** git diff 0856ccd
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` uses underscore while all corrected types use hyphens — may be latent bug of same class
+- Stale `"human"` in invalid JSON test fixture (line 33)
+
+### Suggestions
+- Trailing spaces in match arms
+- Regression test section comment uses temporal framing
+
+---
+
+## Testing Review
+
+### Critical Issues
+- Regression tests for `user`, `queue-operation`, `file-history-snapshot` duplicate existing updated tests
+- `permission-mode` and `attachment` tests don't verify data contents
+- No error path tests for `permission-mode` and `attachment`
+
+### Warnings
+- `last_prompt` should be verified against real wire format
+
+### Suggestions
+- Rename regression section comment
+
+---
+
+## Scala 3 Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` underscore inconsistency (same as style review)
+
+### Suggestions
+- `LogEntryPayload` could be Scala 3 enum (future refactor)
+- `Map[String, Any]` pattern is pre-existing debt
+
+---
+
+## Architecture Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` inconsistency (same finding)
+- `Map[String, Any]` deepens weak typing (pre-existing, out of scope)
+
+### Suggestions
+- Test duplication and temporal naming in regression section
+
+---
+
+## Summary
+
+- **Critical issues:** 3 (all testing — duplicate tests, missing data assertions, missing error path tests)
+- **Warnings:** 6 (most cross-cutting: `last_prompt` naming inconsistency)
+- **Suggestions:** 5 (mostly out of scope / pre-existing patterns)
+
+Note: `last_prompt` naming is a valid concern but out of scope for Phase 1 (which fixes known mismatches from real data analysis). Should be tracked as potential follow-up.

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -21,20 +21,24 @@
       "path": "project-management/issues/CC-41/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T20:41:05.367633319Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T20:57:20.554212156Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 1: Tasks Ready",
-    "type": "success",
+    "text": "Phase 01: Implementing",
+    "type": "progress",
     "subtext": "Fix entry type name mismatches in ConversationLogParser"
   },
   "badges": [
     {
       "label": "High",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ],
-  "message": "Phase 1 tasks ready",
+  "message": "Phase 01 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -21,11 +21,11 @@
       "path": "project-management/issues/CC-41/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T20:57:20.554212156Z",
-  "status": "implementing",
+  "last_updated": "2026-04-10T21:07:23.943780008Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 01: Implementing",
-    "type": "progress",
+    "text": "Phase 01: Awaiting Review",
+    "type": "warning",
     "subtext": "Fix entry type name mismatches in ConversationLogParser"
   },
   "badges": [
@@ -36,6 +36,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
   "message": "Phase 01 implementation started",
@@ -61,6 +65,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -69,5 +78,6 @@
     "1": {
       "context_sha": "context_sha=97133ae79e91cdccb9f63747b036035553a02842"
     }
-  }
+  },
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/42"
 }


### PR DESCRIPTION
Phase 01 implementation for CC-41.

### Files
Browse changed files: https://github.com/iterative-works/claude-code-query/blob/CC-41-phase-01/