### PR TITLE
Phase 2: Derive agentId from transcript filename

### DIFF
--- a/core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Pure parser for sub-agent .meta.json sidecar files into SubAgentMetadata
-// PURPOSE: Returns None for missing required fields or unparseable input
+// PURPOSE: Returns None only for null JSON input; agentType and description are optional fields
 
 package works.iterative.claude.core.log.parsing
 
@@ -9,11 +9,10 @@ import works.iterative.claude.core.log.model.SubAgentMetadata
 object SubAgentMetadataParser:
 
   def parse(json: Json, transcriptPath: os.Path): Option[SubAgentMetadata] =
-    val cursor = json.hcursor
-    for agentId <- cursor.get[String]("agentId").toOption
-    yield SubAgentMetadata(
-      agentId = agentId,
-      agentType = cursor.get[String]("agentType").toOption,
-      description = cursor.get[String]("description").toOption,
-      transcriptPath = transcriptPath
-    )
+    Option.when(!json.isNull):
+      SubAgentMetadata(
+        agentId = transcriptPath.last.stripSuffix(".jsonl"),
+        agentType = json.hcursor.get[String]("agentType").toOption,
+        description = json.hcursor.get[String]("description").toOption,
+        transcriptPath = transcriptPath
+      )

--- a/core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
@@ -8,12 +8,11 @@ import io.circe.parser
 
 class SubAgentMetadataParserTest extends FunSuite:
 
-  private val transcriptPath = os.Path("/tmp/subagents/agent-abc/transcript.jsonl")
+  private val transcriptPath = os.Path("/tmp/subagents/agent-abc123.jsonl")
 
-  test("valid JSON with all fields returns Some(SubAgentMetadata)"):
+  test("JSON with agentType and description returns fully populated SubAgentMetadata"):
     val json = parser
       .parse("""{
-        "agentId": "agent-abc-123",
         "agentType": "coder",
         "description": "Writes Scala code"
       }""")
@@ -21,49 +20,79 @@ class SubAgentMetadataParserTest extends FunSuite:
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
     result match
       case Some(meta) =>
-        assertEquals(meta.agentId, "agent-abc-123")
+        assertEquals(meta.agentId, "agent-abc123")
         assertEquals(meta.agentType, Some("coder"))
         assertEquals(meta.description, Some("Writes Scala code"))
         assertEquals(meta.transcriptPath, transcriptPath)
       case None => fail("Expected Some(SubAgentMetadata)")
 
-  test("JSON with only required agentId returns Some with None optional fields"):
+  test("JSON with no optional fields returns Some with agentId from filename and None optional fields"):
     val json = parser
-      .parse("""{"agentId": "agent-xyz"}""")
+      .parse("""{}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
     result match
       case Some(meta) =>
-        assertEquals(meta.agentId, "agent-xyz")
+        assertEquals(meta.agentId, "agent-abc123")
         assertEquals(meta.agentType, None)
         assertEquals(meta.description, None)
         assertEquals(meta.transcriptPath, transcriptPath)
       case None => fail("Expected Some(SubAgentMetadata)")
 
-  test("JSON missing required agentId returns None"):
+  test("JSON with only agentType and description returns Some"):
     val json = parser
       .parse("""{"agentType": "coder", "description": "Does stuff"}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
-    assertEquals(result, None)
-
-  test("empty JSON object returns None"):
-    val json = parser
-      .parse("""{}""")
-      .getOrElse(fail("parse failed"))
-    val result = SubAgentMetadataParser.parse(json, transcriptPath)
-    assertEquals(result, None)
+    result match
+      case Some(meta) =>
+        assertEquals(meta.agentId, "agent-abc123")
+        assertEquals(meta.agentType, Some("coder"))
+        assertEquals(meta.description, Some("Does stuff"))
+      case None => fail("Expected Some(SubAgentMetadata)")
 
   test("JSON null returns None"):
     val result = SubAgentMetadataParser.parse(io.circe.Json.Null, transcriptPath)
     assertEquals(result, None)
 
   test("transcriptPath is stored in parsed SubAgentMetadata"):
-    val customPath = os.Path("/home/user/.claude/projects/session/subagents/agent-1/transcript.jsonl")
+    val customPath = os.Path("/home/user/.claude/projects/session/subagents/agent-xyz789.jsonl")
     val json = parser
-      .parse("""{"agentId": "agent-1"}""")
+      .parse("""{}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, customPath)
     result match
       case Some(meta) => assertEquals(meta.transcriptPath, customPath)
       case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("agentId is derived from transcript filename, not from JSON"):
+    val pathWithId = os.Path("/tmp/agent-derived-id.jsonl")
+    val json = parser
+      .parse("""{"agentType": "coder"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, pathWithId)
+    result match
+      case Some(meta) => assertEquals(meta.agentId, "agent-derived-id")
+      case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("agentId in JSON is ignored; filename is used instead"):
+    val json = parser
+      .parse("""{"agentId": "should-be-ignored", "agentType": "coder"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, transcriptPath)
+    result match
+      case Some(meta) => assertEquals(meta.agentId, "agent-abc123")
+      case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("real-world .meta.json content without agentId returns Some with agentId from filename"):
+    val realWorldPath = os.Path("/tmp/subagents/agent-a27a237ab9050d9ef.jsonl")
+    val json = parser
+      .parse("""{"agentType":"iterative-works:code-reviewer","description":"Review security of phase 07"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, realWorldPath)
+    result match
+      case Some(meta) =>
+        assertEquals(meta.agentId, "agent-a27a237ab9050d9ef")
+        assertEquals(meta.agentType, Some("iterative-works:code-reviewer"))
+        assertEquals(meta.description, Some("Review security of phase 07"))
+      case None => fail("Expected Some(SubAgentMetadata) for real-world .meta.json content")

--- a/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
@@ -162,7 +162,7 @@ class DirectConversationLogIndexTest extends FunSuite:
     ): projectDir =>
       val result = index.listSubAgents(projectDir, "sess-2")
       assertEquals(result.length, 1)
-      assertEquals(result.head.agentId, "abc")
+      assertEquals(result.head.agentId, "agent-abc")
 
   test("listSubAgents populates all metadata fields from .meta.json"):
     withSubAgentsDir(
@@ -179,7 +179,7 @@ class DirectConversationLogIndexTest extends FunSuite:
       val result = index.listSubAgents(projectDir, "sess-3")
       assertEquals(result.length, 1)
       val meta = result.head
-      assertEquals(meta.agentId, "abc")
+      assertEquals(meta.agentId, "agent-abc")
       assertEquals(meta.agentType, Some("researcher"))
       assertEquals(meta.description, Some("Does research"))
 
@@ -223,7 +223,7 @@ class DirectConversationLogIndexTest extends FunSuite:
     ): projectDir =>
       val result = index.listSubAgents(projectDir, "sess-7")
       assertEquals(result.length, 3)
-      assertEquals(result.map(_.agentId).toSet, Set("aaa", "bbb", "ccc"))
+      assertEquals(result.map(_.agentId).toSet, Set("agent-aaa", "agent-bbb", "agent-ccc"))
 
   test("listSubAgents ignores non-agent files in subagents directory"):
     val tmpRoot = os.temp.dir()
@@ -236,5 +236,5 @@ class DirectConversationLogIndexTest extends FunSuite:
       os.write(subagentsDir / "notes.txt", "irrelevant")
       val result = index.listSubAgents(projectDir, "sess-8")
       assertEquals(result.length, 1)
-      assertEquals(result.head.agentId, "abc")
+      assertEquals(result.head.agentId, "agent-abc")
     finally os.remove.all(tmpRoot)

--- a/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
@@ -163,7 +163,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .listSubAgents(projectDir, "sess-2")
         .map: result =>
           assertEquals(result.length, 1)
-          assertEquals(result.head.agentId, "abc")
+          assertEquals(result.head.agentId, "agent-abc")
 
   test("listSubAgents populates all metadata fields from .meta.json"):
     withSubAgentsDir(
@@ -186,7 +186,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .map: result =>
           assertEquals(result.length, 1)
           val meta = result.head
-          assertEquals(meta.agentId, "abc")
+          assertEquals(meta.agentId, "agent-abc")
           assertEquals(meta.agentType, Some("researcher"))
           assertEquals(meta.description, Some("Does research"))
 
@@ -237,7 +237,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .listSubAgents(projectDir, "sess-7")
         .map: result =>
           assertEquals(result.length, 3)
-          assertEquals(result.map(_.agentId).toSet, Set("aaa", "bbb", "ccc"))
+          assertEquals(result.map(_.agentId).toSet, Set("agent-aaa", "agent-bbb", "agent-ccc"))
 
   test("listSubAgents ignores non-agent files in subagents directory"):
     IO(os.temp.dir()).flatMap: tmpRoot =>
@@ -251,5 +251,5 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
           .listSubAgents(projectDir, "sess-8")
           .map: result =>
             assertEquals(result.length, 1)
-            assertEquals(result.head.agentId, "abc")
+            assertEquals(result.head.agentId, "agent-abc")
           .guarantee(IO(os.remove.all(tmpRoot)))

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -45,6 +45,8 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 **Fix applied:**
 - `SubAgentMetadataParser.scala` — replaced for-comprehension with `Option.when(!json.isNull)`, deriving `agentId` from `transcriptPath.last.stripSuffix(".jsonl")` instead of reading from JSON
 - `SubAgentMetadataParserTest.scala` — updated all test fixtures to use realistic transcript paths (`agent-<id>.jsonl`) and removed `agentId` from JSON; removed duplicate test; renamed tests for clarity; added 3 new tests
+- `DirectConversationLogIndexTest.scala` — updated agentId expectations from `"abc"` to `"agent-abc"` (filename-derived)
+- `EffectfulConversationLogIndexTest.scala` — same agentId expectation updates
 
 **Regression tests added:**
 - 3 new tests: agentId derived from filename, agentId in JSON ignored, real-world `.meta.json` content
@@ -57,6 +59,8 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 ```
 M	core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
 M	core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
+M	direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
 ```
 
 ---

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -37,3 +37,26 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 ```
 
 ---
+
+## Phase 2: Derive agentId from filename in SubAgentMetadataParser (2026-04-10)
+
+**Root cause:** `SubAgentMetadataParser.parse` required `agentId` from JSON via `cursor.get[String]("agentId").toOption` in a for-comprehension guard. Real `.meta.json` files produced by Claude Code CLI contain only `agentType` and `description` — `agentId` is encoded in the transcript filename (`agent-<id>.jsonl`). The for-comprehension always yielded `None` for real data.
+
+**Fix applied:**
+- `SubAgentMetadataParser.scala` — replaced for-comprehension with `Option.when(!json.isNull)`, deriving `agentId` from `transcriptPath.last.stripSuffix(".jsonl")` instead of reading from JSON
+- `SubAgentMetadataParserTest.scala` — updated all test fixtures to use realistic transcript paths (`agent-<id>.jsonl`) and removed `agentId` from JSON; removed duplicate test; renamed tests for clarity; added 3 new tests
+
+**Regression tests added:**
+- 3 new tests: agentId derived from filename, agentId in JSON ignored, real-world `.meta.json` content
+
+**Code review:**
+- Iterations: 1 (no critical issues; warnings fixed: removed duplicate test, inlined cursor variable, improved test names and PURPOSE comment)
+- Review file: review-phase-02-20260410-211739.md
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/phase-02-tasks.md
+++ b/project-management/issues/CC-41/phase-02-tasks.md
@@ -5,9 +5,10 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (parse returns None for real-world .meta.json content without agentId)
-- [ ] [impl] [ ] [reviewed] Investigate root cause — confirm agentId is never in real .meta.json and verify transcriptPath filename pattern from callers
-- [ ] [impl] [ ] [reviewed] Implement fix — derive agentId from transcriptPath filename instead of requiring it in JSON
-- [ ] [impl] [ ] [reviewed] Update existing tests to use realistic fixtures (no agentId in JSON, agent-<id>.jsonl paths)
-- [ ] [impl] [ ] [reviewed] Add new tests: agentId derived from filename, agentId in JSON ignored, empty JSON object with valid path
-- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions (./mill core.compile, ./mill core.test)
+- [x] [impl] [x] [reviewed] Write failing test reproducing the defect (parse returns None for real-world .meta.json content without agentId)
+- [x] [impl] [x] [reviewed] Investigate root cause — confirm agentId is never in real .meta.json and verify transcriptPath filename pattern from callers
+- [x] [impl] [x] [reviewed] Implement fix — derive agentId from transcriptPath filename instead of requiring it in JSON
+- [x] [impl] [x] [reviewed] Update existing tests to use realistic fixtures (no agentId in JSON, agent-<id>.jsonl paths)
+- [x] [impl] [x] [reviewed] Add new tests: agentId derived from filename, agentId in JSON ignored, empty JSON object with valid path
+- [x] [impl] [x] [reviewed] Verify fix passes and no regressions (./mill core.compile, ./mill core.test)
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/review-phase-02-20260410-211739.md
+++ b/project-management/issues/CC-41/review-phase-02-20260410-211739.md
@@ -1,0 +1,78 @@
+# Code Review Results
+
+**Review Context:** Phase 02: Derive agentId from filename in SubAgentMetadataParser for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 2
+**Skills Applied:** code-review-scala3, code-review-testing, code-review-style, code-review-composition
+**Timestamp:** 2026-04-10T21:17:39Z
+**Git Context:** git diff 4a19cc9
+
+---
+
+<review skill="code-review-scala3">
+
+### Critical Issues
+None
+
+### Warnings
+None
+
+### Suggestions
+None — code is idiomatic Scala 3 throughout.
+
+</review>
+
+---
+
+<review skill="code-review-testing">
+
+### Critical Issues
+None
+
+### Warnings
+1. **Duplicate test coverage** between "JSON with no optional fields" (line 29) and "empty JSON object" (line 54) — both parse `{}` against same path, second is strict subset of first.
+2. **Multiple assertions per test** in several cases (lines 21-27, 33-40, 47-52, 100-107) — when one fails, remaining are skipped.
+
+### Suggestions
+1. Test name "valid JSON with all fields" is imprecise after refactor — `agentId` no longer comes from JSON.
+2. No test for non-`.jsonl` extension or filename without a dot.
+
+</review>
+
+---
+
+<review skill="code-review-style">
+
+### Critical Issues
+None
+
+### Warnings
+1. **Duplicate test** between lines 29-40 and 54-61 — second is strict subset.
+
+### Suggestions
+1. British spelling "favour" inconsistent with rest of codebase — use neutral phrasing.
+2. Second PURPOSE line could mention null JSON as the only `None` condition.
+
+</review>
+
+---
+
+<review skill="code-review-composition">
+
+### Critical Issues
+None
+
+### Warnings
+1. **`cursor` variable could be inlined** — `json.hcursor` called directly in constructor args removes intermediate variable.
+
+### Suggestions
+1. Duplicate test case flagged again.
+
+</review>
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** 3 (duplicate test, multiple assertions per test, inlinable cursor)
+- **Suggestions:** 4 (test rename, edge case test, spelling, PURPOSE comment)

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -29,11 +29,11 @@
       "path": "project-management/issues/CC-41/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:14:36.695424277Z",
-  "status": "implementing",
+  "last_updated": "2026-04-10T21:23:39.899134733Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 02: Implementing",
-    "type": "progress",
+    "text": "Phase 02: Awaiting Review",
+    "type": "warning",
     "subtext": "Derive agentId from filename in SubAgentMetadataParser"
   },
   "badges": [
@@ -52,6 +52,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
   "message": "Phase 02 implementation started",
@@ -87,6 +91,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -96,5 +105,5 @@
       "context_sha": "context_sha=7fd16df51262440f70f783f27d5ef7bbdae0683e"
     }
   },
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/42"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/43"
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -29,11 +29,11 @@
       "path": "project-management/issues/CC-41/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:13:53.573356812Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T21:14:36.695424277Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 02: Tasks Ready",
-    "type": "success",
+    "text": "Phase 02: Implementing",
+    "type": "progress",
     "subtext": "Derive agentId from filename in SubAgentMetadataParser"
   },
   "badges": [
@@ -48,9 +48,13 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ],
-  "message": "Phase 02 tasks ready",
+  "message": "Phase 02 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [


### PR DESCRIPTION
Phase 02 implementation for CC-41.

### Files
Browse changed files: https://github.com/iterative-works/claude-code-query/blob/CC-41-phase-02/