### PR TITLE
Phase 3: Support entries without uuid field

### DIFF
--- a/core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
+++ b/core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
@@ -6,7 +6,7 @@ package works.iterative.claude.core.log.model
 import java.time.Instant
 
 case class ConversationLogEntry(
-    uuid: String,
+    uuid: Option[String],
     parentUuid: Option[String],
     timestamp: Option[Instant],
     sessionId: String,

--- a/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
@@ -34,8 +34,8 @@ object ConversationLogParser:
   def parseLogEntry(json: Json): Option[ConversationLogEntry] =
     val cursor = json.hcursor
     for
-      uuid <- cursor.get[String]("uuid").toOption
       sessionId <- cursor.get[String]("sessionId").toOption
+      uuid = cursor.get[String]("uuid").toOption
       entryType <- cursor.get[String]("type").toOption
       parentUuid = cursor.get[String]("parentUuid").toOption
       timestamp = cursor.get[String]("timestamp").toOption.flatMap(parseInstant)

--- a/core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
@@ -117,7 +117,7 @@ class LogModelTest extends FunSuite:
     val payload = UserLogEntry(List(TextBlock("hello")))
     val now = Instant.now()
     val entry = ConversationLogEntry(
-      uuid = "uuid-001",
+      uuid = Some("uuid-001"),
       parentUuid = Some("parent-uuid-000"),
       timestamp = Some(now),
       sessionId = "session-abc",
@@ -126,7 +126,7 @@ class LogModelTest extends FunSuite:
       version = Some("1.0"),
       payload = payload
     )
-    assertEquals(entry.uuid, "uuid-001")
+    assertEquals(entry.uuid, Some("uuid-001"))
     assertEquals(entry.parentUuid, Some("parent-uuid-000"))
     assertEquals(entry.timestamp, Some(now))
     assertEquals(entry.sessionId, "session-abc")
@@ -137,7 +137,7 @@ class LogModelTest extends FunSuite:
 
   test("ConversationLogEntry should allow optional fields to be None"):
     val entry = ConversationLogEntry(
-      uuid = "uuid-002",
+      uuid = Some("uuid-002"),
       parentUuid = None,
       timestamp = None,
       sessionId = "session-xyz",
@@ -155,7 +155,7 @@ class LogModelTest extends FunSuite:
     val sessionId = "session-test"
     val entries = List(
       ConversationLogEntry(
-        "u1",
+        Some("u1"),
         None,
         None,
         sessionId,
@@ -165,7 +165,7 @@ class LogModelTest extends FunSuite:
         UserLogEntry(List.empty)
       ),
       ConversationLogEntry(
-        "u2",
+        Some("u2"),
         None,
         None,
         sessionId,
@@ -175,7 +175,7 @@ class LogModelTest extends FunSuite:
         AssistantLogEntry(List.empty, None, None, None)
       ),
       ConversationLogEntry(
-        "u3",
+        Some("u3"),
         None,
         None,
         sessionId,
@@ -185,7 +185,7 @@ class LogModelTest extends FunSuite:
         SystemLogEntry("init", Map.empty)
       ),
       ConversationLogEntry(
-        "u4",
+        Some("u4"),
         None,
         None,
         sessionId,
@@ -195,7 +195,7 @@ class LogModelTest extends FunSuite:
         ProgressLogEntry(Map.empty, None)
       ),
       ConversationLogEntry(
-        "u5",
+        Some("u5"),
         None,
         None,
         sessionId,
@@ -205,7 +205,7 @@ class LogModelTest extends FunSuite:
         QueueOperationLogEntry("op", None)
       ),
       ConversationLogEntry(
-        "u6",
+        Some("u6"),
         None,
         None,
         sessionId,
@@ -215,7 +215,7 @@ class LogModelTest extends FunSuite:
         FileHistorySnapshotLogEntry(Map.empty)
       ),
       ConversationLogEntry(
-        "u7",
+        Some("u7"),
         None,
         None,
         sessionId,
@@ -225,7 +225,7 @@ class LogModelTest extends FunSuite:
         LastPromptLogEntry(Map.empty)
       ),
       ConversationLogEntry(
-        "u8",
+        Some("u8"),
         None,
         None,
         sessionId,

--- a/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
@@ -34,11 +34,14 @@ class ConversationLogParserTest extends FunSuite:
       None
     )
 
-  test("parseLogEntry with missing required uuid field returns None"):
+  test("parseLogEntry with missing uuid field parses successfully with uuid = None"):
     val json = parser
       .parse("""{"type":"user","sessionId":"s1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
-    assertEquals(ConversationLogParser.parseLogEntry(json), None)
+    val result = ConversationLogParser.parseLogEntry(json)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry) when uuid is absent")
 
   test("parseLogEntry with missing required sessionId field returns None"):
     val json = parser
@@ -64,7 +67,7 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) =>
-        assertEquals(entry.uuid, "uuid-001")
+        assertEquals(entry.uuid, Some("uuid-001"))
         assertEquals(entry.parentUuid, Some("parent-uuid-000"))
         assertEquals(
           entry.timestamp,
@@ -579,17 +582,21 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"permission-mode\" type without uuid returns None"):
+  test("\"permission-mode\" type without uuid parses successfully with uuid = None"):
     val line =
       """{"type":"permission-mode","sessionId":"s43","permissionMode":"default"}"""
     val result = ConversationLogParser.parseLogLine(line)
-    assertEquals(result, None)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry)")
 
-  test("\"attachment\" type without uuid returns None"):
+  test("\"attachment\" type without uuid parses successfully with uuid = None"):
     val line =
       """{"type":"attachment","sessionId":"s44","fileName":"foo.txt"}"""
     val result = ConversationLogParser.parseLogLine(line)
-    assertEquals(result, None)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry)")
 
   test("parseLogEntry with missing required type field returns None"):
     val json = parser
@@ -669,4 +676,41 @@ class ConversationLogParserTest extends FunSuite:
     result match
       case Some(entry) => assertEquals(entry.timestamp, None)
       case None        => fail("Expected Some(ConversationLogEntry)")
+
+  // --- uuid optional tests ---
+
+  test("entry without uuid field is parsed with uuid = None"):
+    val line =
+      """{"type":"permission-mode","sessionId":"s50","permissionMode":"default"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry) for entry without uuid")
+
+  test("entry with uuid field is parsed with uuid = Some(value)"):
+    val line =
+      """{"type":"user","uuid":"u51","sessionId":"s51","message":{"content":"hi"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, Some("u51"))
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  test("file-history-snapshot without uuid is parsed successfully"):
+    val line =
+      """{"type":"file-history-snapshot","sessionId":"s52","files":["/a.txt"]}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(ConversationLogEntry(_, _, _, _, _, _, _, FileHistorySnapshotLogEntry(data), _)) =>
+        assertEquals(data("files"), List("/a.txt"))
+      case Some(entry) => fail(s"Expected FileHistorySnapshotLogEntry, got: ${entry.payload}")
+      case None        => fail("Expected Some(ConversationLogEntry) for entry without uuid")
+
+  test("transcript with mix of uuid-present and uuid-absent entries parses all entries"):
+    val lines = List(
+      """{"type":"user","uuid":"u60","sessionId":"s60","message":{"content":"hello"}}""",
+      """{"type":"permission-mode","sessionId":"s60","permissionMode":"default"}""",
+      """{"type":"assistant","uuid":"u61","sessionId":"s60","message":{"content":[{"type":"text","text":"hi"}]}}"""
+    )
+    val results = lines.flatMap(ConversationLogParser.parseLogLine)
+    assertEquals(results.size, 3, "All three entries should parse, including the one without uuid")
 

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -64,3 +64,30 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 ```
 
 ---
+
+## Phase 3: Support entries without uuid field (2026-04-10)
+
+**Root cause:** `ConversationLogParser.parseLogEntry` used monadic bind (`uuid <- cursor.get[String]("uuid").toOption`) in its for-comprehension. When `uuid` is absent from the JSON (as with `permission-mode`, `file-history-snapshot` entries), `.toOption` yields `None` and the entire for-comprehension short-circuits, silently dropping the entry before payload parsing is attempted.
+
+**Fix applied:**
+- `ConversationLogEntry.scala` — changed `uuid: String` to `uuid: Option[String]`
+- `ConversationLogParser.scala` — changed `uuid <- cursor.get[String]("uuid").toOption` to `uuid = cursor.get[String]("uuid").toOption` (plain assignment instead of monadic bind), reordered for-comprehension to start with `sessionId <-` as the first required binding
+- `ConversationLogParserTest.scala` — updated existing uuid assertions to expect `Some(...)`, added 4 new regression tests covering uuid-absent, uuid-present, file-history-snapshot without uuid, and mixed-entry transcript
+- `LogModelTest.scala` — updated all `ConversationLogEntry` constructions to use `Some("...")` for uuid field
+
+**Regression tests added:**
+- 4 new tests for uuid optional behavior
+
+**Code review:**
+- Iterations: 1 (no critical issues)
+- Review file: review-phase-03-20260410-233419.md
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
+M	core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+M	core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/phase-03-tasks.md
+++ b/project-management/issues/CC-41/phase-03-tasks.md
@@ -5,8 +5,9 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (entry without uuid is silently dropped)
-- [ ] [impl] [ ] [reviewed] Investigate root cause (confirm uuid monadic bind causes short-circuit)
-- [ ] [impl] [ ] [reviewed] Implement fix (make uuid optional in ConversationLogEntry, change `<-` to `=` in for-comprehension)
-- [ ] [impl] [ ] [reviewed] Propagate Option[String] type change through downstream consumers and tests
-- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions
+- [x] [impl] [x] [reviewed] Write failing test reproducing the defect (entry without uuid is silently dropped)
+- [x] [impl] [x] [reviewed] Investigate root cause (confirm uuid monadic bind causes short-circuit)
+- [x] [impl] [x] [reviewed] Implement fix (make uuid optional in ConversationLogEntry, change `<-` to `=` in for-comprehension)
+- [x] [impl] [x] [reviewed] Propagate Option[String] type change through downstream consumers and tests
+- [x] [impl] [x] [reviewed] Verify fix passes and no regressions
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/review-phase-03-20260410-233419.md
+++ b/project-management/issues/CC-41/review-phase-03-20260410-233419.md
@@ -1,0 +1,73 @@
+# Code Review Results
+
+**Review Context:** Phase 3: Support entries without uuid field for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 4
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-04-10 23:34:19
+**Git Context:** git diff 1d15b36
+
+---
+
+## Style Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Section divider comment `// --- uuid optional tests ---` uses a style inconsistent with rest of file
+
+### Suggestions
+- Duplicated test coverage between renamed existing tests and new tests
+- `assertEquals` message with embedded count could become stale
+
+---
+
+## Testing Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Duplicate test coverage: permission-mode tested at line 585 and again at line 682
+- `LogModelTest` does not add a test for `uuid = None` case
+
+### Suggestions
+- `match`/`fail` pattern repeated across many tests — consider a helper
+- Mixed-transcript integration test only asserts size, not individual entry content
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+None found.
+
+### Warnings
+None found.
+
+### Suggestions
+- `uuid: Option[String]` is a candidate for opaque type (pre-existing, not introduced by this diff)
+- Pattern-match style in tests is verbose — could use `getOrElse(fail(...))` idiom
+
+---
+
+## Composition Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Repeated `match`/`fail` pattern not composed into helper
+
+### Suggestions
+- `parseLogEntry` for-comprehension mixes effectful and pure bindings — brief comment would help readability
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** 3
+- **Suggestions:** 6
+
+No critical issues found. Warnings relate to test duplication and missing model-level test coverage. All suggestions are improvements to existing patterns, not regressions introduced by this change.

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -37,11 +37,11 @@
       "path": "project-management/issues/CC-41/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:30:07.943545072Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T21:30:57.467613747Z",
+  "status": "implementing",
   "display": {
-    "text": "Phase 03: Tasks Ready",
-    "type": "success",
+    "text": "Phase 03: Implementing",
+    "type": "progress",
     "subtext": "Support entries without uuid field"
   },
   "badges": [
@@ -64,9 +64,13 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
     }
   ],
-  "message": "Phase 03 tasks ready",
+  "message": "Phase 03 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -37,11 +37,11 @@
       "path": "project-management/issues/CC-41/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:30:57.467613747Z",
-  "status": "implementing",
+  "last_updated": "2026-04-10T21:36:39.730209227Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 03: Implementing",
-    "type": "progress",
+    "text": "Phase 03: Awaiting Review",
+    "type": "warning",
     "subtext": "Support entries without uuid field"
   },
   "badges": [
@@ -68,6 +68,10 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
   "message": "Phase 03 implementation started",
@@ -113,6 +117,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -122,5 +131,5 @@
       "context_sha": "context_sha=8a9d1bc33084892701f6b447e2d5198f89227c3e"
     }
   },
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/43"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/44"
 }


### PR DESCRIPTION
Phase 03 implementation for CC-41.

### Files
Browse changed files: https://github.com/iterative-works/claude-code-query/blob/CC-41-phase-03/