### PR TITLE
Fix conversation log parsing bugs (CC-41)

### DIFF
--- a/core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
+++ b/core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
@@ -6,7 +6,7 @@ package works.iterative.claude.core.log.model
 import java.time.Instant
 
 case class ConversationLogEntry(
-    uuid: String,
+    uuid: Option[String],
     parentUuid: Option[String],
     timestamp: Option[Instant],
     sessionId: String,

--- a/core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
+++ b/core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
@@ -42,6 +42,14 @@ case class LastPromptLogEntry(
     data: Map[String, Any]
 ) extends LogEntryPayload
 
+case class PermissionModeLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
+case class AttachmentLogEntry(
+    data: Map[String, Any]
+) extends LogEntryPayload
+
 case class RawLogEntry(
     entryType: String,
     json: Json

--- a/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
@@ -66,15 +66,19 @@ object ConversationLogParser:
       json: Json
   ): Option[LogEntryPayload] =
     entryType match
-      case "human"                 => parseUserPayload(cursor)
+      case "user"                  => parseUserPayload(cursor)
       case "assistant"             => parseAssistantPayload(cursor)
       case "system"                => parseSystemPayload(cursor, json)
       case "progress"              => Some(parseProgressPayload(cursor, json))
-      case "queue_operation"       => parseQueueOperationPayload(cursor)
-      case "file_history_snapshot" =>
+      case "queue-operation"       => parseQueueOperationPayload(cursor)
+      case "file-history-snapshot" =>
         Some(parseDataOnlyPayload(json, FileHistorySnapshotLogEntry.apply))
       case "last_prompt" =>
         Some(parseDataOnlyPayload(json, LastPromptLogEntry.apply))
+      case "permission-mode" =>
+        Some(parseDataOnlyPayload(json, PermissionModeLogEntry.apply))
+      case "attachment" =>
+        Some(parseDataOnlyPayload(json, AttachmentLogEntry.apply))
       case _ => Some(RawLogEntry(entryType, json))
 
   private def parseContentBlocks(cursor: HCursor): List[ContentBlock] =

--- a/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
@@ -34,8 +34,8 @@ object ConversationLogParser:
   def parseLogEntry(json: Json): Option[ConversationLogEntry] =
     val cursor = json.hcursor
     for
-      uuid <- cursor.get[String]("uuid").toOption
       sessionId <- cursor.get[String]("sessionId").toOption
+      uuid = cursor.get[String]("uuid").toOption
       entryType <- cursor.get[String]("type").toOption
       parentUuid = cursor.get[String]("parentUuid").toOption
       timestamp = cursor.get[String]("timestamp").toOption.flatMap(parseInstant)

--- a/core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
+++ b/core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Pure parser for sub-agent .meta.json sidecar files into SubAgentMetadata
-// PURPOSE: Returns None for missing required fields or unparseable input
+// PURPOSE: Returns None only for null JSON input; agentType and description are optional fields
 
 package works.iterative.claude.core.log.parsing
 
@@ -9,11 +9,10 @@ import works.iterative.claude.core.log.model.SubAgentMetadata
 object SubAgentMetadataParser:
 
   def parse(json: Json, transcriptPath: os.Path): Option[SubAgentMetadata] =
-    val cursor = json.hcursor
-    for agentId <- cursor.get[String]("agentId").toOption
-    yield SubAgentMetadata(
-      agentId = agentId,
-      agentType = cursor.get[String]("agentType").toOption,
-      description = cursor.get[String]("description").toOption,
-      transcriptPath = transcriptPath
-    )
+    Option.when(!json.isNull):
+      SubAgentMetadata(
+        agentId = transcriptPath.last.stripSuffix(".jsonl"),
+        agentType = json.hcursor.get[String]("agentType").toOption,
+        description = json.hcursor.get[String]("description").toOption,
+        transcriptPath = transcriptPath
+      )

--- a/core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
@@ -117,7 +117,7 @@ class LogModelTest extends FunSuite:
     val payload = UserLogEntry(List(TextBlock("hello")))
     val now = Instant.now()
     val entry = ConversationLogEntry(
-      uuid = "uuid-001",
+      uuid = Some("uuid-001"),
       parentUuid = Some("parent-uuid-000"),
       timestamp = Some(now),
       sessionId = "session-abc",
@@ -126,7 +126,7 @@ class LogModelTest extends FunSuite:
       version = Some("1.0"),
       payload = payload
     )
-    assertEquals(entry.uuid, "uuid-001")
+    assertEquals(entry.uuid, Some("uuid-001"))
     assertEquals(entry.parentUuid, Some("parent-uuid-000"))
     assertEquals(entry.timestamp, Some(now))
     assertEquals(entry.sessionId, "session-abc")
@@ -137,7 +137,7 @@ class LogModelTest extends FunSuite:
 
   test("ConversationLogEntry should allow optional fields to be None"):
     val entry = ConversationLogEntry(
-      uuid = "uuid-002",
+      uuid = Some("uuid-002"),
       parentUuid = None,
       timestamp = None,
       sessionId = "session-xyz",
@@ -155,7 +155,7 @@ class LogModelTest extends FunSuite:
     val sessionId = "session-test"
     val entries = List(
       ConversationLogEntry(
-        "u1",
+        Some("u1"),
         None,
         None,
         sessionId,
@@ -165,7 +165,7 @@ class LogModelTest extends FunSuite:
         UserLogEntry(List.empty)
       ),
       ConversationLogEntry(
-        "u2",
+        Some("u2"),
         None,
         None,
         sessionId,
@@ -175,7 +175,7 @@ class LogModelTest extends FunSuite:
         AssistantLogEntry(List.empty, None, None, None)
       ),
       ConversationLogEntry(
-        "u3",
+        Some("u3"),
         None,
         None,
         sessionId,
@@ -185,7 +185,7 @@ class LogModelTest extends FunSuite:
         SystemLogEntry("init", Map.empty)
       ),
       ConversationLogEntry(
-        "u4",
+        Some("u4"),
         None,
         None,
         sessionId,
@@ -195,7 +195,7 @@ class LogModelTest extends FunSuite:
         ProgressLogEntry(Map.empty, None)
       ),
       ConversationLogEntry(
-        "u5",
+        Some("u5"),
         None,
         None,
         sessionId,
@@ -205,7 +205,7 @@ class LogModelTest extends FunSuite:
         QueueOperationLogEntry("op", None)
       ),
       ConversationLogEntry(
-        "u6",
+        Some("u6"),
         None,
         None,
         sessionId,
@@ -215,7 +215,7 @@ class LogModelTest extends FunSuite:
         FileHistorySnapshotLogEntry(Map.empty)
       ),
       ConversationLogEntry(
-        "u7",
+        Some("u7"),
         None,
         None,
         sessionId,
@@ -225,7 +225,7 @@ class LogModelTest extends FunSuite:
         LastPromptLogEntry(Map.empty)
       ),
       ConversationLogEntry(
-        "u8",
+        Some("u8"),
         None,
         None,
         sessionId,

--- a/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
@@ -15,7 +15,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parseLogLine with valid JSONL line returns Some(ConversationLogEntry)"):
     val line =
-      """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+      """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     assert(
       result.isDefined,
@@ -30,19 +30,19 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parseLogLine with invalid JSON returns None"):
     assertEquals(
-      ConversationLogParser.parseLogLine("""{"type": "human", malformed}"""),
+      ConversationLogParser.parseLogLine("""{"type": "user", malformed}"""),
       None
     )
 
   test("parseLogEntry with missing required uuid field returns None"):
     val json = parser
-      .parse("""{"type":"human","sessionId":"s1","message":{"content":"hi"}}""")
+      .parse("""{"type":"user","sessionId":"s1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
     assertEquals(ConversationLogParser.parseLogEntry(json), None)
 
   test("parseLogEntry with missing required sessionId field returns None"):
     val json = parser
-      .parse("""{"type":"human","uuid":"u1","message":{"content":"hi"}}""")
+      .parse("""{"type":"user","uuid":"u1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
     assertEquals(ConversationLogParser.parseLogEntry(json), None)
 
@@ -51,7 +51,7 @@ class ConversationLogParserTest extends FunSuite:
   test("parses all envelope metadata fields"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"uuid-001",
         "parentUuid":"parent-uuid-000",
         "timestamp":"2024-01-15T10:30:00Z",
@@ -78,7 +78,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("parses with optional fields absent"):
     val line =
-      """{"type":"human","uuid":"u2","sessionId":"s2","message":{"content":"hi"}}"""
+      """{"type":"user","uuid":"u2","sessionId":"s2","message":{"content":"hi"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) =>
@@ -91,7 +91,7 @@ class ConversationLogParserTest extends FunSuite:
   test("parses ISO-8601 timestamp string to Instant"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u3",
         "sessionId":"s3",
         "timestamp":"2025-06-01T12:00:00.000Z",
@@ -108,7 +108,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("isSidechain defaults to false when absent"):
     val line =
-      """{"type":"human","uuid":"u4","sessionId":"s4","message":{"content":"x"}}"""
+      """{"type":"user","uuid":"u4","sessionId":"s4","message":{"content":"x"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) => assertEquals(entry.isSidechain, false)
@@ -117,10 +117,10 @@ class ConversationLogParserTest extends FunSuite:
   // --- Payload type tests ---
 
   test(
-    """"human" type with string content produces UserLogEntry with List(TextBlock)"""
+    """"user" type with string content produces UserLogEntry with List(TextBlock)"""
   ):
     val line =
-      """{"type":"human","uuid":"u5","sessionId":"s5","message":{"content":"hello world"}}"""
+      """{"type":"user","uuid":"u5","sessionId":"s5","message":{"content":"hello world"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(
@@ -131,11 +131,11 @@ class ConversationLogParserTest extends FunSuite:
       case None        => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"human" type with array content produces UserLogEntry with parsed content blocks"""
+    """"user" type with array content produces UserLogEntry with parsed content blocks"""
   ):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u6",
         "sessionId":"s6",
         "message":{
@@ -305,11 +305,11 @@ class ConversationLogParserTest extends FunSuite:
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"queue_operation" type with operation and content produces QueueOperationLogEntry"""
+    """"queue-operation" type with operation and content produces QueueOperationLogEntry"""
   ):
     val line =
       """{
-        "type":"queue_operation",
+        "type":"queue-operation",
         "uuid":"u11",
         "sessionId":"s11",
         "operation":"enqueue",
@@ -337,11 +337,11 @@ class ConversationLogParserTest extends FunSuite:
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test(
-    """"file_history_snapshot" type with data produces FileHistorySnapshotLogEntry"""
+    """"file-history-snapshot" type with data produces FileHistorySnapshotLogEntry"""
   ):
     val line =
       """{
-        "type":"file_history_snapshot",
+        "type":"file-history-snapshot",
         "uuid":"u12",
         "sessionId":"s12",
         "files":["/a.txt","/b.txt"]
@@ -382,6 +382,66 @@ class ConversationLogParserTest extends FunSuite:
         assertEquals(data("promptText"), "what is 2+2?")
       case Some(entry) =>
         fail(s"Expected LastPromptLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"permission-mode" type with data produces PermissionModeLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"permission-mode",
+        "uuid":"u43",
+        "sessionId":"s43",
+        "permissionMode":"default"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              PermissionModeLogEntry(data),
+              _
+            )
+          ) =>
+        assertEquals(data("permissionMode"), "default")
+      case Some(entry) =>
+        fail(s"Expected PermissionModeLogEntry, got: ${entry.payload}")
+      case None => fail("Expected Some(ConversationLogEntry)")
+
+  test(
+    """"attachment" type with data produces AttachmentLogEntry"""
+  ):
+    val line =
+      """{
+        "type":"attachment",
+        "uuid":"u44",
+        "sessionId":"s44",
+        "fileName":"foo.txt"
+      }"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(
+            ConversationLogEntry(
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              AttachmentLogEntry(data),
+              _
+            )
+          ) =>
+        assertEquals(data("fileName"), "foo.txt")
+      case Some(entry) =>
+        fail(s"Expected AttachmentLogEntry, got: ${entry.payload}")
       case None => fail("Expected Some(ConversationLogEntry)")
 
   test("unknown type produces RawLogEntry with preserved JSON"):
@@ -501,21 +561,33 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"queue_operation\" type without operation returns None"):
+  test("\"queue-operation\" type without operation returns None"):
     val line =
-      """{"type":"queue_operation","uuid":"u21","sessionId":"s21","content":"msg"}"""
+      """{"type":"queue-operation","uuid":"u21","sessionId":"s21","content":"msg"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"human\" type without message field returns None"):
+  test("\"user\" type without message field returns None"):
     val line =
-      """{"type":"human","uuid":"u22","sessionId":"s22"}"""
+      """{"type":"user","uuid":"u22","sessionId":"s22"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
   test("\"assistant\" type without message field returns None"):
     val line =
       """{"type":"assistant","uuid":"u23","sessionId":"s23"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"permission-mode\" type without uuid returns None"):
+    val line =
+      """{"type":"permission-mode","sessionId":"s43","permissionMode":"default"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    assertEquals(result, None)
+
+  test("\"attachment\" type without uuid returns None"):
+    val line =
+      """{"type":"attachment","sessionId":"s44","fileName":"foo.txt"}"""
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
@@ -530,7 +602,7 @@ class ConversationLogParserTest extends FunSuite:
   test("JSONL line with agentId field extracts Some(agentId)"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u30",
         "sessionId":"s30",
         "agentId":"agent-abc-123",
@@ -543,7 +615,7 @@ class ConversationLogParserTest extends FunSuite:
 
   test("JSONL line without agentId field extracts None"):
     val line =
-      """{"type":"human","uuid":"u31","sessionId":"s31","message":{"content":"hi"}}"""
+      """{"type":"user","uuid":"u31","sessionId":"s31","message":{"content":"hi"}}"""
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) => assertEquals(entry.agentId, None)
@@ -587,7 +659,7 @@ class ConversationLogParserTest extends FunSuite:
   test("malformed timestamp string results in None timestamp"):
     val line =
       """{
-        "type":"human",
+        "type":"user",
         "uuid":"u25",
         "sessionId":"s25",
         "timestamp":"not-a-date",
@@ -597,3 +669,4 @@ class ConversationLogParserTest extends FunSuite:
     result match
       case Some(entry) => assertEquals(entry.timestamp, None)
       case None        => fail("Expected Some(ConversationLogEntry)")
+

--- a/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
@@ -34,11 +34,14 @@ class ConversationLogParserTest extends FunSuite:
       None
     )
 
-  test("parseLogEntry with missing required uuid field returns None"):
+  test("parseLogEntry with missing uuid field parses successfully with uuid = None"):
     val json = parser
       .parse("""{"type":"user","sessionId":"s1","message":{"content":"hi"}}""")
       .getOrElse(fail("parse failed"))
-    assertEquals(ConversationLogParser.parseLogEntry(json), None)
+    val result = ConversationLogParser.parseLogEntry(json)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry) when uuid is absent")
 
   test("parseLogEntry with missing required sessionId field returns None"):
     val json = parser
@@ -64,7 +67,7 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     result match
       case Some(entry) =>
-        assertEquals(entry.uuid, "uuid-001")
+        assertEquals(entry.uuid, Some("uuid-001"))
         assertEquals(entry.parentUuid, Some("parent-uuid-000"))
         assertEquals(
           entry.timestamp,
@@ -579,17 +582,21 @@ class ConversationLogParserTest extends FunSuite:
     val result = ConversationLogParser.parseLogLine(line)
     assertEquals(result, None)
 
-  test("\"permission-mode\" type without uuid returns None"):
+  test("\"permission-mode\" type without uuid parses successfully with uuid = None"):
     val line =
       """{"type":"permission-mode","sessionId":"s43","permissionMode":"default"}"""
     val result = ConversationLogParser.parseLogLine(line)
-    assertEquals(result, None)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry)")
 
-  test("\"attachment\" type without uuid returns None"):
+  test("\"attachment\" type without uuid parses successfully with uuid = None"):
     val line =
       """{"type":"attachment","sessionId":"s44","fileName":"foo.txt"}"""
     val result = ConversationLogParser.parseLogLine(line)
-    assertEquals(result, None)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry)")
 
   test("parseLogEntry with missing required type field returns None"):
     val json = parser
@@ -669,4 +676,41 @@ class ConversationLogParserTest extends FunSuite:
     result match
       case Some(entry) => assertEquals(entry.timestamp, None)
       case None        => fail("Expected Some(ConversationLogEntry)")
+
+  // --- uuid optional tests ---
+
+  test("entry without uuid field is parsed with uuid = None"):
+    val line =
+      """{"type":"permission-mode","sessionId":"s50","permissionMode":"default"}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, None)
+      case None        => fail("Expected Some(ConversationLogEntry) for entry without uuid")
+
+  test("entry with uuid field is parsed with uuid = Some(value)"):
+    val line =
+      """{"type":"user","uuid":"u51","sessionId":"s51","message":{"content":"hi"}}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(entry) => assertEquals(entry.uuid, Some("u51"))
+      case None        => fail("Expected Some(ConversationLogEntry)")
+
+  test("file-history-snapshot without uuid is parsed successfully"):
+    val line =
+      """{"type":"file-history-snapshot","sessionId":"s52","files":["/a.txt"]}"""
+    val result = ConversationLogParser.parseLogLine(line)
+    result match
+      case Some(ConversationLogEntry(_, _, _, _, _, _, _, FileHistorySnapshotLogEntry(data), _)) =>
+        assertEquals(data("files"), List("/a.txt"))
+      case Some(entry) => fail(s"Expected FileHistorySnapshotLogEntry, got: ${entry.payload}")
+      case None        => fail("Expected Some(ConversationLogEntry) for entry without uuid")
+
+  test("transcript with mix of uuid-present and uuid-absent entries parses all entries"):
+    val lines = List(
+      """{"type":"user","uuid":"u60","sessionId":"s60","message":{"content":"hello"}}""",
+      """{"type":"permission-mode","sessionId":"s60","permissionMode":"default"}""",
+      """{"type":"assistant","uuid":"u61","sessionId":"s60","message":{"content":[{"type":"text","text":"hi"}]}}"""
+    )
+    val results = lines.flatMap(ConversationLogParser.parseLogLine)
+    assertEquals(results.size, 3, "All three entries should parse, including the one without uuid")
 

--- a/core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
+++ b/core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
@@ -8,12 +8,11 @@ import io.circe.parser
 
 class SubAgentMetadataParserTest extends FunSuite:
 
-  private val transcriptPath = os.Path("/tmp/subagents/agent-abc/transcript.jsonl")
+  private val transcriptPath = os.Path("/tmp/subagents/agent-abc123.jsonl")
 
-  test("valid JSON with all fields returns Some(SubAgentMetadata)"):
+  test("JSON with agentType and description returns fully populated SubAgentMetadata"):
     val json = parser
       .parse("""{
-        "agentId": "agent-abc-123",
         "agentType": "coder",
         "description": "Writes Scala code"
       }""")
@@ -21,49 +20,79 @@ class SubAgentMetadataParserTest extends FunSuite:
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
     result match
       case Some(meta) =>
-        assertEquals(meta.agentId, "agent-abc-123")
+        assertEquals(meta.agentId, "agent-abc123")
         assertEquals(meta.agentType, Some("coder"))
         assertEquals(meta.description, Some("Writes Scala code"))
         assertEquals(meta.transcriptPath, transcriptPath)
       case None => fail("Expected Some(SubAgentMetadata)")
 
-  test("JSON with only required agentId returns Some with None optional fields"):
+  test("JSON with no optional fields returns Some with agentId from filename and None optional fields"):
     val json = parser
-      .parse("""{"agentId": "agent-xyz"}""")
+      .parse("""{}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
     result match
       case Some(meta) =>
-        assertEquals(meta.agentId, "agent-xyz")
+        assertEquals(meta.agentId, "agent-abc123")
         assertEquals(meta.agentType, None)
         assertEquals(meta.description, None)
         assertEquals(meta.transcriptPath, transcriptPath)
       case None => fail("Expected Some(SubAgentMetadata)")
 
-  test("JSON missing required agentId returns None"):
+  test("JSON with only agentType and description returns Some"):
     val json = parser
       .parse("""{"agentType": "coder", "description": "Does stuff"}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, transcriptPath)
-    assertEquals(result, None)
-
-  test("empty JSON object returns None"):
-    val json = parser
-      .parse("""{}""")
-      .getOrElse(fail("parse failed"))
-    val result = SubAgentMetadataParser.parse(json, transcriptPath)
-    assertEquals(result, None)
+    result match
+      case Some(meta) =>
+        assertEquals(meta.agentId, "agent-abc123")
+        assertEquals(meta.agentType, Some("coder"))
+        assertEquals(meta.description, Some("Does stuff"))
+      case None => fail("Expected Some(SubAgentMetadata)")
 
   test("JSON null returns None"):
     val result = SubAgentMetadataParser.parse(io.circe.Json.Null, transcriptPath)
     assertEquals(result, None)
 
   test("transcriptPath is stored in parsed SubAgentMetadata"):
-    val customPath = os.Path("/home/user/.claude/projects/session/subagents/agent-1/transcript.jsonl")
+    val customPath = os.Path("/home/user/.claude/projects/session/subagents/agent-xyz789.jsonl")
     val json = parser
-      .parse("""{"agentId": "agent-1"}""")
+      .parse("""{}""")
       .getOrElse(fail("parse failed"))
     val result = SubAgentMetadataParser.parse(json, customPath)
     result match
       case Some(meta) => assertEquals(meta.transcriptPath, customPath)
       case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("agentId is derived from transcript filename, not from JSON"):
+    val pathWithId = os.Path("/tmp/agent-derived-id.jsonl")
+    val json = parser
+      .parse("""{"agentType": "coder"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, pathWithId)
+    result match
+      case Some(meta) => assertEquals(meta.agentId, "agent-derived-id")
+      case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("agentId in JSON is ignored; filename is used instead"):
+    val json = parser
+      .parse("""{"agentId": "should-be-ignored", "agentType": "coder"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, transcriptPath)
+    result match
+      case Some(meta) => assertEquals(meta.agentId, "agent-abc123")
+      case None       => fail("Expected Some(SubAgentMetadata)")
+
+  test("real-world .meta.json content without agentId returns Some with agentId from filename"):
+    val realWorldPath = os.Path("/tmp/subagents/agent-a27a237ab9050d9ef.jsonl")
+    val json = parser
+      .parse("""{"agentType":"iterative-works:code-reviewer","description":"Review security of phase 07"}""")
+      .getOrElse(fail("parse failed"))
+    val result = SubAgentMetadataParser.parse(json, realWorldPath)
+    result match
+      case Some(meta) =>
+        assertEquals(meta.agentId, "agent-a27a237ab9050d9ef")
+        assertEquals(meta.agentType, Some("iterative-works:code-reviewer"))
+        assertEquals(meta.description, Some("Review security of phase 07"))
+      case None => fail("Expected Some(SubAgentMetadata) for real-world .meta.json content")

--- a/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
@@ -162,7 +162,7 @@ class DirectConversationLogIndexTest extends FunSuite:
     ): projectDir =>
       val result = index.listSubAgents(projectDir, "sess-2")
       assertEquals(result.length, 1)
-      assertEquals(result.head.agentId, "abc")
+      assertEquals(result.head.agentId, "agent-abc")
 
   test("listSubAgents populates all metadata fields from .meta.json"):
     withSubAgentsDir(
@@ -179,7 +179,7 @@ class DirectConversationLogIndexTest extends FunSuite:
       val result = index.listSubAgents(projectDir, "sess-3")
       assertEquals(result.length, 1)
       val meta = result.head
-      assertEquals(meta.agentId, "abc")
+      assertEquals(meta.agentId, "agent-abc")
       assertEquals(meta.agentType, Some("researcher"))
       assertEquals(meta.description, Some("Does research"))
 
@@ -223,7 +223,7 @@ class DirectConversationLogIndexTest extends FunSuite:
     ): projectDir =>
       val result = index.listSubAgents(projectDir, "sess-7")
       assertEquals(result.length, 3)
-      assertEquals(result.map(_.agentId).toSet, Set("aaa", "bbb", "ccc"))
+      assertEquals(result.map(_.agentId).toSet, Set("agent-aaa", "agent-bbb", "agent-ccc"))
 
   test("listSubAgents ignores non-agent files in subagents directory"):
     val tmpRoot = os.temp.dir()
@@ -236,5 +236,5 @@ class DirectConversationLogIndexTest extends FunSuite:
       os.write(subagentsDir / "notes.txt", "irrelevant")
       val result = index.listSubAgents(projectDir, "sess-8")
       assertEquals(result.length, 1)
-      assertEquals(result.head.agentId, "abc")
+      assertEquals(result.head.agentId, "agent-abc")
     finally os.remove.all(tmpRoot)

--- a/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+++ b/direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
@@ -11,8 +11,8 @@ class DirectConversationLogReaderTest extends FunSuite:
 
   private val reader = DirectConversationLogReader()
 
-  private val humanLine =
-    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val userLine =
+    """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
   private val assistantLine =
     """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
   private val systemLine =
@@ -38,8 +38,8 @@ class DirectConversationLogReaderTest extends FunSuite:
       val result = reader.readAll(path)
       assertEquals(result, List.empty[ConversationLogEntry])
 
-  test("readAll parses a single human entry"):
-    withLogFile(List(humanLine)): path =>
+  test("readAll parses a single user entry"):
+    withLogFile(List(userLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 1)
       assertEquals(result.head.sessionId, "s1")
@@ -49,29 +49,29 @@ class DirectConversationLogReaderTest extends FunSuite:
       )
 
   test("readAll parses multiple entries of different types"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 3)
 
   test("readAll preserves order of entries"):
-    withLogFile(List(humanLine, assistantLine)): path =>
+    withLogFile(List(userLine, assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
       assert(result(0).payload.isInstanceOf[UserLogEntry])
       assert(result(1).payload.isInstanceOf[AssistantLogEntry])
 
   test("readAll skips malformed JSON lines silently"):
-    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+    withLogFile(List(userLine, "{bad json}", assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
 
   test("readAll handles mixed blank and valid lines"):
-    withLogFile(List(emptyLine, humanLine, blankLine, assistantLine)): path =>
+    withLogFile(List(emptyLine, userLine, blankLine, assistantLine)): path =>
       val result = reader.readAll(path)
       assertEquals(result.length, 2)
 
   test("stream produces same entries as readAll"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       val fromReadAll = reader.readAll(path)
       val fromStream = supervised:
         reader.stream(path).runToList()
@@ -85,7 +85,7 @@ class DirectConversationLogReaderTest extends FunSuite:
 
   test("stream skips blank and malformed lines"):
     withLogFile(
-      List(emptyLine, humanLine, "{not json}", blankLine, assistantLine)
+      List(emptyLine, userLine, "{not json}", blankLine, assistantLine)
     ): path =>
       val result = supervised:
         reader.stream(path).runToList()

--- a/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
@@ -163,7 +163,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .listSubAgents(projectDir, "sess-2")
         .map: result =>
           assertEquals(result.length, 1)
-          assertEquals(result.head.agentId, "abc")
+          assertEquals(result.head.agentId, "agent-abc")
 
   test("listSubAgents populates all metadata fields from .meta.json"):
     withSubAgentsDir(
@@ -186,7 +186,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .map: result =>
           assertEquals(result.length, 1)
           val meta = result.head
-          assertEquals(meta.agentId, "abc")
+          assertEquals(meta.agentId, "agent-abc")
           assertEquals(meta.agentType, Some("researcher"))
           assertEquals(meta.description, Some("Does research"))
 
@@ -237,7 +237,7 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
         .listSubAgents(projectDir, "sess-7")
         .map: result =>
           assertEquals(result.length, 3)
-          assertEquals(result.map(_.agentId).toSet, Set("aaa", "bbb", "ccc"))
+          assertEquals(result.map(_.agentId).toSet, Set("agent-aaa", "agent-bbb", "agent-ccc"))
 
   test("listSubAgents ignores non-agent files in subagents directory"):
     IO(os.temp.dir()).flatMap: tmpRoot =>
@@ -251,5 +251,5 @@ class EffectfulConversationLogIndexTest extends CatsEffectSuite:
           .listSubAgents(projectDir, "sess-8")
           .map: result =>
             assertEquals(result.length, 1)
-            assertEquals(result.head.agentId, "abc")
+            assertEquals(result.head.agentId, "agent-abc")
           .guarantee(IO(os.remove.all(tmpRoot)))

--- a/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
+++ b/effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
@@ -11,8 +11,8 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
 
   private val reader = EffectfulConversationLogReader()
 
-  private val humanLine =
-    """{"type":"human","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
+  private val userLine =
+    """{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}"""
   private val assistantLine =
     """{"type":"assistant","uuid":"u2","sessionId":"s1","message":{"content":[{"type":"text","text":"hi there"}]}}"""
   private val systemLine =
@@ -40,8 +40,8 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
         .map: result =>
           assertEquals(result, List.empty[ConversationLogEntry])
 
-  test("readAll parses a single human entry"):
-    withLogFile(List(humanLine)): path =>
+  test("readAll parses a single user entry"):
+    withLogFile(List(userLine)): path =>
       reader
         .readAll(path)
         .map: result =>
@@ -53,14 +53,14 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           )
 
   test("readAll parses multiple entries of different types"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       reader
         .readAll(path)
         .map: result =>
           assertEquals(result.length, 3)
 
   test("readAll preserves order of entries"):
-    withLogFile(List(humanLine, assistantLine)): path =>
+    withLogFile(List(userLine, assistantLine)): path =>
       reader
         .readAll(path)
         .map: result =>
@@ -69,14 +69,14 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           assert(result(1).payload.isInstanceOf[AssistantLogEntry])
 
   test("readAll skips malformed JSON lines silently"):
-    withLogFile(List(humanLine, "{bad json}", assistantLine)): path =>
+    withLogFile(List(userLine, "{bad json}", assistantLine)): path =>
       reader
         .readAll(path)
         .map: result =>
           assertEquals(result.length, 2)
 
   test("stream produces same entries as readAll"):
-    withLogFile(List(humanLine, assistantLine, systemLine)): path =>
+    withLogFile(List(userLine, assistantLine, systemLine)): path =>
       for
         fromReadAll <- reader.readAll(path)
         fromStream <- reader.stream(path).compile.toList
@@ -92,7 +92,7 @@ class EffectfulConversationLogReaderTest extends CatsEffectSuite:
           assertEquals(result, List.empty[ConversationLogEntry])
 
   test("stream skips blank and malformed lines"):
-    withLogFile(List("", humanLine, "{not json}", "   ", assistantLine)):
+    withLogFile(List("", userLine, "{not json}", "   ", assistantLine)):
       path =>
         reader
           .stream(path)

--- a/project-management/issues/CC-41/analysis.md
+++ b/project-management/issues/CC-41/analysis.md
@@ -1,0 +1,170 @@
+# Diagnostic Analysis: CC-41
+
+**Parser mismatches: wrong entry type names, SubAgentMetadataParser requires missing field**
+
+## Problem Statement
+
+Three related parsing bugs in the conversation log parsing subsystem cause silent data loss when processing real Claude Code JSONL transcripts. The bugs were discovered during transcript analysis of 18 real sessions (PROC-272).
+
+**Severity: High** — core parsing functionality is broken for real-world data, causing all user entries and all sub-agent metadata to be silently dropped.
+
+## Defects
+
+### Defect 1: Entry type name mismatches in ConversationLogParser
+
+**File:** `core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala`, lines 68-78
+
+**Observed behavior:** `parsePayload` matches on type strings that don't match the actual JSONL format produced by Claude Code. Real transcripts use `"user"`, `"file-history-snapshot"`, and `"queue-operation"`, but the parser expects `"human"`, `"file_history_snapshot"`, and `"queue_operation"`.
+
+**Impact:**
+- All user entries silently fall through to `RawLogEntry` → `numTurns` always 0, user-side token metrics lost
+- `file-history-snapshot` entries fall through to `RawLogEntry` instead of `FileHistorySnapshotLogEntry`
+- `queue-operation` entries fall through to `RawLogEntry` instead of `QueueOperationLogEntry`
+
+Additionally, two entry types observed in real transcripts are not handled at all:
+- `"permission-mode"` — carries `permissionMode` and `sessionId`
+- `"attachment"` — observed in real transcripts
+
+**Evidence from real session (08acd9a6):**
+```
+107 assistant
+ 77 user          ← parser expects "human", gets 0 matches
+  8 file-history-snapshot
+  2 permission-mode
+  2 attachment
+  2 queue-operation
+  1 system
+```
+
+#### Reproduction Steps
+
+1. Create a JSONL line with `"type": "user"` (as produced by real Claude Code sessions)
+2. Parse it with `ConversationLogParser.parseLogLine`
+3. Observe the payload is `RawLogEntry("user", ...)` instead of `UserLogEntry(...)`
+
+Similarly for `"file-history-snapshot"` and `"queue-operation"`.
+
+#### Root Cause Hypothesis
+
+**H1 (Confidence: Very High):** The type name strings in the `parsePayload` match expression were written based on an assumed format rather than the actual JSONL format produced by Claude Code. The parser uses `"human"` (Anthropic API convention) instead of `"user"` (Claude Code CLI convention), and uses underscores instead of hyphens for compound type names.
+
+**Supporting evidence:**
+- Line 69: `case "human"` — but real data uses `"user"`
+- Line 73: `case "queue_operation"` — but real data uses `"queue-operation"`
+- Line 74: `case "file_history_snapshot"` — but real data uses `"file-history-snapshot"`
+- The existing test suite uses the wrong type names too (e.g., `"type":"human"` in test fixtures)
+
+#### Fix Strategy
+
+1. Change `"human"` → `"user"` in `parsePayload` match (line 69)
+2. Change `"queue_operation"` → `"queue-operation"` in `parsePayload` match (line 73)
+3. Change `"file_history_snapshot"` → `"file-history-snapshot"` in `parsePayload` match (line 74)
+4. Add match cases for `"permission-mode"` and `"attachment"` entry types (new model types needed)
+5. Update all existing tests to use the correct type names
+6. Add tests for the new entry types
+
+**Effort:** Small — straightforward string changes plus new match cases and model types.
+
+---
+
+### Defect 2: SubAgentMetadataParser requires `agentId` field absent from `.meta.json`
+
+**File:** `core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala`, lines 11-13
+
+**Observed behavior:** `parse` requires `agentId` from the JSON:
+```scala
+for agentId <- cursor.get[String]("agentId").toOption
+```
+
+But actual `.meta.json` files contain only `agentType` and `description`:
+```json
+{"agentType":"iterative-works:code-reviewer","description":"Review security of phase 07"}
+```
+
+The agent ID is encoded in the filename (e.g., `agent-a27a237ab9050d9ef.meta.json`).
+
+**Impact:** `parse` returns `None` for every real sub-agent → empty sub-agent lists → no role classification or attribution in transcript analysis.
+
+#### Reproduction Steps
+
+1. Create a JSON object with only `agentType` and `description` (matching real `.meta.json` format)
+2. Call `SubAgentMetadataParser.parse(json, transcriptPath)`
+3. Observe it returns `None` because `agentId` is missing from JSON
+
+#### Root Cause Hypothesis
+
+**H1 (Confidence: Very High):** The parser was written assuming `agentId` would be in the JSON, but the actual `.meta.json` format doesn't include it. The callers (`DirectConversationLogIndex`, `EffectfulConversationLogIndex`) already pass the `transcriptPath` which contains the agent ID in its filename (e.g., `agent-a27a237ab9050d9ef.jsonl`).
+
+**Supporting evidence:**
+- `DirectConversationLogIndex.scala:46-54`: iterates files matching `agent-*.jsonl`, passes `jsonlPath` to parser
+- `EffectfulConversationLogIndex.scala:74`: same pattern
+- The `transcriptPath` parameter is already available — the agent ID just needs to be extracted from the filename
+
+#### Fix Strategy
+
+1. Derive `agentId` from `transcriptPath` filename instead of requiring it in JSON:
+   - Extract from filename pattern `agent-<id>.jsonl` → `agent-<id>`
+   - Or strip `.jsonl` suffix from filename: `agent-a27a237ab9050d9ef.jsonl` → `agent-a27a237ab9050d9ef`
+2. Make `agentId` no longer required from JSON (remove from for-comprehension guard)
+3. Update tests to reflect new behavior (parse succeeds without `agentId` in JSON)
+
+**Effort:** Small — extract ID from path, adjust for-comprehension.
+
+---
+
+### Defect 3: Entries without `uuid` are silently dropped
+
+**File:** `core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala`, lines 36-37
+
+**Observed behavior:** `parseLogEntry` requires `uuid` in its for-comprehension:
+```scala
+for
+  uuid <- cursor.get[String]("uuid").toOption
+```
+
+Some entry types (`permission-mode`, `file-history-snapshot`, possibly others) don't carry a `uuid` field. These entries are silently dropped before payload parsing is even attempted.
+
+**Impact:** Entry types without `uuid` can never be parsed, regardless of whether their type name is correctly matched. This compounds with Defect 1 for `file-history-snapshot` entries.
+
+#### Reproduction Steps
+
+1. Create a JSONL line with `"type": "file-history-snapshot"` but no `"uuid"` field
+2. Parse with `ConversationLogParser.parseLogEntry`
+3. Observe it returns `None` due to missing `uuid`
+
+#### Root Cause Hypothesis
+
+**H1 (Confidence: High):** The parser was written assuming all entries have a `uuid`, but some entry types in the Claude Code format don't include one. The `uuid` field should be optional in `ConversationLogEntry`, or entries without `uuid` should receive a synthetic one.
+
+**Supporting evidence:**
+- `ConversationLogEntry` stores `uuid: String` (non-optional)
+- Real transcripts show entry types without `uuid` field
+- The `uuid` is used for parent-child linking — entry types that don't participate in threading may legitimately lack it
+
+#### Fix Strategy
+
+Two options:
+
+**Option A (Minimal):** Make `uuid` optional (`Option[String]`) in `ConversationLogEntry`. Change the for-comprehension to use `= cursor.get[String]("uuid").toOption` instead of `<-`. This preserves all entries but requires downstream consumers to handle `None` uuid.
+
+**Option B (Synthetic UUID):** Generate a synthetic UUID for entries that lack one (e.g., using a hash of the entry content or a random UUID). This preserves the non-optional `uuid: String` type but introduces synthetic data.
+
+**Recommended: Option A** — it's more honest about what the data contains and avoids masking missing data.
+
+**Effort:** Small-Medium — changing `uuid` from `String` to `Option[String]` in `ConversationLogEntry` will ripple to all pattern matches and consumers.
+
+## Estimates
+
+| Defect | Effort | Risk |
+|--------|--------|------|
+| 1: Entry type name mismatches | 1-2h | Low — straightforward string fixes |
+| 2: SubAgentMetadataParser agentId | 1h | Low — extract from existing path |
+| 3: UUID-less entries | 1-2h | Medium — type change ripples through consumers |
+| **Total** | **3-6h** | |
+
+## Testing Strategy
+
+- **Defect 1:** Update existing test fixtures to use real type names (`"user"`, `"file-history-snapshot"`, `"queue-operation"`). Add tests for `"permission-mode"` and `"attachment"` types.
+- **Defect 2:** Update test to verify parsing succeeds with only `agentType` and `description` in JSON, with `agentId` derived from transcript path.
+- **Defect 3:** Add tests for entries without `uuid` field. Verify they parse successfully with `None` uuid.
+- **Integration:** If real JSONL fixtures are available, add a smoke test that parses a representative sample and verifies non-zero counts for user entries and sub-agents.

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -1,0 +1,39 @@
+# Implementation Log: Parser mismatches
+
+Issue: CC-41
+
+This log tracks the evolution of investigation and fixes across phases.
+
+---
+
+## Phase 1: Fix entry type name mismatches in ConversationLogParser (2026-04-10)
+
+**Root cause:** The type name strings in `parsePayload` match expression were written using assumed Anthropic API conventions (`"human"`, underscores) rather than actual Claude Code CLI format (`"user"`, hyphens). Test fixtures used the same wrong names, so tests passed but didn't reflect real data.
+
+**Fix applied:**
+- `ConversationLogParser.scala` — fixed 3 type name strings (`"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`), added 2 new match cases for `"permission-mode"` and `"attachment"` using existing `parseDataOnlyPayload` helper
+- `LogEntryPayload.scala` — added `PermissionModeLogEntry` and `AttachmentLogEntry` case classes with `data: Map[String, Any]`
+- `ConversationLogParserTest.scala` — updated all fixtures to correct type names, added tests for new types with data assertions and error path coverage
+- `DirectConversationLogReaderTest.scala` — updated fixture from `"human"` to `"user"`
+- `EffectfulConversationLogReaderTest.scala` — updated fixture from `"human"` to `"user"`
+
+**Regression tests added:**
+- 4 new tests (2 happy path with data assertions, 2 error path for missing uuid)
+
+**Code review:**
+- Iterations: 1 (critical issues fixed: removed duplicate tests, added data assertions, added error path tests)
+- Review file: review-phase-01-20260410-205956.md
+
+**Notes:**
+- `last_prompt` match case still uses underscore — reviewers flagged as potential same-class bug but out of scope for this phase (needs verification against real data)
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala
+M	core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+M	direct/test/src/works/iterative/claude/direct/log/DirectConversationLogReaderTest.scala
+M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogReaderTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -64,3 +64,30 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 ```
 
 ---
+
+## Phase 3: Support entries without uuid field (2026-04-10)
+
+**Root cause:** `ConversationLogParser.parseLogEntry` used monadic bind (`uuid <- cursor.get[String]("uuid").toOption`) in its for-comprehension. When `uuid` is absent from the JSON (as with `permission-mode`, `file-history-snapshot` entries), `.toOption` yields `None` and the entire for-comprehension short-circuits, silently dropping the entry before payload parsing is attempted.
+
+**Fix applied:**
+- `ConversationLogEntry.scala` — changed `uuid: String` to `uuid: Option[String]`
+- `ConversationLogParser.scala` — changed `uuid <- cursor.get[String]("uuid").toOption` to `uuid = cursor.get[String]("uuid").toOption` (plain assignment instead of monadic bind), reordered for-comprehension to start with `sessionId <-` as the first required binding
+- `ConversationLogParserTest.scala` — updated existing uuid assertions to expect `Some(...)`, added 4 new regression tests covering uuid-absent, uuid-present, file-history-snapshot without uuid, and mixed-entry transcript
+- `LogModelTest.scala` — updated all `ConversationLogEntry` constructions to use `Some("...")` for uuid field
+
+**Regression tests added:**
+- 4 new tests for uuid optional behavior
+
+**Code review:**
+- Iterations: 1 (no critical issues)
+- Review file: review-phase-03-20260410-233419.md
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/model/ConversationLogEntry.scala
+M	core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala
+M	core/test/src/works/iterative/claude/core/log/model/LogModelTest.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/implementation-log.md
+++ b/project-management/issues/CC-41/implementation-log.md
@@ -37,3 +37,30 @@ M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationL
 ```
 
 ---
+
+## Phase 2: Derive agentId from filename in SubAgentMetadataParser (2026-04-10)
+
+**Root cause:** `SubAgentMetadataParser.parse` required `agentId` from JSON via `cursor.get[String]("agentId").toOption` in a for-comprehension guard. Real `.meta.json` files produced by Claude Code CLI contain only `agentType` and `description` — `agentId` is encoded in the transcript filename (`agent-<id>.jsonl`). The for-comprehension always yielded `None` for real data.
+
+**Fix applied:**
+- `SubAgentMetadataParser.scala` — replaced for-comprehension with `Option.when(!json.isNull)`, deriving `agentId` from `transcriptPath.last.stripSuffix(".jsonl")` instead of reading from JSON
+- `SubAgentMetadataParserTest.scala` — updated all test fixtures to use realistic transcript paths (`agent-<id>.jsonl`) and removed `agentId` from JSON; removed duplicate test; renamed tests for clarity; added 3 new tests
+- `DirectConversationLogIndexTest.scala` — updated agentId expectations from `"abc"` to `"agent-abc"` (filename-derived)
+- `EffectfulConversationLogIndexTest.scala` — same agentId expectation updates
+
+**Regression tests added:**
+- 3 new tests: agentId derived from filename, agentId in JSON ignored, real-world `.meta.json` content
+
+**Code review:**
+- Iterations: 1 (no critical issues; warnings fixed: removed duplicate test, inlined cursor variable, improved test names and PURPOSE comment)
+- Review file: review-phase-02-20260410-211739.md
+
+**Files changed:**
+```
+M	core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala
+M	core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala
+M	direct/test/src/works/iterative/claude/direct/log/DirectConversationLogIndexTest.scala
+M	effectful/test/src/works/iterative/claude/effectful/log/EffectfulConversationLogIndexTest.scala
+```
+
+---

--- a/project-management/issues/CC-41/phase-01-context.md
+++ b/project-management/issues/CC-41/phase-01-context.md
@@ -1,0 +1,107 @@
+# Phase 01: Fix entry type name mismatches in ConversationLogParser
+
+## Defect Description
+
+The `ConversationLogParser.parsePayload` match expression uses type name strings that don't match the actual JSONL format produced by Claude Code CLI. Three type names are wrong and two observed entry types are entirely unhandled:
+
+**Wrong type names (silently fall through to `RawLogEntry`):**
+- Line 69: matches `"human"` but real data uses `"user"`
+- Line 73: matches `"queue_operation"` but real data uses `"queue-operation"`
+- Line 74: matches `"file_history_snapshot"` but real data uses `"file-history-snapshot"`
+
+**Missing entry types (no match case at all):**
+- `"permission-mode"` — carries `permissionMode` and `sessionId`
+- `"attachment"` — observed in real transcripts
+
+The most impactful bug is `"human"` vs `"user"`: all user entries become `RawLogEntry`, so `numTurns` is always 0 and user-side token metrics are lost.
+
+## Reproduction Steps
+
+1. Create a JSONL line with `"type": "user"` (as produced by real Claude Code sessions):
+   ```json
+   {"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}
+   ```
+2. Parse it with `ConversationLogParser.parseLogLine`
+3. Observe payload is `RawLogEntry("user", ...)` instead of `UserLogEntry(...)`
+
+Same pattern for `"queue-operation"` and `"file-history-snapshot"`.
+
+## Root Cause Hypotheses
+
+**H1 (Confidence: Very High):** The type name strings were written based on assumed format (Anthropic API convention: `"human"`, underscores) rather than the actual Claude Code CLI format (`"user"`, hyphens). The existing test suite also uses the wrong type names, so tests pass but don't reflect real data.
+
+Supporting evidence:
+- Real session (08acd9a6) shows 77 `user` entries, 0 `human` entries
+- Real data uses hyphens (`file-history-snapshot`) not underscores (`file_history_snapshot`)
+- Test fixtures match the buggy code, not real data
+
+## Investigation Plan
+
+1. Confirm the three wrong type name strings in `parsePayload` match expression
+2. Identify all test fixtures using the wrong type names
+3. Check if any downstream consumers depend on the wrong names (grep for `"human"`, `"queue_operation"`, `"file_history_snapshot"`)
+4. Determine required model types for `permission-mode` and `attachment`
+
+## Fix Strategy
+
+1. **Fix type name strings in `parsePayload`:**
+   - `"human"` -> `"user"` (line 69)
+   - `"queue_operation"` -> `"queue-operation"` (line 73)
+   - `"file_history_snapshot"` -> `"file-history-snapshot"` (line 74)
+
+2. **Add model types for new entry types** in `LogEntryPayload.scala`:
+   - `PermissionModeLogEntry(permissionMode: String, data: Map[String, Any])` — or use `parseDataOnlyPayload` pattern
+   - `AttachmentLogEntry(data: Map[String, Any])` — use `parseDataOnlyPayload` pattern
+
+3. **Add match cases** in `parsePayload` for `"permission-mode"` and `"attachment"`
+
+4. **Update all existing tests** to use correct type names (`"user"` instead of `"human"`, etc.)
+
+5. **Add new tests** for `"permission-mode"` and `"attachment"` entry types
+
+6. **Update test descriptions** that reference old type names (e.g., `"human" type with string content...`)
+
+## Files to Modify
+
+- `core/src/works/iterative/claude/core/log/parsing/ConversationLogParser.scala` — fix 3 type name strings, add 2 new match cases
+- `core/src/works/iterative/claude/core/log/model/LogEntryPayload.scala` — add `PermissionModeLogEntry` and `AttachmentLogEntry` types
+- `core/test/src/works/iterative/claude/core/log/parsing/ConversationLogParserTest.scala` — update all `"human"` fixtures to `"user"`, `"queue_operation"` to `"queue-operation"`, `"file_history_snapshot"` to `"file-history-snapshot"`; add tests for new types; update test descriptions
+
+## Testing Requirements
+
+**Existing tests to update (type name in fixture JSON):**
+- `parseLogLine with valid JSONL line` — uses `"human"`
+- `parseLogEntry with missing required uuid field` — uses `"human"`
+- `parseLogEntry with missing required sessionId field` — uses `"human"`
+- `parses all envelope metadata fields` — uses `"human"`
+- `parses with optional fields absent` — uses `"human"`
+- `parses ISO-8601 timestamp string to Instant` — uses `"human"`
+- `isSidechain defaults to false when absent` — uses `"human"`
+- `"human" type with string content` — uses `"human"` in fixture and description
+- `"human" type with array content` — uses `"human"` in fixture and description
+- `"queue_operation" type with operation and content` — uses `"queue_operation"` in fixture and description
+- `"file_history_snapshot" type with data` — uses `"file_history_snapshot"` in fixture and description
+- `"queue_operation" type without operation returns None` — uses `"queue_operation"` in fixture and description
+- `"human" type without message field returns None` — uses `"human"` in fixture and description
+- `JSONL line with agentId field` — uses `"human"`
+- `JSONL line without agentId field` — uses `"human"`
+- `agentId is excluded from data maps in system entries` — no change needed
+- `malformed timestamp string results in None timestamp` — uses `"human"`
+
+**New tests to add:**
+- `"permission-mode"` type produces correct payload with `permissionMode` field
+- `"attachment"` type produces correct payload
+- Verify `"user"` type is parsed as `UserLogEntry` (not just updating old test — confirm the fix works)
+
+## Acceptance Criteria
+
+1. All three wrong type name strings are fixed in `parsePayload`
+2. `ConversationLogParser.parseLogLine` correctly produces `UserLogEntry` for `"type": "user"` entries
+3. `ConversationLogParser.parseLogLine` correctly produces `QueueOperationLogEntry` for `"type": "queue-operation"` entries
+4. `ConversationLogParser.parseLogLine` correctly produces `FileHistorySnapshotLogEntry` for `"type": "file-history-snapshot"` entries
+5. New model types exist for `permission-mode` and `attachment` entry types
+6. `parsePayload` handles `"permission-mode"` and `"attachment"` without falling through to `RawLogEntry`
+7. All existing tests pass with updated type names
+8. New tests exist and pass for `permission-mode` and `attachment` types
+9. `./mill core.compile` succeeds with no warnings
+10. `./mill core.test` passes all tests

--- a/project-management/issues/CC-41/phase-01-tasks.md
+++ b/project-management/issues/CC-41/phase-01-tasks.md
@@ -1,0 +1,11 @@
+# Phase 01 Tasks: Fix entry type name mismatches in ConversationLogParser
+
+## Tasks
+
+- [ ] [impl] [ ] [reviewed] Write failing tests reproducing the type name mismatches (`"user"` → `RawLogEntry` instead of `UserLogEntry`, `"queue-operation"` → `RawLogEntry` instead of `QueueOperationLogEntry`, `"file-history-snapshot"` → `RawLogEntry` instead of `FileHistorySnapshotLogEntry`)
+- [ ] [impl] [ ] [reviewed] Write failing tests for unhandled entry types (`"permission-mode"` and `"attachment"` fall through to `RawLogEntry`)
+- [ ] [impl] [ ] [reviewed] Fix type name strings in `ConversationLogParser.parsePayload`: `"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`
+- [ ] [impl] [ ] [reviewed] Add model types for `PermissionModeLogEntry` and `AttachmentLogEntry` in `LogEntryPayload.scala`
+- [ ] [impl] [ ] [reviewed] Add match cases for `"permission-mode"` and `"attachment"` in `parsePayload`
+- [ ] [impl] [ ] [reviewed] Update all existing test fixtures to use correct type names (`"user"`, `"queue-operation"`, `"file-history-snapshot"`) and update test descriptions
+- [ ] [impl] [ ] [reviewed] Verify all tests pass and no compilation warnings (`./mill core.compile` and `./mill core.test`)

--- a/project-management/issues/CC-41/phase-01-tasks.md
+++ b/project-management/issues/CC-41/phase-01-tasks.md
@@ -2,10 +2,11 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing tests reproducing the type name mismatches (`"user"` → `RawLogEntry` instead of `UserLogEntry`, `"queue-operation"` → `RawLogEntry` instead of `QueueOperationLogEntry`, `"file-history-snapshot"` → `RawLogEntry` instead of `FileHistorySnapshotLogEntry`)
-- [ ] [impl] [ ] [reviewed] Write failing tests for unhandled entry types (`"permission-mode"` and `"attachment"` fall through to `RawLogEntry`)
-- [ ] [impl] [ ] [reviewed] Fix type name strings in `ConversationLogParser.parsePayload`: `"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`
-- [ ] [impl] [ ] [reviewed] Add model types for `PermissionModeLogEntry` and `AttachmentLogEntry` in `LogEntryPayload.scala`
-- [ ] [impl] [ ] [reviewed] Add match cases for `"permission-mode"` and `"attachment"` in `parsePayload`
-- [ ] [impl] [ ] [reviewed] Update all existing test fixtures to use correct type names (`"user"`, `"queue-operation"`, `"file-history-snapshot"`) and update test descriptions
-- [ ] [impl] [ ] [reviewed] Verify all tests pass and no compilation warnings (`./mill core.compile` and `./mill core.test`)
+- [x] [impl] [x] [reviewed] Write failing tests reproducing the type name mismatches (`"user"` → `RawLogEntry` instead of `UserLogEntry`, `"queue-operation"` → `RawLogEntry` instead of `QueueOperationLogEntry`, `"file-history-snapshot"` → `RawLogEntry` instead of `FileHistorySnapshotLogEntry`)
+- [x] [impl] [x] [reviewed] Write failing tests for unhandled entry types (`"permission-mode"` and `"attachment"` fall through to `RawLogEntry`)
+- [x] [impl] [x] [reviewed] Fix type name strings in `ConversationLogParser.parsePayload`: `"human"` → `"user"`, `"queue_operation"` → `"queue-operation"`, `"file_history_snapshot"` → `"file-history-snapshot"`
+- [x] [impl] [x] [reviewed] Add model types for `PermissionModeLogEntry` and `AttachmentLogEntry` in `LogEntryPayload.scala`
+- [x] [impl] [x] [reviewed] Add match cases for `"permission-mode"` and `"attachment"` in `parsePayload`
+- [x] [impl] [x] [reviewed] Update all existing test fixtures to use correct type names (`"user"`, `"queue-operation"`, `"file-history-snapshot"`) and update test descriptions
+- [x] [impl] [x] [reviewed] Verify all tests pass and no compilation warnings (`./mill core.compile` and `./mill core.test`)
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/phase-02-context.md
+++ b/project-management/issues/CC-41/phase-02-context.md
@@ -1,0 +1,105 @@
+# Phase 02: Derive agentId from filename in SubAgentMetadataParser
+
+## Defect Description
+
+`SubAgentMetadataParser.parse` requires `agentId` from the JSON payload:
+```scala
+for agentId <- cursor.get[String]("agentId").toOption
+```
+
+But actual `.meta.json` files produced by Claude Code CLI contain only `agentType` and `description`:
+```json
+{"agentType":"iterative-works:code-reviewer","description":"Review security of phase 07"}
+```
+
+The agent ID is encoded in the filename (e.g., `agent-a27a237ab9050d9ef.meta.json`), not in the JSON content.
+
+**Impact:** `parse` returns `None` for every real sub-agent metadata file, producing empty sub-agent lists. This means no role classification or attribution in transcript analysis.
+
+## Reproduction Steps
+
+1. Create a `.meta.json` file with real-world content (no `agentId` field):
+   ```json
+   {"agentType":"iterative-works:code-reviewer","description":"Review security of phase 07"}
+   ```
+2. Create a corresponding transcript path: `/tmp/subagents/agent-a27a237ab9050d9ef.jsonl`
+3. Call `SubAgentMetadataParser.parse(json, transcriptPath)`
+4. Observe result is `None` — the for-comprehension fails because `agentId` is not in JSON
+
+## Root Cause Hypotheses
+
+**H1 (Confidence: Very High):** The parser was written assuming `agentId` would be present in the JSON payload, but the actual Claude Code CLI `.meta.json` format does not include it. The agent ID is only available from the filename of the transcript (and meta) files, which already follows the pattern `agent-<id>.jsonl`. The `transcriptPath` parameter already carries this information.
+
+Supporting evidence:
+- Real `.meta.json` files contain only `agentType` and `description`
+- The filename pattern `agent-<id>.jsonl` is enforced by both callers (`DirectConversationLogIndex` and `EffectfulConversationLogIndex`) via `startsWith("agent-")` and `endsWith(".jsonl")` filters
+- The existing test that expects `None` for JSON missing `agentId` actually represents the real-world scenario (test titled "JSON missing required agentId returns None")
+
+## Investigation Plan
+
+1. Confirm `agentId` is never present in real `.meta.json` files
+2. Verify that the `transcriptPath` parameter always follows the `agent-<id>.jsonl` naming pattern (check both callers)
+3. Determine the correct extraction logic: strip `.jsonl` suffix from filename to get `agent-<id>`
+4. Review `SubAgentMetadata` model to confirm `agentId` field type and usage downstream
+
+## Fix Strategy
+
+1. **Derive `agentId` from `transcriptPath` filename** instead of requiring it in JSON:
+   - Extract from `transcriptPath.last.stripSuffix(".jsonl")` to get e.g. `agent-a27a237ab9050d9ef`
+   - The `agentId` is always available since callers filter for `agent-*.jsonl` files
+
+2. **Remove `agentId` from the for-comprehension guard** — the parser should always succeed when given valid JSON (even empty `{}`), since `agentType` and `description` are already optional
+
+3. **Decide on parse behavior for edge cases:**
+   - Empty JSON object `{}`: should now succeed (agentId from filename, optional fields as None)
+   - JSON null: should still return None (cannot extract cursor)
+   - Consider whether to validate the filename pattern or trust the caller
+
+4. **Update tests** to reflect that:
+   - `agentId` comes from the transcript path filename, not JSON
+   - JSON without `agentId` is the normal case (not an error)
+   - Test fixtures should use realistic `.meta.json` content
+   - The transcript path in test fixtures should use realistic filenames like `agent-abc123.jsonl`
+
+## Files to Modify
+
+- `core/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParser.scala` — derive `agentId` from `transcriptPath.last.stripSuffix(".jsonl")` instead of reading from JSON
+- `core/test/src/works/iterative/claude/core/log/parsing/SubAgentMetadataParserTest.scala` — update test fixtures and expectations:
+  - Use realistic transcript paths (`agent-<id>.jsonl`)
+  - Use realistic JSON content (no `agentId` field)
+  - Fix expectations for what returns `Some` vs `None`
+
+## What Was Fixed in Phase 01
+
+Phase 01 fixed entry type name mismatches in `ConversationLogParser.parsePayload`:
+- Corrected 3 type name strings (`"human"` → `"user"`, underscores → hyphens)
+- Added `PermissionModeLogEntry` and `AttachmentLogEntry` model types and match cases
+- Updated all test fixtures to use correct type names
+- All tests pass after fixes
+
+## Testing Requirements
+
+**Existing tests to update:**
+- `"valid JSON with all fields returns Some(SubAgentMetadata)"` — remove `agentId` from JSON fixture; use a realistic transcript path like `agent-abc123.jsonl`; assert `agentId` equals `"agent-abc123"` (derived from path)
+- `"JSON with only required agentId returns Some with None optional fields"` — rename and update: JSON should be `{}` or contain only non-id fields; `agentId` still derived from path
+- `"JSON missing required agentId returns None"` — this should now return `Some` since agentId comes from filename; update test accordingly
+- `"empty JSON object returns None"` — should now return `Some` with agentId from filename and None optional fields
+- `"JSON null returns None"` — should still return None (or reconsider based on implementation)
+- `"transcriptPath is stored in parsed SubAgentMetadata"` — update to use realistic path; remove `agentId` from JSON
+
+**New tests to add:**
+- Verify `agentId` is derived from transcript filename, not from JSON
+- Verify `agentId` in JSON is ignored (if present) in favor of filename-derived value
+- Verify realistic `.meta.json` content (only `agentType` and `description`) parses successfully
+
+## Acceptance Criteria
+
+1. `SubAgentMetadataParser.parse` returns `Some(SubAgentMetadata)` for real-world `.meta.json` content that lacks `agentId`
+2. `agentId` is derived from the transcript path filename (e.g., `agent-a27a237ab9050d9ef.jsonl` → `"agent-a27a237ab9050d9ef"`)
+3. `agentType` and `description` are still parsed from JSON as optional fields
+4. JSON without any fields (empty object) still produces a valid `SubAgentMetadata` with agentId from filename
+5. All updated and new tests pass
+6. `./mill core.compile` succeeds with no warnings
+7. `./mill core.test` passes all tests
+8. No changes to `SubAgentMetadata` model class (field types remain the same)
+9. No changes to caller code in `DirectConversationLogIndex` or `EffectfulConversationLogIndex`

--- a/project-management/issues/CC-41/phase-02-tasks.md
+++ b/project-management/issues/CC-41/phase-02-tasks.md
@@ -5,9 +5,10 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (parse returns None for real-world .meta.json content without agentId)
-- [ ] [impl] [ ] [reviewed] Investigate root cause — confirm agentId is never in real .meta.json and verify transcriptPath filename pattern from callers
-- [ ] [impl] [ ] [reviewed] Implement fix — derive agentId from transcriptPath filename instead of requiring it in JSON
-- [ ] [impl] [ ] [reviewed] Update existing tests to use realistic fixtures (no agentId in JSON, agent-<id>.jsonl paths)
-- [ ] [impl] [ ] [reviewed] Add new tests: agentId derived from filename, agentId in JSON ignored, empty JSON object with valid path
-- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions (./mill core.compile, ./mill core.test)
+- [x] [impl] [x] [reviewed] Write failing test reproducing the defect (parse returns None for real-world .meta.json content without agentId)
+- [x] [impl] [x] [reviewed] Investigate root cause — confirm agentId is never in real .meta.json and verify transcriptPath filename pattern from callers
+- [x] [impl] [x] [reviewed] Implement fix — derive agentId from transcriptPath filename instead of requiring it in JSON
+- [x] [impl] [x] [reviewed] Update existing tests to use realistic fixtures (no agentId in JSON, agent-<id>.jsonl paths)
+- [x] [impl] [x] [reviewed] Add new tests: agentId derived from filename, agentId in JSON ignored, empty JSON object with valid path
+- [x] [impl] [x] [reviewed] Verify fix passes and no regressions (./mill core.compile, ./mill core.test)
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/phase-02-tasks.md
+++ b/project-management/issues/CC-41/phase-02-tasks.md
@@ -1,0 +1,13 @@
+# Phase 02 Tasks: Derive agentId from filename in SubAgentMetadataParser
+
+**Issue:** CC-41
+**Phase:** 02 — Derive agentId from filename in SubAgentMetadataParser
+
+## Tasks
+
+- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (parse returns None for real-world .meta.json content without agentId)
+- [ ] [impl] [ ] [reviewed] Investigate root cause — confirm agentId is never in real .meta.json and verify transcriptPath filename pattern from callers
+- [ ] [impl] [ ] [reviewed] Implement fix — derive agentId from transcriptPath filename instead of requiring it in JSON
+- [ ] [impl] [ ] [reviewed] Update existing tests to use realistic fixtures (no agentId in JSON, agent-<id>.jsonl paths)
+- [ ] [impl] [ ] [reviewed] Add new tests: agentId derived from filename, agentId in JSON ignored, empty JSON object with valid path
+- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions (./mill core.compile, ./mill core.test)

--- a/project-management/issues/CC-41/phase-03-context.md
+++ b/project-management/issues/CC-41/phase-03-context.md
@@ -1,0 +1,61 @@
+# Phase 03: Support entries without uuid field
+
+## Defect Description
+
+`ConversationLogParser.parseLogEntry` requires a `uuid` field in its for-comprehension (line 36-37 of `ConversationLogParser.scala`):
+
+```scala
+for
+  uuid <- cursor.get[String]("uuid").toOption
+```
+
+Entry types such as `permission-mode` and `file-history-snapshot` do not carry a `uuid` field in the Claude Code JSON format. Because the for-comprehension short-circuits on `None`, these entries are silently dropped before payload parsing is even attempted. This means entire categories of log entries are invisible to consumers regardless of whether their type name is correctly matched.
+
+## Reproduction Steps
+
+1. Obtain a Claude Code transcript containing a `permission-mode` or `file-history-snapshot` entry (these lack a `uuid` field)
+2. Parse the transcript using `ConversationLogParser.parseConversationLog`
+3. Observe that entries without `uuid` are absent from the parsed result
+4. Confirm the entries exist in the raw JSON but are filtered out by the `uuid <- ...toOption` binding
+
+## Root Cause Hypotheses
+
+### H1: Parser assumes all entries carry a uuid field (Confidence: High)
+
+The for-comprehension in `parseLogEntry` uses monadic binding (`<-`) for the `uuid` extraction. When `cursor.get[String]("uuid")` fails (because the field is absent), `.toOption` yields `None`, and the entire for-comprehension short-circuits to `None`. The parser was written under the assumption that every entry has a `uuid`, but the Claude Code format does not guarantee this for all entry types.
+
+## Fix Strategy
+
+Make `uuid` optional in `ConversationLogEntry` (change from `String` to `Option[String]`). In the for-comprehension, replace the monadic bind:
+
+```scala
+// Before
+uuid <- cursor.get[String]("uuid").toOption
+
+// After
+uuid = cursor.get[String]("uuid").toOption
+```
+
+This converts `uuid` from a filter condition into a plain assignment, so entries without `uuid` pass through with `None` instead of being dropped. Downstream consumers of `ConversationLogEntry` must then handle `Option[String]` for the `uuid` field.
+
+Propagate the type change through any code that references `ConversationLogEntry.uuid` (model classes, tests, downstream consumers).
+
+## Previous Phase Fixes
+
+- **Phase 01** fixed entry type name mismatches (`"human"` to `"user"`, underscore to hyphen for compound types) and added `permission-mode` and `attachment` entry type support. Without Phase 03, `permission-mode` entries are still dropped despite their type name now being recognized, because they lack `uuid`.
+- **Phase 02** made `agentId` derived from the transcript filename rather than requiring it in the JSON. This removed one source of silent entry dropping; Phase 03 removes another.
+
+## Testing Requirements
+
+- **Unit test**: Parse a JSON entry that has no `uuid` field and verify it produces a `ConversationLogEntry` with `uuid = None`
+- **Unit test**: Parse a JSON entry that has a `uuid` field and verify it produces a `ConversationLogEntry` with `uuid = Some(value)`
+- **Unit test**: Parse a transcript containing a mix of entries with and without `uuid` and verify all entries are present in the result
+- **Regression test**: Verify that existing entry types (`user`, `assistant`, `tool-use`, `tool-result`) that do carry `uuid` still parse correctly with `Some(uuid)`
+
+## Acceptance Criteria
+
+- `ConversationLogEntry.uuid` has type `Option[String]`
+- Entries without a `uuid` field in the JSON are parsed successfully (not silently dropped)
+- Entries with a `uuid` field still parse correctly, with the value wrapped in `Some`
+- All existing tests pass (updated to expect `Option[String]` where needed)
+- New tests cover both the `uuid`-present and `uuid`-absent cases

--- a/project-management/issues/CC-41/phase-03-tasks.md
+++ b/project-management/issues/CC-41/phase-03-tasks.md
@@ -5,8 +5,9 @@
 
 ## Tasks
 
-- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (entry without uuid is silently dropped)
-- [ ] [impl] [ ] [reviewed] Investigate root cause (confirm uuid monadic bind causes short-circuit)
-- [ ] [impl] [ ] [reviewed] Implement fix (make uuid optional in ConversationLogEntry, change `<-` to `=` in for-comprehension)
-- [ ] [impl] [ ] [reviewed] Propagate Option[String] type change through downstream consumers and tests
-- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions
+- [x] [impl] [x] [reviewed] Write failing test reproducing the defect (entry without uuid is silently dropped)
+- [x] [impl] [x] [reviewed] Investigate root cause (confirm uuid monadic bind causes short-circuit)
+- [x] [impl] [x] [reviewed] Implement fix (make uuid optional in ConversationLogEntry, change `<-` to `=` in for-comprehension)
+- [x] [impl] [x] [reviewed] Propagate Option[String] type change through downstream consumers and tests
+- [x] [impl] [x] [reviewed] Verify fix passes and no regressions
+**Phase Status:** Complete

--- a/project-management/issues/CC-41/phase-03-tasks.md
+++ b/project-management/issues/CC-41/phase-03-tasks.md
@@ -1,0 +1,12 @@
+# Phase 03 Tasks: Support entries without uuid field
+
+**Issue:** CC-41
+**Phase:** 03 — Support entries without uuid field
+
+## Tasks
+
+- [ ] [impl] [ ] [reviewed] Write failing test reproducing the defect (entry without uuid is silently dropped)
+- [ ] [impl] [ ] [reviewed] Investigate root cause (confirm uuid monadic bind causes short-circuit)
+- [ ] [impl] [ ] [reviewed] Implement fix (make uuid optional in ConversationLogEntry, change `<-` to `=` in for-comprehension)
+- [ ] [impl] [ ] [reviewed] Propagate Option[String] type change through downstream consumers and tests
+- [ ] [impl] [ ] [reviewed] Verify fix passes and no regressions

--- a/project-management/issues/CC-41/release-notes.md
+++ b/project-management/issues/CC-41/release-notes.md
@@ -1,0 +1,10 @@
+# Oprava parsování konverzačních logů
+
+**Issue:** CC-41
+**Datum:** 2026-04-10
+
+Parsování konverzačních logů z Claude Code nyní správně rozpoznává všechny typy záznamů, které se v reálných přepisech vyskytují. Dříve byly uživatelské zprávy, metadata subagentů a některé další záznamy tiše zahazovány, což vedlo k neúplným výsledkům analýzy — například počet uživatelských vstupů byl vždy nulový a informace o subagenttech zcela chyběly.
+
+Po opravě systém korektně zpracovává uživatelské zprávy, záznamy o historii souborů, operacích ve frontě, oprávněních a přílohách. Metadata subagentů jsou nyní spolehlivě načítána, takže analýza přepisů zahrnuje kompletní přehled o rolích a aktivitách všech subagentů v konverzaci. Záznamy, které neobsahují identifikátor UUID, již nejsou ignorovány a jsou korektně zahrnuty do výsledků.
+
+Díky těmto změnám poskytuje analýza přepisů úplný a přesný obraz o průběhu konverzací, včetně správného počtu interakcí, tokenových metrik a atribuce rolí subagentů.

--- a/project-management/issues/CC-41/review-phase-01-20260410-205956.md
+++ b/project-management/issues/CC-41/review-phase-01-20260410-205956.md
@@ -1,0 +1,75 @@
+# Code Review Results
+
+**Review Context:** Phase 1: Fix entry type name mismatches in ConversationLogParser for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 3
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-architecture
+**Timestamp:** 2026-04-10T20:59:56Z
+**Git Context:** git diff 0856ccd
+
+---
+
+## Style Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` uses underscore while all corrected types use hyphens — may be latent bug of same class
+- Stale `"human"` in invalid JSON test fixture (line 33)
+
+### Suggestions
+- Trailing spaces in match arms
+- Regression test section comment uses temporal framing
+
+---
+
+## Testing Review
+
+### Critical Issues
+- Regression tests for `user`, `queue-operation`, `file-history-snapshot` duplicate existing updated tests
+- `permission-mode` and `attachment` tests don't verify data contents
+- No error path tests for `permission-mode` and `attachment`
+
+### Warnings
+- `last_prompt` should be verified against real wire format
+
+### Suggestions
+- Rename regression section comment
+
+---
+
+## Scala 3 Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` underscore inconsistency (same as style review)
+
+### Suggestions
+- `LogEntryPayload` could be Scala 3 enum (future refactor)
+- `Map[String, Any]` pattern is pre-existing debt
+
+---
+
+## Architecture Review
+
+### Critical Issues
+None.
+
+### Warnings
+- `last_prompt` inconsistency (same finding)
+- `Map[String, Any]` deepens weak typing (pre-existing, out of scope)
+
+### Suggestions
+- Test duplication and temporal naming in regression section
+
+---
+
+## Summary
+
+- **Critical issues:** 3 (all testing — duplicate tests, missing data assertions, missing error path tests)
+- **Warnings:** 6 (most cross-cutting: `last_prompt` naming inconsistency)
+- **Suggestions:** 5 (mostly out of scope / pre-existing patterns)
+
+Note: `last_prompt` naming is a valid concern but out of scope for Phase 1 (which fixes known mismatches from real data analysis). Should be tracked as potential follow-up.

--- a/project-management/issues/CC-41/review-phase-02-20260410-211739.md
+++ b/project-management/issues/CC-41/review-phase-02-20260410-211739.md
@@ -1,0 +1,78 @@
+# Code Review Results
+
+**Review Context:** Phase 02: Derive agentId from filename in SubAgentMetadataParser for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 2
+**Skills Applied:** code-review-scala3, code-review-testing, code-review-style, code-review-composition
+**Timestamp:** 2026-04-10T21:17:39Z
+**Git Context:** git diff 4a19cc9
+
+---
+
+<review skill="code-review-scala3">
+
+### Critical Issues
+None
+
+### Warnings
+None
+
+### Suggestions
+None — code is idiomatic Scala 3 throughout.
+
+</review>
+
+---
+
+<review skill="code-review-testing">
+
+### Critical Issues
+None
+
+### Warnings
+1. **Duplicate test coverage** between "JSON with no optional fields" (line 29) and "empty JSON object" (line 54) — both parse `{}` against same path, second is strict subset of first.
+2. **Multiple assertions per test** in several cases (lines 21-27, 33-40, 47-52, 100-107) — when one fails, remaining are skipped.
+
+### Suggestions
+1. Test name "valid JSON with all fields" is imprecise after refactor — `agentId` no longer comes from JSON.
+2. No test for non-`.jsonl` extension or filename without a dot.
+
+</review>
+
+---
+
+<review skill="code-review-style">
+
+### Critical Issues
+None
+
+### Warnings
+1. **Duplicate test** between lines 29-40 and 54-61 — second is strict subset.
+
+### Suggestions
+1. British spelling "favour" inconsistent with rest of codebase — use neutral phrasing.
+2. Second PURPOSE line could mention null JSON as the only `None` condition.
+
+</review>
+
+---
+
+<review skill="code-review-composition">
+
+### Critical Issues
+None
+
+### Warnings
+1. **`cursor` variable could be inlined** — `json.hcursor` called directly in constructor args removes intermediate variable.
+
+### Suggestions
+1. Duplicate test case flagged again.
+
+</review>
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** 3 (duplicate test, multiple assertions per test, inlinable cursor)
+- **Suggestions:** 4 (test rename, edge case test, spelling, PURPOSE comment)

--- a/project-management/issues/CC-41/review-phase-03-20260410-233419.md
+++ b/project-management/issues/CC-41/review-phase-03-20260410-233419.md
@@ -1,0 +1,73 @@
+# Code Review Results
+
+**Review Context:** Phase 3: Support entries without uuid field for issue CC-41 (Iteration 1/3)
+**Files Reviewed:** 4
+**Skills Applied:** code-review-style, code-review-testing, code-review-scala3, code-review-composition
+**Timestamp:** 2026-04-10 23:34:19
+**Git Context:** git diff 1d15b36
+
+---
+
+## Style Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Section divider comment `// --- uuid optional tests ---` uses a style inconsistent with rest of file
+
+### Suggestions
+- Duplicated test coverage between renamed existing tests and new tests
+- `assertEquals` message with embedded count could become stale
+
+---
+
+## Testing Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Duplicate test coverage: permission-mode tested at line 585 and again at line 682
+- `LogModelTest` does not add a test for `uuid = None` case
+
+### Suggestions
+- `match`/`fail` pattern repeated across many tests — consider a helper
+- Mixed-transcript integration test only asserts size, not individual entry content
+
+---
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+None found.
+
+### Warnings
+None found.
+
+### Suggestions
+- `uuid: Option[String]` is a candidate for opaque type (pre-existing, not introduced by this diff)
+- Pattern-match style in tests is verbose — could use `getOrElse(fail(...))` idiom
+
+---
+
+## Composition Review
+
+### Critical Issues
+None found.
+
+### Warnings
+- Repeated `match`/`fail` pattern not composed into helper
+
+### Suggestions
+- `parseLogEntry` for-comprehension mixes effectful and pure bindings — brief comment would help readability
+
+---
+
+## Summary
+
+- **Critical Issues:** 0
+- **Warnings:** 3
+- **Suggestions:** 6
+
+No critical issues found. Warnings relate to test duplication and missing model-level test coverage. All suggestions are improvements to existing patterns, not regressions introduced by this change.

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -29,11 +29,11 @@
       "path": "project-management/issues/CC-41/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:13:53.573356812Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T21:23:39.899134733Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 02: Tasks Ready",
-    "type": "success",
+    "text": "Phase 02: Awaiting Review",
+    "type": "warning",
     "subtext": "Derive agentId from filename in SubAgentMetadataParser"
   },
   "badges": [
@@ -48,9 +48,17 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 02 tasks ready",
+  "message": "Phase 02 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
@@ -83,6 +91,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -92,5 +105,5 @@
       "context_sha": "context_sha=7fd16df51262440f70f783f27d5ef7bbdae0683e"
     }
   },
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/42"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/43"
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -21,20 +21,28 @@
       "path": "project-management/issues/CC-41/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T20:41:05.367633319Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T21:07:23.943780008Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 1: Tasks Ready",
-    "type": "success",
+    "text": "Phase 01: Awaiting Review",
+    "type": "warning",
     "subtext": "Fix entry type name mismatches in ConversationLogParser"
   },
   "badges": [
     {
       "label": "High",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 1 tasks ready",
+  "message": "Phase 01 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
@@ -57,6 +65,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -65,5 +78,6 @@
     "1": {
       "context_sha": "context_sha=97133ae79e91cdccb9f63747b036035553a02842"
     }
-  }
+  },
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/42"
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -35,13 +35,21 @@
     {
       "label": "Phase 3 Tasks",
       "path": "project-management/issues/CC-41/phase-03-tasks.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-41/implementation-log.md"
+    },
+    {
+      "label": "Release Notes",
+      "path": "project-management/issues/CC-41/release-notes.md"
     }
   ],
-  "last_updated": "2026-04-10T21:36:39.730209227Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-10T21:40:06.506792918Z",
+  "status": "all_complete",
   "display": {
-    "text": "Phase 03: Awaiting Review",
-    "type": "warning",
+    "text": "Ready for Final Review",
+    "type": "success",
     "subtext": "Support entries without uuid field"
   },
   "badges": [
@@ -74,7 +82,7 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 03 implementation started",
+  "message": "All phases complete - final PR created",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
@@ -122,6 +130,11 @@
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -131,5 +144,5 @@
       "context_sha": "context_sha=8a9d1bc33084892701f6b447e2d5198f89227c3e"
     }
   },
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/44"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/45"
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -11,14 +11,18 @@
       "label": "Tasks",
       "path": "project-management/issues/CC-41/tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Context",
+      "path": "project-management/issues/CC-41/phase-01-context.md"
     }
   ],
-  "last_updated": "2026-04-10T18:03:05.923453133Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T18:08:36.622684105Z",
+  "status": "context_ready",
   "display": {
-    "text": "Tasks Ready",
-    "type": "success",
-    "subtext": "3 phases identified"
+    "text": "Phase 1: Context Ready",
+    "type": "info",
+    "subtext": "Fix entry type name mismatches in ConversationLogParser"
   },
   "badges": [
     {
@@ -26,8 +30,8 @@
       "type": "warning"
     }
   ],
-  "message": "Task breakdown complete. Ready to begin implementation.",
-  "activity": "waiting",
+  "message": "Phase 1 context ready for review",
+  "activity": "working",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -47,5 +51,10 @@
     }
   ],
   "git_sha": "460dfe1",
-  "needs_attention": true
+  "needs_attention": true,
+  "phase_checkpoints": {
+    "1": {
+      "context_sha": "context_sha=97133ae79e91cdccb9f63747b036035553a02842"
+    }
+  }
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -1,0 +1,51 @@
+{
+  "version": 2,
+  "issue_id": "CC-41",
+  "artifacts": [
+    {
+      "label": "Analysis",
+      "path": "project-management/issues/CC-41/analysis.md",
+      "category": "input"
+    },
+    {
+      "label": "Tasks",
+      "path": "project-management/issues/CC-41/tasks.md",
+      "category": "output"
+    }
+  ],
+  "last_updated": "2026-04-10T18:03:05.923453133Z",
+  "status": "tasks_ready",
+  "display": {
+    "text": "Tasks Ready",
+    "type": "success",
+    "subtext": "3 phases identified"
+  },
+  "badges": [
+    {
+      "label": "High",
+      "type": "warning"
+    }
+  ],
+  "message": "Task breakdown complete. Ready to begin implementation.",
+  "activity": "waiting",
+  "workflow_type": "diagnostic",
+  "available_actions": [
+    {
+      "id": "create-tasks",
+      "label": "Generate Tasks",
+      "skill": "dx-create-tasks"
+    },
+    {
+      "id": "fix",
+      "label": "Start Investigation",
+      "skill": "dx-fix"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "dx-fix"
+    }
+  ],
+  "git_sha": "460dfe1",
+  "needs_attention": true
+}

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -27,14 +27,18 @@
     {
       "label": "Phase 2 Tasks",
       "path": "project-management/issues/CC-41/phase-02-tasks.md"
+    },
+    {
+      "label": "Phase 3 Context",
+      "path": "project-management/issues/CC-41/phase-03-context.md"
     }
   ],
-  "last_updated": "2026-04-10T21:23:39.899134733Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-10T21:28:50.417996833Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 02: Awaiting Review",
-    "type": "warning",
-    "subtext": "Derive agentId from filename in SubAgentMetadataParser"
+    "text": "Phase 03: Context Ready",
+    "type": "info",
+    "subtext": "Support entries without uuid field"
   },
   "badges": [
     {
@@ -58,8 +62,8 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 02 implementation started",
-  "activity": "waiting",
+  "message": "Phase 03 context ready for review",
+  "activity": "working",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -101,8 +105,8 @@
   "git_sha": "460dfe1",
   "needs_attention": true,
   "phase_checkpoints": {
-    "2": {
-      "context_sha": "context_sha=7fd16df51262440f70f783f27d5ef7bbdae0683e"
+    "3": {
+      "context_sha": "context_sha=8a9d1bc33084892701f6b447e2d5198f89227c3e"
     }
   },
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/43"

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -15,13 +15,17 @@
     {
       "label": "Phase 1 Context",
       "path": "project-management/issues/CC-41/phase-01-context.md"
+    },
+    {
+      "label": "Phase 1 Tasks",
+      "path": "project-management/issues/CC-41/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T18:08:36.622684105Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-10T20:41:05.367633319Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 1: Context Ready",
-    "type": "info",
+    "text": "Phase 1: Tasks Ready",
+    "type": "success",
     "subtext": "Fix entry type name mismatches in ConversationLogParser"
   },
   "badges": [
@@ -30,8 +34,8 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 1 context ready for review",
-  "activity": "working",
+  "message": "Phase 1 tasks ready",
+  "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -47,6 +51,11 @@
     {
       "id": "implement",
       "label": "Start Implementation",
+      "skill": "dx-fix"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
       "skill": "dx-fix"
     }
   ],

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -19,14 +19,18 @@
     {
       "label": "Phase 1 Tasks",
       "path": "project-management/issues/CC-41/phase-01-tasks.md"
+    },
+    {
+      "label": "Phase 2 Context",
+      "path": "project-management/issues/CC-41/phase-02-context.md"
     }
   ],
-  "last_updated": "2026-04-10T21:07:23.943780008Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-10T21:11:40.691417088Z",
+  "status": "context_ready",
   "display": {
-    "text": "Phase 01: Awaiting Review",
-    "type": "warning",
-    "subtext": "Fix entry type name mismatches in ConversationLogParser"
+    "text": "Phase 02: Context Ready",
+    "type": "info",
+    "subtext": "Derive agentId from filename in SubAgentMetadataParser"
   },
   "badges": [
     {
@@ -42,8 +46,8 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 01 implementation started",
-  "activity": "waiting",
+  "message": "Phase 02 context ready for review",
+  "activity": "working",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -75,8 +79,8 @@
   "git_sha": "460dfe1",
   "needs_attention": true,
   "phase_checkpoints": {
-    "1": {
-      "context_sha": "context_sha=97133ae79e91cdccb9f63747b036035553a02842"
+    "2": {
+      "context_sha": "context_sha=7fd16df51262440f70f783f27d5ef7bbdae0683e"
     }
   },
   "pr_url": "https://github.com/iterative-works/claude-code-query/pull/42"

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -37,11 +37,11 @@
       "path": "project-management/issues/CC-41/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:30:07.943545072Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-10T21:36:39.730209227Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 03: Tasks Ready",
-    "type": "success",
+    "text": "Phase 03: Awaiting Review",
+    "type": "warning",
     "subtext": "Support entries without uuid field"
   },
   "badges": [
@@ -64,9 +64,17 @@
     {
       "label": "Review Needed",
       "type": "warning"
+    },
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
   ],
-  "message": "Phase 03 tasks ready",
+  "message": "Phase 03 implementation started",
   "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
@@ -109,6 +117,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "dx-fix"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "460dfe1",
@@ -118,5 +131,5 @@
       "context_sha": "context_sha=8a9d1bc33084892701f6b447e2d5198f89227c3e"
     }
   },
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/43"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/44"
 }

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -23,13 +23,17 @@
     {
       "label": "Phase 2 Context",
       "path": "project-management/issues/CC-41/phase-02-context.md"
+    },
+    {
+      "label": "Phase 2 Tasks",
+      "path": "project-management/issues/CC-41/phase-02-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:11:40.691417088Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-10T21:13:53.573356812Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 02: Context Ready",
-    "type": "info",
+    "text": "Phase 02: Tasks Ready",
+    "type": "success",
     "subtext": "Derive agentId from filename in SubAgentMetadataParser"
   },
   "badges": [
@@ -46,8 +50,8 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 02 context ready for review",
-  "activity": "working",
+  "message": "Phase 02 tasks ready",
+  "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -74,6 +78,11 @@
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "dx-fix"
     }
   ],
   "git_sha": "460dfe1",

--- a/project-management/issues/CC-41/review-state.json
+++ b/project-management/issues/CC-41/review-state.json
@@ -31,13 +31,17 @@
     {
       "label": "Phase 3 Context",
       "path": "project-management/issues/CC-41/phase-03-context.md"
+    },
+    {
+      "label": "Phase 3 Tasks",
+      "path": "project-management/issues/CC-41/phase-03-tasks.md"
     }
   ],
-  "last_updated": "2026-04-10T21:28:50.417996833Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-10T21:30:07.943545072Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 03: Context Ready",
-    "type": "info",
+    "text": "Phase 03: Tasks Ready",
+    "type": "success",
     "subtext": "Support entries without uuid field"
   },
   "badges": [
@@ -62,8 +66,8 @@
       "type": "warning"
     }
   ],
-  "message": "Phase 03 context ready for review",
-  "activity": "working",
+  "message": "Phase 03 tasks ready",
+  "activity": "waiting",
   "workflow_type": "diagnostic",
   "available_actions": [
     {
@@ -100,6 +104,11 @@
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "dx-fix"
     }
   ],
   "git_sha": "460dfe1",

--- a/project-management/issues/CC-41/tasks.md
+++ b/project-management/issues/CC-41/tasks.md
@@ -3,17 +3,17 @@
 **Issue:** CC-41
 **Created:** 2026-04-10
 **Severity:** High
-**Status:** 2/3 phases complete (67%)
+**Status:** 3/3 phases complete (100%)
 
 ## Phase Index
 
 - [x] Phase 01: Fix entry type name mismatches in ConversationLogParser (Est: 1-2h) → `phase-01-context.md`
 - [x] Phase 02: Derive agentId from filename in SubAgentMetadataParser (Est: 1h) → `phase-02-context.md`
-- [ ] Phase 03: Support entries without uuid field (Est: 1-2h) → `phase-03-context.md`
+- [x] Phase 03: Support entries without uuid field (Est: 1-2h) → `phase-03-context.md`
 
 ## Progress Tracker
 
-**Completed:** 2/3 phases
+**Completed:** 3/3 phases
 **Estimated Total:** 3-5 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-41/tasks.md
+++ b/project-management/issues/CC-41/tasks.md
@@ -3,17 +3,17 @@
 **Issue:** CC-41
 **Created:** 2026-04-10
 **Severity:** High
-**Status:** 1/3 phases complete (33%)
+**Status:** 2/3 phases complete (67%)
 
 ## Phase Index
 
 - [x] Phase 01: Fix entry type name mismatches in ConversationLogParser (Est: 1-2h) → `phase-01-context.md`
-- [ ] Phase 02: Derive agentId from filename in SubAgentMetadataParser (Est: 1h) → `phase-02-context.md`
+- [x] Phase 02: Derive agentId from filename in SubAgentMetadataParser (Est: 1h) → `phase-02-context.md`
 - [ ] Phase 03: Support entries without uuid field (Est: 1-2h) → `phase-03-context.md`
 
 ## Progress Tracker
 
-**Completed:** 1/3 phases
+**Completed:** 2/3 phases
 **Estimated Total:** 3-5 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/CC-41/tasks.md
+++ b/project-management/issues/CC-41/tasks.md
@@ -1,0 +1,26 @@
+# Investigation Tasks: Parser mismatches: wrong entry type names, SubAgentMetadataParser requires missing field
+
+**Issue:** CC-41
+**Created:** 2026-04-10
+**Severity:** High
+**Status:** 0/3 phases complete (0%)
+
+## Phase Index
+
+- [ ] Phase 01: Fix entry type name mismatches in ConversationLogParser (Est: 1-2h) → `phase-01-context.md`
+- [ ] Phase 02: Derive agentId from filename in SubAgentMetadataParser (Est: 1h) → `phase-02-context.md`
+- [ ] Phase 03: Support entries without uuid field (Est: 1-2h) → `phase-03-context.md`
+
+## Progress Tracker
+
+**Completed:** 0/3 phases
+**Estimated Total:** 3-5 hours
+**Time Spent:** 0 hours
+
+## Notes
+
+- Phase context files generated just-in-time during investigation
+- Use dx-fix to start next phase automatically
+- Estimates are rough and will be refined during investigation
+- Each phase follows: reproduce → investigate → fix → verify
+- Phases ordered by impact: user entry parsing (highest) → sub-agent metadata → uuid handling

--- a/project-management/issues/CC-41/tasks.md
+++ b/project-management/issues/CC-41/tasks.md
@@ -3,17 +3,17 @@
 **Issue:** CC-41
 **Created:** 2026-04-10
 **Severity:** High
-**Status:** 0/3 phases complete (0%)
+**Status:** 1/3 phases complete (33%)
 
 ## Phase Index
 
-- [ ] Phase 01: Fix entry type name mismatches in ConversationLogParser (Est: 1-2h) → `phase-01-context.md`
+- [x] Phase 01: Fix entry type name mismatches in ConversationLogParser (Est: 1-2h) → `phase-01-context.md`
 - [ ] Phase 02: Derive agentId from filename in SubAgentMetadataParser (Est: 1h) → `phase-02-context.md`
 - [ ] Phase 03: Support entries without uuid field (Est: 1-2h) → `phase-03-context.md`
 
 ## Progress Tracker
 
-**Completed:** 0/3 phases
+**Completed:** 1/3 phases
 **Estimated Total:** 3-5 hours
 **Time Spent:** 0 hours
 


### PR DESCRIPTION
## Summary

- **Fix entry type name mismatches**: Parser now uses correct type names from real Claude Code JSONL (`"user"` instead of `"human"`, hyphens instead of underscores), and handles `"permission-mode"` and `"attachment"` entry types
- **Fix SubAgentMetadataParser**: Derives `agentId` from transcript filename instead of requiring it in JSON (which doesn't contain it)
- **Support entries without UUID**: Made `uuid` optional in `ConversationLogEntry` so entries like `permission-mode` and `file-history-snapshot` are no longer silently dropped

## Impact

Before these fixes, parsing real Claude Code transcripts resulted in:
- `numTurns` always 0 (all user entries dropped)
- Empty sub-agent lists (metadata parsing always failed)
- Missing entries for types without UUID field

## Test plan

- [x] All existing tests updated to use correct type names from real data
- [x] 11 new regression tests across all three defects
- [x] All tests pass (`./mill __.test`)
- [x] Code reviewed in 3 phase PRs (#42, #43, #44)

## Release Notes

Parsování konverzačních logů z Claude Code nyní správně rozpoznává všechny typy záznamů. Uživatelské zprávy, metadata subagentů a záznamy bez UUID již nejsou tiše zahazovány.

🤖 Generated with [Claude Code](https://claude.com/claude-code)