### PR TITLE
CC-46: Option-C tool-isolation knobs (strict MCP, mcp-config path, setting-sources, DontAsk)

### DIFF
--- a/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+++ b/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
@@ -52,11 +52,26 @@ object CLIArgumentBuilder:
         List("--permission-mode", "acceptEdits")
       case Some(PermissionMode.BypassPermissions) =>
         List("--permission-mode", "bypassPermissions")
+      case Some(PermissionMode.DontAsk) =>
+        List("--permission-mode", "dontAsk")
       case None => List.empty
 
     val maxThinkingTokensArgs = options.maxThinkingTokens match
       case Some(tokens) => List("--max-thinking-tokens", tokens.toString)
       case None         => List.empty
+
+    val strictMcpConfigArgs = options.strictMcpConfig match
+      case Some(true) => List("--strict-mcp-config")
+      case _          => List.empty
+
+    val mcpConfigPathArgs = options.mcpConfigPath match
+      case Some(path) => List("--mcp-config", path, "--")
+      case None       => List.empty
+
+    val settingSourcesArgs =
+      if options.settingSources.nonEmpty then
+        List("--setting-sources", options.settingSources.mkString(","))
+      else List.empty
 
     List(
       maxTurnsArgs,
@@ -68,7 +83,10 @@ object CLIArgumentBuilder:
       continueConversationArgs,
       resumeArgs,
       permissionModeArgs,
-      maxThinkingTokensArgs
+      maxThinkingTokensArgs,
+      strictMcpConfigArgs,
+      mcpConfigPathArgs,
+      settingSourcesArgs
     ).flatten
 
   /** Converts SessionOptions into list of CLI arguments for a Claude Code
@@ -115,11 +133,26 @@ object CLIArgumentBuilder:
         List("--permission-mode", "acceptEdits")
       case Some(PermissionMode.BypassPermissions) =>
         List("--permission-mode", "bypassPermissions")
+      case Some(PermissionMode.DontAsk) =>
+        List("--permission-mode", "dontAsk")
       case None => List.empty
 
     val maxThinkingTokensArgs = options.maxThinkingTokens match
       case Some(tokens) => List("--max-thinking-tokens", tokens.toString)
       case None         => List.empty
+
+    val strictMcpConfigArgs = options.strictMcpConfig match
+      case Some(true) => List("--strict-mcp-config")
+      case _          => List.empty
+
+    val mcpConfigPathArgs = options.mcpConfigPath match
+      case Some(path) => List("--mcp-config", path, "--")
+      case None       => List.empty
+
+    val settingSourcesArgs =
+      if options.settingSources.nonEmpty then
+        List("--setting-sources", options.settingSources.mkString(","))
+      else List.empty
 
     List(
       List(
@@ -138,5 +171,8 @@ object CLIArgumentBuilder:
       continueConversationArgs,
       resumeArgs,
       permissionModeArgs,
-      maxThinkingTokensArgs
+      maxThinkingTokensArgs,
+      strictMcpConfigArgs,
+      mcpConfigPathArgs,
+      settingSourcesArgs
     ).flatten

--- a/core/src/works/iterative/claude/core/model/PermissionMode.scala
+++ b/core/src/works/iterative/claude/core/model/PermissionMode.scala
@@ -8,3 +8,6 @@ enum PermissionMode:
   case Default
   case AcceptEdits
   case BypassPermissions
+
+  /** Enforce `allowedTools` as a hard allow-list; no prompts, no hangs. */
+  case DontAsk

--- a/core/src/works/iterative/claude/core/model/QueryOptions.scala
+++ b/core/src/works/iterative/claude/core/model/QueryOptions.scala
@@ -64,6 +64,8 @@ case class QueryOptions(
       *   - AcceptEdits: Auto-accept file edit operations
       *   - BypassPermissions: Allow all tools without prompting (use with
       *     caution)
+      *   - DontAsk: Enforce `allowedTools` as a hard allow-list; no prompts, no
+      *     hangs
       */
     permissionMode: Option[PermissionMode] = None,
 
@@ -101,7 +103,23 @@ case class QueryOptions(
       * true) or used as the complete environment (if inheritEnvironment is
       * false).
       */
-    environmentVariables: Option[Map[String, String]] = None
+    environmentVariables: Option[Map[String, String]] = None,
+
+    /** Restrict Claude to only the MCP servers listed in --mcp-config
+      * (--strict-mcp-config). `Some(true)` emits the flag; `Some(false)` and
+      * `None` emit nothing.
+      */
+    strictMcpConfig: Option[Boolean] = None,
+
+    /** Path to an MCP configuration file (--mcp-config <path> --). The trailing
+      * `--` terminator is mandatory because the flag is variadic.
+      */
+    mcpConfigPath: Option[String] = None,
+
+    /** Ordered list of setting sources to load (--setting-sources <csv>). Empty
+      * list emits nothing.
+      */
+    settingSources: List[String] = Nil
 ):
   // ==== FLUENT API FOR FUNCTIONAL MUTATION ====
 
@@ -139,6 +157,12 @@ case class QueryOptions(
     copy(inheritEnvironment = Some(inherit))
   def withEnvironmentVariables(vars: Map[String, String]): QueryOptions =
     copy(environmentVariables = Some(vars))
+  def withStrictMcpConfig(flag: Boolean): QueryOptions =
+    copy(strictMcpConfig = Some(flag))
+  def withMcpConfigPath(path: String): QueryOptions =
+    copy(mcpConfigPath = Some(path))
+  def withSettingSources(sources: List[String]): QueryOptions =
+    copy(settingSources = sources)
 
 object QueryOptions:
   /** Create QueryOptions with just a prompt and sane defaults */
@@ -161,5 +185,8 @@ object QueryOptions:
     maxThinkingTokens = None,
     timeout = None,
     inheritEnvironment = None,
-    environmentVariables = None
+    environmentVariables = None,
+    strictMcpConfig = None,
+    mcpConfigPath = None,
+    settingSources = Nil
   )

--- a/core/src/works/iterative/claude/core/model/SessionOptions.scala
+++ b/core/src/works/iterative/claude/core/model/SessionOptions.scala
@@ -69,7 +69,23 @@ case class SessionOptions(
 
     /** Additional environment variables to set for the Claude Code CLI process
       */
-    environmentVariables: Option[Map[String, String]] = None
+    environmentVariables: Option[Map[String, String]] = None,
+
+    /** Restrict Claude to only the MCP servers listed in --mcp-config
+      * (--strict-mcp-config). `Some(true)` emits the flag; `Some(false)` and
+      * `None` emit nothing.
+      */
+    strictMcpConfig: Option[Boolean] = None,
+
+    /** Path to an MCP configuration file (--mcp-config <path> --). The trailing
+      * `--` terminator is mandatory because the flag is variadic.
+      */
+    mcpConfigPath: Option[String] = None,
+
+    /** Ordered list of setting sources to load (--setting-sources <csv>). Empty
+      * list emits nothing.
+      */
+    settingSources: List[String] = Nil
 ):
   def withCwd(cwd: String): SessionOptions = copy(cwd = Some(cwd))
   def withExecutable(executable: String): SessionOptions =
@@ -105,6 +121,12 @@ case class SessionOptions(
     copy(inheritEnvironment = Some(inherit))
   def withEnvironmentVariables(vars: Map[String, String]): SessionOptions =
     copy(environmentVariables = Some(vars))
+  def withStrictMcpConfig(flag: Boolean): SessionOptions =
+    copy(strictMcpConfig = Some(flag))
+  def withMcpConfigPath(path: String): SessionOptions =
+    copy(mcpConfigPath = Some(path))
+  def withSettingSources(sources: List[String]): SessionOptions =
+    copy(settingSources = sources)
 
 object SessionOptions:
   /** Create SessionOptions with all defaults */

--- a/core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala
+++ b/core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala
@@ -185,6 +185,84 @@ class CLIArgumentBuilderTest extends CatsEffectSuite:
     assert(args.contains(""))
     assert(args.contains("--disallowedTools"))
 
+  test("PermissionMode.DontAsk maps to --permission-mode dontAsk"):
+    val options = QueryOptions
+      .simple("test prompt")
+      .withPermissionMode(PermissionMode.DontAsk)
+
+    val args = CLIArgumentBuilder.buildArgs(options)
+
+    assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+  test("strictMcpConfig = Some(true) emits --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildArgs(
+      QueryOptions.simple("test prompt").withStrictMcpConfig(true)
+    )
+    assert(args.contains("--strict-mcp-config"))
+
+  test("strictMcpConfig default (None) does not emit --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildArgs(QueryOptions.simple("test prompt"))
+    assert(!args.contains("--strict-mcp-config"))
+
+  test("strictMcpConfig = Some(false) does not emit --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildArgs(
+      QueryOptions.simple("test prompt").withStrictMcpConfig(false)
+    )
+    assert(!args.contains("--strict-mcp-config"))
+
+  test("mcpConfigPath maps to --mcp-config <path> --"):
+    val args = CLIArgumentBuilder.buildArgs(
+      QueryOptions.simple("test prompt").withMcpConfigPath("./.mcp.json")
+    )
+    assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
+
+  test("mcpConfigPath default (None) does not emit --mcp-config"):
+    val args = CLIArgumentBuilder.buildArgs(QueryOptions.simple("test prompt"))
+    assert(!args.contains("--mcp-config"))
+
+  test(
+    "settingSources non-empty maps to --setting-sources with CSV value"
+  ):
+    val args = CLIArgumentBuilder.buildArgs(
+      QueryOptions
+        .simple("test prompt")
+        .withSettingSources(List("project", "user"))
+    )
+    assert(args.containsSlice(List("--setting-sources", "project,user")))
+
+  test("settingSources default (Nil) does not emit --setting-sources"):
+    val args = CLIArgumentBuilder.buildArgs(QueryOptions.simple("test prompt"))
+    assert(!args.contains("--setting-sources"))
+
+  test(
+    "all four Option-C isolation flags round-trip in deterministic order"
+  ):
+    val options = QueryOptions
+      .simple("test prompt")
+      .withStrictMcpConfig(true)
+      .withMcpConfigPath("./.mcp.json")
+      .withSettingSources(List("project", "local"))
+      .withPermissionMode(PermissionMode.DontAsk)
+
+    val args = CLIArgumentBuilder.buildArgs(options)
+
+    // presence
+    assert(args.contains("--strict-mcp-config"))
+    // --mcp-config is variadic; must be followed by "--" to isolate it
+    assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
+    assert(args.containsSlice(List("--setting-sources", "project,local")))
+    assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+    // deterministic order: permission-mode precedes the MCP/settings trio,
+    // which appears as strict -> mcp-config (+ terminator) -> setting-sources
+    val pmIdx = args.indexOf("--permission-mode")
+    val strictIdx = args.indexOf("--strict-mcp-config")
+    val mcpIdx = args.indexOf("--mcp-config")
+    val ssIdx = args.indexOf("--setting-sources")
+    assert(pmIdx < strictIdx)
+    assert(strictIdx < mcpIdx)
+    assert(mcpIdx < ssIdx)
+
   test("special characters in prompts and values are preserved"):
     val options = QueryOptions(
       prompt = "test prompt",

--- a/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+++ b/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
@@ -122,6 +122,89 @@ class SessionOptionsArgsTest extends CatsEffectSuite:
     val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
     assertEquals(args, requiredFlags)
 
+  test("PermissionMode.DontAsk maps to --permission-mode dontAsk"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withPermissionMode(PermissionMode.DontAsk)
+    )
+    assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+  test("strictMcpConfig = Some(true) emits --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withStrictMcpConfig(true)
+    )
+    assert(args.contains("--strict-mcp-config"))
+
+  test("strictMcpConfig default (None) does not emit --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assert(!args.contains("--strict-mcp-config"))
+
+  test("strictMcpConfig = Some(false) does not emit --strict-mcp-config"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withStrictMcpConfig(false)
+    )
+    assert(!args.contains("--strict-mcp-config"))
+
+  test("mcpConfigPath maps to --mcp-config <path> --"):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withMcpConfigPath("./.mcp.json")
+    )
+    assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
+
+  test("mcpConfigPath default (None) does not emit --mcp-config"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assert(!args.contains("--mcp-config"))
+
+  test(
+    "settingSources non-empty maps to --setting-sources with CSV value"
+  ):
+    val args = CLIArgumentBuilder.buildSessionArgs(
+      SessionOptions().withSettingSources(List("project", "user"))
+    )
+    assert(args.containsSlice(List("--setting-sources", "project,user")))
+
+  test("settingSources default (Nil) does not emit --setting-sources"):
+    val args = CLIArgumentBuilder.buildSessionArgs(SessionOptions())
+    assert(!args.contains("--setting-sources"))
+
+  test(
+    "all four Option-C isolation flags round-trip in deterministic order"
+  ):
+    val options = SessionOptions()
+      .withStrictMcpConfig(true)
+      .withMcpConfigPath("./.mcp.json")
+      .withSettingSources(List("project", "local"))
+      .withPermissionMode(PermissionMode.DontAsk)
+
+    val args = CLIArgumentBuilder.buildSessionArgs(options)
+
+    // presence
+    assert(args.contains("--strict-mcp-config"))
+    assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
+    assert(args.containsSlice(List("--setting-sources", "project,local")))
+    assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+    // deterministic order: permission-mode precedes the MCP/settings trio
+    val pmIdx = args.indexOf("--permission-mode")
+    val strictIdx = args.indexOf("--strict-mcp-config")
+    val mcpIdx = args.indexOf("--mcp-config")
+    val ssIdx = args.indexOf("--setting-sources")
+    assert(pmIdx < strictIdx)
+    assert(strictIdx < mcpIdx)
+    assert(mcpIdx < ssIdx)
+
+  test(
+    "required session flags still appear at the start of the argument list when all four new flags are set"
+  ):
+    val options = SessionOptions()
+      .withStrictMcpConfig(true)
+      .withMcpConfigPath("./.mcp.json")
+      .withSettingSources(List("project"))
+      .withPermissionMode(PermissionMode.DontAsk)
+
+    val args = CLIArgumentBuilder.buildSessionArgs(options)
+
+    assertEquals(args.take(requiredFlags.length), requiredFlags)
+
   test("multiple options combine correctly"):
     val args = CLIArgumentBuilder.buildSessionArgs(
       SessionOptions()

--- a/project-management/issues/CC-46/analysis.md
+++ b/project-management/issues/CC-46/analysis.md
@@ -1,0 +1,375 @@
+# Technical Analysis: Add Option-C tool-isolation knobs (strict MCP config, mcp-config path, setting sources, DontAsk permission mode)
+
+**Issue:** CC-46 (GitHub: [iterative-works/claude-code-query#46](https://github.com/iterative-works/claude-code-query/issues/46))
+**Created:** 2026-04-21
+**Status:** Draft
+
+## Problem Statement
+
+Consumer `iterative-works/procedures` (issue PROC-401, ADR 0001 Step 2) needs to spawn event-processor subprocesses with a **hard** tool allow-list that cannot be widened by inherited `.mcp.json` files, user-level settings, or interactive permission prompts.
+
+Today, `QueryOptions` / `SessionOptions` expose `allowedTools` and `permissionMode` but cannot express the full Claude Code CLI "Option C" isolation story. Without the four CLI flags below, an isolated subprocess can either (a) silently inherit the user's `.mcp.json` / `~/.claude/settings.json`, or (b) hang on an interactive permission prompt for a tool not in `allowedTools`:
+
+| CLI flag                     | Purpose                                                                |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `--strict-mcp-config`        | Prevent merging of any `.mcp.json` other than the one we pass.         |
+| `--mcp-config <path>`        | Explicitly point at a specific `.mcp.json` (don't rely on cwd lookup). |
+| `--setting-sources <csv>`    | Restrict settings resolution (e.g., `project` excludes user/managed).  |
+| `--permission-mode dontAsk`  | Enforce `allowedTools` as a hard allow-list (no prompts, no hangs).    |
+
+This is a pure additive feature: the SDK must expose these four knobs through the existing `QueryOptions` / `SessionOptions` / `PermissionMode` / `CLIArgumentBuilder` surface with zero behavioural change for callers that don't set them.
+
+## Proposed Solution
+
+### High-Level Approach
+
+A thin, three-layer extension entirely inside the `core` module:
+
+1. Extend the **domain model** (`PermissionMode`, `QueryOptions`, `SessionOptions`) with one new enum case and three new optional fields plus matching fluent `with*` helpers, all defaulting to the current no-op behaviour.
+2. Extend the **CLI translation layer** (`CLIArgumentBuilder.buildArgs` and `buildSessionArgs`) with one new match branch for `PermissionMode.DontAsk` and three new translations for the new fields. Defaults emit no flags, preserving backwards compatibility.
+3. Extend the **test layer** (`CLIArgumentBuilderTest`, `SessionOptionsArgsTest`) with per-field "emitted when set, absent when default" coverage, the new `DontAsk` branch, and a smoke round-trip test asserting all four flags appear together in deterministic order.
+
+### Why This Approach
+
+- The existing code already models every other CLI flag the same way (`Option[T]` field + fluent helper + `match` branch emitting `List[String]`), so mirroring the pattern keeps the diff small, obvious, and review-friendly.
+- No behavioural change to existing flags and no deprecation of existing `PermissionMode` cases — aligns with the issue's non-goals.
+- Adding case-class fields with defaults and a new enum case propagates through `direct`/`effectful` automatically because both modules re-export via `type`/`val` aliases (`direct/src/.../package.scala`, `effectful/src/.../package.scala`) — no source changes needed there.
+
+## Architecture Design
+
+**Purpose:** Define WHAT components each layer needs. Scope is the single `core` module; `direct` and `effectful` pick up the additions transparently via re-export.
+
+### Domain / Model Layer
+
+**Components:**
+- `core/src/works/iterative/claude/core/model/PermissionMode.scala` — add enum case `DontAsk`.
+- `core/src/works/iterative/claude/core/model/QueryOptions.scala` — add three fields (`strictMcpConfig: Boolean = false`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`) with matching `withStrictMcpConfig(flag: Boolean)`, `withMcpConfigPath(path: String)`, `withSettingSources(sources: List[String])` helpers. Update the `QueryOptions.simple(prompt)` factory to explicitly pass the new defaults so the factory remains exhaustive in named arguments.
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` — symmetric three fields + three fluent helpers. `SessionOptions.defaults` remains `SessionOptions()` and needs no edit because the new fields have defaults.
+
+**Responsibilities:**
+- Model the four CLI knobs as first-class configuration.
+- Preserve full source/binary compatibility for callers that don't touch the new fields (defaults match today's behaviour: no flag emitted).
+
+**Estimated Effort:** 0.75-1.25 hours
+**Complexity:** Straightforward
+
+---
+
+### CLI Translation Layer
+
+**Components:**
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — two edits, one per public method:
+  - `buildArgs(QueryOptions)`:
+    - Extend the `permissionMode` match with `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")`.
+    - Add `strictMcpConfigArgs`: `if options.strictMcpConfig then List("--strict-mcp-config") else Nil`.
+    - Add `mcpConfigPathArgs`: `options.mcpConfigPath match { case Some(path) => List("--mcp-config", path); case None => Nil }`.
+    - Add `settingSourcesArgs`: `if options.settingSources.nonEmpty then List("--setting-sources", options.settingSources.mkString(",")) else Nil`.
+    - Append the new arg groups to the final `List(...).flatten` in deterministic order.
+  - `buildSessionArgs(SessionOptions)`: same four additions, same ordering.
+
+**Responsibilities:**
+- Translate each new field into its CLI flag when set, emit nothing when default.
+- Maintain a single, deterministic argv order (see Technical Decisions below).
+- Keep the `DontAsk` branch exhaustive across both builder methods (Scala 3 will warn on non-exhaustive match; we must update both sites).
+
+**Estimated Effort:** 0.75-1.25 hours
+**Complexity:** Straightforward
+
+---
+
+### Test Layer
+
+**Components:**
+- `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` — add one test per new field ("emitted when set" + "absent when default"), one test for the `PermissionMode.DontAsk` branch, and the smoke round-trip test.
+- `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` — symmetric coverage for `buildSessionArgs`, including a session-flavoured round-trip test.
+
+**Responsibilities:**
+- Lock down presence/absence of each new flag.
+- Lock down the deterministic ordering decided in Technical Decisions (so future reorderings surface as test failures, not silent breakage for consumers that grep argv).
+- Cover the `DontAsk` serialisation string exactly (`"dontAsk"`, camelCase — matches the CLI docs and mirrors `"acceptEdits"` / `"bypassPermissions"`).
+
+**Estimated Effort:** 1.25-2 hours
+**Complexity:** Straightforward
+
+---
+
+## Technical Decisions
+
+### Patterns
+
+- **Mirror existing style.** Each new flag follows the same `Option[T]` / boolean / `List[String]` + `match` / `if` template already used in `CLIArgumentBuilder`. Do not introduce a new abstraction (builder, typeclass, DSL) — YAGNI.
+- **Functional core.** All additions are pure: immutable case classes, pure `List[String]` outputs.
+- **Defaults preserve behaviour.** `strictMcpConfig: Boolean = false`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`. Each translates to `List.empty` when defaulted.
+- **Enum case naming.** Keep `DontAsk` exactly as specified in the issue (Scala PascalCase). The CLI string is `"dontAsk"` (camelCase), matching the existing pattern `AcceptEdits -> "acceptEdits"` and `BypassPermissions -> "bypassPermissions"`.
+
+### Technology Choices
+
+- **Frameworks/Libraries:** None new. Scala 3 stdlib only.
+- **Data Storage:** N/A.
+- **External Systems:** N/A (this only prepares argv for the existing Claude Code CLI subprocess).
+
+### Integration Points
+
+- `direct` module (`direct/src/works/iterative/claude/direct/package.scala`): `PermissionMode` is re-exported as `type PermissionMode = ...; val PermissionMode = ...`, so `PermissionMode.DontAsk` is automatically visible to direct callers. No edit required.
+- `effectful` module (`effectful/src/works/iterative/claude/effectful/package.scala`): same pattern, same outcome.
+- Downstream consumers (PROC-401 specifically) must recompile against the new `0.3.0-SNAPSHOT` to pick up the enum case and fields.
+
+### Argv Ordering (concrete proposal)
+
+Append the four new arg groups to the existing `List(...).flatten` in the following order, placed **after** `permissionModeArgs` and **after** `maxThinkingTokensArgs` (i.e., at the tail end of the existing sequence). Within the new group, order is:
+
+1. `strictMcpConfigArgs`
+2. `mcpConfigPathArgs`
+3. `settingSourcesArgs`
+
+The `DontAsk` branch slots into the existing `permissionModeArgs` position (no positional change to that group).
+
+So for `buildArgs`, the final `List(...).flatten` becomes:
+
+```
+maxTurnsArgs, modelArgs, allowedToolsArgs, disallowedToolsArgs,
+systemPromptArgs, appendSystemPromptArgs, continueConversationArgs,
+resumeArgs, permissionModeArgs, maxThinkingTokensArgs,
+strictMcpConfigArgs, mcpConfigPathArgs, settingSourcesArgs
+```
+
+For `buildSessionArgs`, same order appended after `maxThinkingTokensArgs`, with the required streaming flags block remaining first.
+
+Rationale: appending at the tail avoids disturbing any existing test that asserts positional invariants (e.g., `args.take(requiredFlags.length)` in `SessionOptionsArgsTest`). The order *within* the new group is alphabetically stable by semantic grouping (strict flag first, then the path it governs, then orthogonal settings-source restriction).
+
+> **CLARIFY:** Is the proposed tail-append position + intra-group order acceptable, or does PROC-401 (or any downstream) prefer a specific ordering? If there's no preference, this ordering stands and is locked by the smoke test.
+
+## Technical Risks & Uncertainties
+
+### CLARIFY: Missing `QueryOptionsArgsTest.scala` file
+
+The issue's acceptance criteria mention `QueryOptionsArgsTest` symmetric to `SessionOptionsArgsTest`, but that file does **not** exist in the repo today. `CLIArgumentBuilderTest.scala` is the de-facto "QueryOptions args test" (it exclusively exercises `buildArgs(QueryOptions)`).
+
+**Questions to answer:**
+1. Should we add the new coverage to the existing `CLIArgumentBuilderTest.scala` (matches current repo convention, smallest diff)?
+2. Should we create a new `QueryOptionsArgsTest.scala` alongside `CLIArgumentBuilderTest.scala` to mirror `SessionOptionsArgsTest.scala` naming (uniform but introduces a second file that partially overlaps with the existing one)?
+3. Should we rename `CLIArgumentBuilderTest.scala` to `QueryOptionsArgsTest.scala` as a follow-up cleanup (out of scope for this issue, but worth noting)?
+
+**Options:**
+- **Option A (recommended):** Add new cases to the existing `CLIArgumentBuilderTest.scala`. Minimal, consistent with current layout.
+- **Option B:** Create a new `QueryOptionsArgsTest.scala` alongside. Matches issue wording literally; introduces two partially-overlapping files.
+- **Option C:** Rename existing file. Larger churn; out of scope unless requested.
+
+**Impact:** Choice of test-file naming only; no runtime behaviour difference.
+
+---
+
+### CLARIFY: Argv ordering policy
+
+See Technical Decisions > Argv Ordering. The proposal is tail-append in the order (`strictMcpConfig`, `mcpConfigPath`, `settingSources`). This needs a green-light so the smoke round-trip test can assert the exact sequence.
+
+**Questions to answer:**
+1. Confirm tail-append position.
+2. Confirm intra-group order.
+3. Should the smoke test assert the exact sub-sequence (`args.containsSlice(...)`) or just containment of each flag individually?
+
+**Options:**
+- **Option A (recommended):** Tail-append, order as proposed, smoke test uses `containsSlice` on the four new flags for determinism.
+- **Option B:** Tail-append, order as proposed, smoke test only uses `contains` per flag (looser, slightly more forgiving).
+- **Option C:** Different position (e.g., immediately after `permissionModeArgs`). Requires updating this analysis and the test.
+
+**Impact:** Test strictness and future refactor latitude.
+
+---
+
+### CLARIFY: Boolean fluent helper ergonomics
+
+`withStrictMcpConfig(flag: Boolean)` is the pattern from the issue. The rest of the fluent API for boolean-like fields is mixed: `continueConversation` is `Option[Boolean]` with `withContinueConversation(continue: Boolean)` (no no-arg convenience), `inheritEnvironment` is the same.
+
+**Questions to answer:**
+1. Is `withStrictMcpConfig(flag: Boolean)` (always taking an explicit boolean) sufficient, matching the `continueConversation` / `inheritEnvironment` precedent?
+2. Or should we also offer a no-arg `withStrictMcpConfig: QueryOptions` that sets it to `true` for cleaner consumer call sites (`opts.withStrictMcpConfig`)?
+
+**Options:**
+- **Option A (recommended):** Single `withStrictMcpConfig(flag: Boolean)` — matches existing precedent, YAGNI.
+- **Option B:** Both `withStrictMcpConfig(flag: Boolean)` and zero-arg `withStrictMcpConfig`. Minor convenience, small surface growth.
+
+**Impact:** API surface size and call-site ergonomics.
+
+---
+
+### CLARIFY: `strictMcpConfig` field type — `Boolean` vs `Option[Boolean]`
+
+Other boolean-like options in `QueryOptions` use `Option[Boolean]` (e.g., `continueConversation`, `inheritEnvironment`). The issue specifies `strictMcpConfig: Boolean = false`.
+
+**Questions to answer:**
+1. Is the plain `Boolean = false` from the issue the right choice (matches "flag" semantics — either present or absent)?
+2. Or should we use `Option[Boolean] = None` for stylistic consistency with `continueConversation` (tri-state: unset / explicit false / explicit true)?
+
+**Options:**
+- **Option A (recommended, matches issue):** `strictMcpConfig: Boolean = false`. Simpler. Flag is either emitted (true) or not (false / default). Matches CLI semantics — the flag has no "off" equivalent.
+- **Option B:** `Option[Boolean] = None`. Stylistic consistency with `continueConversation`. But `Some(false)` would be semantically indistinguishable from `None` because there is no `--no-strict-mcp-config` flag — adds complexity for no gain.
+
+**Impact:** Field declaration and one `match`/`if` line in the CLI builder.
+
+---
+
+## Total Estimates
+
+**Per-Layer Breakdown:**
+- Domain / Model Layer: 0.75-1.25 hours
+- CLI Translation Layer: 0.75-1.25 hours
+- Test Layer: 1.25-2 hours
+
+**Total Range:** 2.75-4.5 hours
+
+**Confidence:** High
+
+**Reasoning:**
+- Pure additive mirror of an existing, well-understood pattern — no design discovery required.
+- Single-module scope; no cross-module churn thanks to re-export aliases.
+- Test surface is small and mechanical.
+- The CLARIFY markers are about style/naming, not about unknowns that could blow up effort.
+
+## Recommended Phase Plan
+
+Total estimate is 2.75-4.5h. Low-end is below the 3h floor and the whole change is tightly coupled (the `DontAsk` enum case forces the CLI builder update forces the test update), so **a single phase is the right answer**.
+
+- **Phase 1: Option-C isolation knobs (domain + CLI + tests)**
+  - Includes: Domain/Model layer, CLI translation layer, Test layer
+  - Estimate: 2.75-4.5 hours
+  - Rationale: The three layers are mechanically coupled (adding the enum case without updating the CLI builder's match produces a non-exhaustive-match warning; adding fields without tests violates the project's TDD rule). Merging also keeps the review packet cohesive — a reviewer wants to see the flag, its translation, and its test together. Splitting would multiply ceremony (three PRs, three reviews) for no isolation benefit.
+
+**Total phases:** 1 (for total estimate 2.75-4.5 hours)
+
+## Testing Strategy
+
+### Per-Layer Testing
+
+Unit tests only — this change has no integration or E2E surface (it's pure argv construction).
+
+**Domain / Model Layer:**
+- No dedicated tests. Case-class field defaults and fluent helpers are exercised transitively by the CLI translation tests below. (Consistent with how existing fields like `continueConversation` are covered.)
+
+**CLI Translation Layer (`CLIArgumentBuilderTest.scala`):**
+Add the following tests:
+1. `strictMcpConfig = true emits --strict-mcp-config` — asserts `args.contains("--strict-mcp-config")`.
+2. `strictMcpConfig default (false) does not emit --strict-mcp-config` — asserts `!args.contains("--strict-mcp-config")`.
+3. `mcpConfigPath maps to --mcp-config <path>` — asserts the pair appears.
+4. `mcpConfigPath default (None) does not emit --mcp-config` — asserts absent.
+5. `settingSources non-empty maps to --setting-sources with CSV value` — asserts `args.contains("--setting-sources")` and `args.contains("project,user")` for `List("project", "user")`.
+6. `settingSources default (Nil) does not emit --setting-sources` — asserts absent.
+7. `PermissionMode.DontAsk maps to --permission-mode dontAsk` — asserts pair appears and string is exactly `"dontAsk"`.
+8. **Smoke round-trip test** (verbatim spec):
+
+   ```scala
+   test("all four Option-C isolation flags round-trip in deterministic order"):
+     val options = QueryOptions
+       .simple("test prompt")
+       .withStrictMcpConfig(true)
+       .withMcpConfigPath("./.mcp.json")
+       .withSettingSources(List("project"))
+       .withPermissionMode(PermissionMode.DontAsk)
+
+     val args = CLIArgumentBuilder.buildArgs(options)
+
+     // presence
+     assert(args.contains("--strict-mcp-config"))
+     assert(args.containsSlice(List("--mcp-config", "./.mcp.json")))
+     assert(args.containsSlice(List("--setting-sources", "project")))
+     assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+     // deterministic order: permission-mode precedes the MCP/settings trio,
+     // which appears as strict -> mcp-config -> setting-sources
+     val pmIdx = args.indexOf("--permission-mode")
+     val strictIdx = args.indexOf("--strict-mcp-config")
+     val mcpIdx = args.indexOf("--mcp-config")
+     val ssIdx = args.indexOf("--setting-sources")
+     assert(pmIdx < strictIdx)
+     assert(strictIdx < mcpIdx)
+     assert(mcpIdx < ssIdx)
+   ```
+
+**Session Translation Layer (`SessionOptionsArgsTest.scala`):**
+Same seven single-field tests, plus a session-flavoured round-trip using `SessionOptions().withStrictMcpConfig(true).withMcpConfigPath("./.mcp.json").withSettingSources(List("project")).withPermissionMode(PermissionMode.DontAsk)`. Also add: `required session flags still appear at the start of the argument list when all four new flags are set` — reuses the existing pattern (`args.take(requiredFlags.length) == requiredFlags`).
+
+**Test Data Strategy:**
+- Inline literal values per test. No fixtures needed.
+
+**Regression Coverage:**
+- Existing tests in both test files must continue to pass unchanged.
+- Existing argv-ordering assertions (`args.take(requiredFlags.length)` in `SessionOptionsArgsTest`) are preserved because new flags append at the tail.
+- The `PermissionMode` match in `CLIArgumentBuilder` is currently exhaustive only on `Default / AcceptEdits / BypassPermissions / None`. Scala 3 will emit a non-exhaustive-match warning when `DontAsk` is added to the enum — this is a **required regression signal**, not a failure: it proves both match sites were updated.
+
+## Deployment Considerations
+
+### Database Changes
+None.
+
+### Configuration Changes
+None in this SDK. Consumers (PROC-401) will start passing the four new flags.
+
+### Rollout Strategy
+- Publish under continuing `0.3.0-SNAPSHOT` on a feature branch (per issue's "Delivery" section).
+- PROC-401 bumps Maven coord, exercises the flags against the real event-processor subprocess, and reports back.
+- Cut `v0.3.0` tag after PROC-401 validation settles.
+
+### Rollback Plan
+- Additive, opt-in feature. Rollback = consumers stop setting the new fields (behaviour reverts to pre-change since defaults emit nothing) or pin to the previous snapshot.
+
+## Dependencies
+
+### Prerequisites
+- None. Current codebase (branch `CC-46`) is in clean state.
+
+### Layer Dependencies
+- Domain → CLI translation → Tests. Strict forward dependency within the phase.
+- `direct` and `effectful` modules have no source dependencies (re-export handles propagation). They will recompile cleanly.
+
+### External Blockers
+- None.
+
+## Risks & Mitigations
+
+### Risk 1: Non-exhaustive `PermissionMode` match somewhere other than `CLIArgumentBuilder`
+**Likelihood:** Low
+**Impact:** Medium (compilation warning → possible CI failure given `-Xfatal-warnings` if enabled)
+**Mitigation:** Grep the repo for `PermissionMode` uses before committing. The issue-provided context lists only two match sites (`buildArgs`, `buildSessionArgs`). Verify this during implementation with `sg --lang scala -p 'PermissionMode.$CASE'` / `rg 'case PermissionMode\\.'`.
+
+### Risk 2: Consumer (PROC-401) expects a different argv order than our chosen one
+**Likelihood:** Low
+**Impact:** Low (the CLI accepts any order; our smoke test just pins one)
+**Mitigation:** Flagged as CLARIFY above. Get confirmation before locking the order into the smoke test. If PROC-401 only inspects by flag presence, keep our order; if it expects a specific slice, match that.
+
+### Risk 3: `settingSources: List[String]` vs typed enum drift
+**Likelihood:** Low
+**Impact:** Low (stringly-typed API is what the issue specifies)
+**Mitigation:** Stick with `List[String]` per the issue. A future ticket can introduce a `SettingSource` enum if PROC-401 or another consumer asks for it. Note this in the journal rather than acting now (YAGNI).
+
+---
+
+## Implementation Sequence
+
+**Recommended Layer Order (within the single phase):**
+
+1. **Domain / Model Layer** — Add `PermissionMode.DontAsk`; add three fields + three fluent helpers to `QueryOptions` and `SessionOptions`; update `QueryOptions.simple` named-arg list. Pure, no dependencies.
+2. **CLI Translation Layer (TDD pairing with Tests)** — Per project TDD rule: write a failing test for each new field/branch in `CLIArgumentBuilderTest` / `SessionOptionsArgsTest`, then add the corresponding branch/translation in `CLIArgumentBuilder`. Repeat per field. Final step in this layer is the smoke round-trip test.
+3. **Cleanup & Verification** — Run `./mill __.compile` to confirm no non-exhaustive-match warnings remain; run `./mill __.test` to confirm green; run `./mill direct.compile` / `./mill effectful.compile` to confirm re-export propagation works without source edits there.
+
+**Ordering Rationale:**
+- Domain first because the CLI builder and tests both depend on the new enum case and new fields existing.
+- CLI translation and tests are written hand-in-hand (TDD) — conceptually one step.
+- Final compile/test sweep catches any exhaustiveness or downstream-module surprises.
+
+## Documentation Requirements
+
+- [x] Code documentation — extend the Scaladoc on `QueryOptions` / `SessionOptions` new fields to describe the CLI flag they map to (match the existing field comment style).
+- [x] Code documentation — add a line to `PermissionMode` enum Scaladoc describing `DontAsk` as "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs" (mirror existing per-case comments in `QueryOptions.permissionMode`).
+- [ ] API documentation — no external API doc site to update.
+- [ ] Architecture decision record — not warranted; this is a mechanical extension of an existing pattern.
+- [ ] User-facing documentation — none (no UI).
+- [ ] Migration guide — not needed (additive, defaults preserve behaviour).
+
+---
+
+**Analysis Status:** Ready for Review
+
+**Next Steps:**
+1. Resolve the four CLARIFY markers (test file naming, argv ordering, fluent helper ergonomics, `Boolean` vs `Option[Boolean]`).
+2. Run **wf-create-tasks** with issue ID `CC-46`.
+3. Run **wf-implement** for the single merged phase.

--- a/project-management/issues/CC-46/analysis.md
+++ b/project-management/issues/CC-46/analysis.md
@@ -43,7 +43,7 @@ A thin, three-layer extension entirely inside the `core` module:
 
 **Components:**
 - `core/src/works/iterative/claude/core/model/PermissionMode.scala` — add enum case `DontAsk`.
-- `core/src/works/iterative/claude/core/model/QueryOptions.scala` — add three fields (`strictMcpConfig: Boolean = false`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`) with matching `withStrictMcpConfig(flag: Boolean)`, `withMcpConfigPath(path: String)`, `withSettingSources(sources: List[String])` helpers. Update the `QueryOptions.simple(prompt)` factory to explicitly pass the new defaults so the factory remains exhaustive in named arguments.
+- `core/src/works/iterative/claude/core/model/QueryOptions.scala` — add three fields (`strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`) with matching `withStrictMcpConfig(flag: Boolean)` (wraps in `Some`), `withMcpConfigPath(path: String)`, `withSettingSources(sources: List[String])` helpers. Update the `QueryOptions.simple(prompt)` factory to explicitly pass the new defaults so the factory remains exhaustive in named arguments.
 - `core/src/works/iterative/claude/core/model/SessionOptions.scala` — symmetric three fields + three fluent helpers. `SessionOptions.defaults` remains `SessionOptions()` and needs no edit because the new fields have defaults.
 
 **Responsibilities:**
@@ -61,8 +61,8 @@ A thin, three-layer extension entirely inside the `core` module:
 - `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — two edits, one per public method:
   - `buildArgs(QueryOptions)`:
     - Extend the `permissionMode` match with `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")`.
-    - Add `strictMcpConfigArgs`: `if options.strictMcpConfig then List("--strict-mcp-config") else Nil`.
-    - Add `mcpConfigPathArgs`: `options.mcpConfigPath match { case Some(path) => List("--mcp-config", path); case None => Nil }`.
+    - Add `strictMcpConfigArgs`: `options.strictMcpConfig match { case Some(true) => List("--strict-mcp-config"); case _ => Nil }` (covers `None` and `Some(false)` — no `--no-strict-mcp-config` flag exists today).
+    - Add `mcpConfigPathArgs`: `options.mcpConfigPath match { case Some(path) => List("--mcp-config", path, "--"); case None => Nil }`. The trailing `"--"` is mandatory — `--mcp-config` is variadic and would otherwise consume downstream argv tokens (prompt, caller-appended flags) as additional config paths.
     - Add `settingSourcesArgs`: `if options.settingSources.nonEmpty then List("--setting-sources", options.settingSources.mkString(",")) else Nil`.
     - Append the new arg groups to the final `List(...).flatten` in deterministic order.
   - `buildSessionArgs(SessionOptions)`: same four additions, same ordering.
@@ -99,7 +99,7 @@ A thin, three-layer extension entirely inside the `core` module:
 
 - **Mirror existing style.** Each new flag follows the same `Option[T]` / boolean / `List[String]` + `match` / `if` template already used in `CLIArgumentBuilder`. Do not introduce a new abstraction (builder, typeclass, DSL) — YAGNI.
 - **Functional core.** All additions are pure: immutable case classes, pure `List[String]` outputs.
-- **Defaults preserve behaviour.** `strictMcpConfig: Boolean = false`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`. Each translates to `List.empty` when defaulted.
+- **Defaults preserve behaviour.** `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`. Each translates to `List.empty` when defaulted (and `Some(false)` also emits nothing, since no negation flag exists).
 - **Enum case naming.** Keep `DontAsk` exactly as specified in the issue (Scala PascalCase). The CLI string is `"dontAsk"` (camelCase), matching the existing pattern `AcceptEdits -> "acceptEdits"` and `BypassPermissions -> "bypassPermissions"`.
 
 ### Technology Choices
@@ -114,15 +114,22 @@ A thin, three-layer extension entirely inside the `core` module:
 - `effectful` module (`effectful/src/works/iterative/claude/effectful/package.scala`): same pattern, same outcome.
 - Downstream consumers (PROC-401 specifically) must recompile against the new `0.3.0-SNAPSHOT` to pick up the enum case and fields.
 
-### Argv Ordering (concrete proposal)
+### Argv Ordering (decided)
 
-Append the four new arg groups to the existing `List(...).flatten` in the following order, placed **after** `permissionModeArgs` and **after** `maxThinkingTokensArgs` (i.e., at the tail end of the existing sequence). Within the new group, order is:
+Append the new arg groups to the existing `List(...).flatten` in the following order, placed **after** `permissionModeArgs` and **after** `maxThinkingTokensArgs` (i.e., at the tail end of the existing sequence). Within the new group, order is:
 
 1. `strictMcpConfigArgs`
 2. `mcpConfigPathArgs`
 3. `settingSourcesArgs`
 
 The `DontAsk` branch slots into the existing `permissionModeArgs` position (no positional change to that group).
+
+**Critical: `--mcp-config` is variadic — it greedily consumes subsequent tokens as additional config paths until it hits a recognized flag or a `--` terminator. Tail-positioning alone is NOT safe**, because `buildArgs` output is concatenated with downstream pieces (prompt, other CLI fragments) by the process runner, so anything appended by the caller would be swallowed as a config path. Emitting a `--` terminator immediately after the path isolates the variadic regardless of argv position or what follows.
+
+Therefore:
+
+- `mcpConfigPathArgs` emits `List("--mcp-config", path, "--")` when set (path + explicit terminator).
+- `mcpConfigPathArgs` emits `Nil` when unset (no flag, no terminator).
 
 So for `buildArgs`, the final `List(...).flatten` becomes:
 
@@ -133,79 +140,43 @@ resumeArgs, permissionModeArgs, maxThinkingTokensArgs,
 strictMcpConfigArgs, mcpConfigPathArgs, settingSourcesArgs
 ```
 
+where `mcpConfigPathArgs`, when non-empty, is a three-element list `["--mcp-config", "<path>", "--"]`.
+
 For `buildSessionArgs`, same order appended after `maxThinkingTokensArgs`, with the required streaming flags block remaining first.
 
-Rationale: appending at the tail avoids disturbing any existing test that asserts positional invariants (e.g., `args.take(requiredFlags.length)` in `SessionOptionsArgsTest`). The order *within* the new group is alphabetically stable by semantic grouping (strict flag first, then the path it governs, then orthogonal settings-source restriction).
+Rationale: tail-append keeps the existing `args.take(requiredFlags.length)` invariant in `SessionOptionsArgsTest` intact. Within the new group, the order is semantically grouped (strict flag first, then the path it governs, then orthogonal settings-source restriction). The `--` terminator after `--mcp-config <path>` makes the group position-independent and robust to future additions or caller-appended arguments.
 
-> **CLARIFY:** Is the proposed tail-append position + intra-group order acceptable, or does PROC-401 (or any downstream) prefer a specific ordering? If there's no preference, this ordering stands and is locked by the smoke test.
+## Resolved Decisions
 
-## Technical Risks & Uncertainties
+### Decision: QueryOptions-side test file
 
-### CLARIFY: Missing `QueryOptionsArgsTest.scala` file
+The issue mentions `QueryOptionsArgsTest` symmetric to `SessionOptionsArgsTest`, but that file does not exist. `CLIArgumentBuilderTest.scala` is the de-facto QueryOptions args test today.
 
-The issue's acceptance criteria mention `QueryOptionsArgsTest` symmetric to `SessionOptionsArgsTest`, but that file does **not** exist in the repo today. `CLIArgumentBuilderTest.scala` is the de-facto "QueryOptions args test" (it exclusively exercises `buildArgs(QueryOptions)`).
-
-**Questions to answer:**
-1. Should we add the new coverage to the existing `CLIArgumentBuilderTest.scala` (matches current repo convention, smallest diff)?
-2. Should we create a new `QueryOptionsArgsTest.scala` alongside `CLIArgumentBuilderTest.scala` to mirror `SessionOptionsArgsTest.scala` naming (uniform but introduces a second file that partially overlaps with the existing one)?
-3. Should we rename `CLIArgumentBuilderTest.scala` to `QueryOptionsArgsTest.scala` as a follow-up cleanup (out of scope for this issue, but worth noting)?
-
-**Options:**
-- **Option A (recommended):** Add new cases to the existing `CLIArgumentBuilderTest.scala`. Minimal, consistent with current layout.
-- **Option B:** Create a new `QueryOptionsArgsTest.scala` alongside. Matches issue wording literally; introduces two partially-overlapping files.
-- **Option C:** Rename existing file. Larger churn; out of scope unless requested.
-
-**Impact:** Choice of test-file naming only; no runtime behaviour difference.
+**Decided:** Option A — add the new QueryOptions-side coverage (seven per-field/branch tests plus the smoke round-trip) to the existing `CLIArgumentBuilderTest.scala`. Smallest diff, consistent with current repo layout. Potential future canonicalization (rename to `QueryOptionsArgsTest.scala`) is out of scope for this issue.
 
 ---
 
-### CLARIFY: Argv ordering policy
+### Decision: Argv ordering policy
 
-See Technical Decisions > Argv Ordering. The proposal is tail-append in the order (`strictMcpConfig`, `mcpConfigPath`, `settingSources`). This needs a green-light so the smoke round-trip test can assert the exact sequence.
-
-**Questions to answer:**
-1. Confirm tail-append position.
-2. Confirm intra-group order.
-3. Should the smoke test assert the exact sub-sequence (`args.containsSlice(...)`) or just containment of each flag individually?
-
-**Options:**
-- **Option A (recommended):** Tail-append, order as proposed, smoke test uses `containsSlice` on the four new flags for determinism.
-- **Option B:** Tail-append, order as proposed, smoke test only uses `contains` per flag (looser, slightly more forgiving).
-- **Option C:** Different position (e.g., immediately after `permissionModeArgs`). Requires updating this analysis and the test.
-
-**Impact:** Test strictness and future refactor latitude.
+**Decided:** Tail-append the three new groups in order `strictMcpConfigArgs` → `mcpConfigPathArgs` → `settingSourcesArgs`, after `maxThinkingTokensArgs`. `mcpConfigPathArgs` emits a three-element list `["--mcp-config", "<path>", "--"]` to terminate the variadic `--mcp-config` and prevent downstream argv tokens (prompt, caller-appended flags) from being swallowed as additional config paths. Smoke test uses `containsSlice` for pair/triple adjacency and `indexOf` comparisons for cross-group ordering. See Technical Decisions > Argv Ordering for the full rationale.
 
 ---
 
-### CLARIFY: Boolean fluent helper ergonomics
+### Decision: Boolean fluent helper shape
 
-`withStrictMcpConfig(flag: Boolean)` is the pattern from the issue. The rest of the fluent API for boolean-like fields is mixed: `continueConversation` is `Option[Boolean]` with `withContinueConversation(continue: Boolean)` (no no-arg convenience), `inheritEnvironment` is the same.
-
-**Questions to answer:**
-1. Is `withStrictMcpConfig(flag: Boolean)` (always taking an explicit boolean) sufficient, matching the `continueConversation` / `inheritEnvironment` precedent?
-2. Or should we also offer a no-arg `withStrictMcpConfig: QueryOptions` that sets it to `true` for cleaner consumer call sites (`opts.withStrictMcpConfig`)?
-
-**Options:**
-- **Option A (recommended):** Single `withStrictMcpConfig(flag: Boolean)` — matches existing precedent, YAGNI.
-- **Option B:** Both `withStrictMcpConfig(flag: Boolean)` and zero-arg `withStrictMcpConfig`. Minor convenience, small surface growth.
-
-**Impact:** API surface size and call-site ergonomics.
+**Decided:** Option A — single `withStrictMcpConfig(flag: Boolean)` on both `QueryOptions` and `SessionOptions`. No zero-arg convenience. Matches existing precedent from `withContinueConversation(continue: Boolean)` and `withInheritEnvironment(inherit: Boolean)` in the same case classes.
 
 ---
 
-### CLARIFY: `strictMcpConfig` field type — `Boolean` vs `Option[Boolean]`
+### Decision: `strictMcpConfig` field type
 
-Other boolean-like options in `QueryOptions` use `Option[Boolean]` (e.g., `continueConversation`, `inheritEnvironment`). The issue specifies `strictMcpConfig: Boolean = false`.
+**Decided:** Option B — `strictMcpConfig: Option[Boolean] = None` on both `QueryOptions` and `SessionOptions`. Consistent with other boolean-ish fields (`continueConversation`, `inheritEnvironment`). Preserves the possibility of distinguishing "unset" from "explicit false" in case a future CLI surface adds a negation semantic; the SDK should not prematurely flatten that.
 
-**Questions to answer:**
-1. Is the plain `Boolean = false` from the issue the right choice (matches "flag" semantics — either present or absent)?
-2. Or should we use `Option[Boolean] = None` for stylistic consistency with `continueConversation` (tri-state: unset / explicit false / explicit true)?
+**Translation:**
+- `Some(true)` → `List("--strict-mcp-config")`
+- `Some(false)` or `None` → `Nil` (no flag emitted — today the CLI has no `--no-strict-mcp-config`, so both default and explicit-false are argv-identical)
 
-**Options:**
-- **Option A (recommended, matches issue):** `strictMcpConfig: Boolean = false`. Simpler. Flag is either emitted (true) or not (false / default). Matches CLI semantics — the flag has no "off" equivalent.
-- **Option B:** `Option[Boolean] = None`. Stylistic consistency with `continueConversation`. But `Some(false)` would be semantically indistinguishable from `None` because there is no `--no-strict-mcp-config` flag — adds complexity for no gain.
-
-**Impact:** Field declaration and one `match`/`if` line in the CLI builder.
+**Fluent helper:** `withStrictMcpConfig(flag: Boolean): QueryOptions = copy(strictMcpConfig = Some(flag))` (and the mirror on `SessionOptions`).
 
 ---
 
@@ -224,7 +195,7 @@ Other boolean-like options in `QueryOptions` use `Option[Boolean]` (e.g., `conti
 - Pure additive mirror of an existing, well-understood pattern — no design discovery required.
 - Single-module scope; no cross-module churn thanks to re-export aliases.
 - Test surface is small and mechanical.
-- The CLARIFY markers are about style/naming, not about unknowns that could blow up effort.
+- Resolved decisions (see "Resolved Decisions" section) are about style/naming, not about unknowns that could blow up effort.
 
 ## Recommended Phase Plan
 
@@ -248,10 +219,11 @@ Unit tests only — this change has no integration or E2E surface (it's pure arg
 
 **CLI Translation Layer (`CLIArgumentBuilderTest.scala`):**
 Add the following tests:
-1. `strictMcpConfig = true emits --strict-mcp-config` — asserts `args.contains("--strict-mcp-config")`.
-2. `strictMcpConfig default (false) does not emit --strict-mcp-config` — asserts `!args.contains("--strict-mcp-config")`.
-3. `mcpConfigPath maps to --mcp-config <path>` — asserts the pair appears.
-4. `mcpConfigPath default (None) does not emit --mcp-config` — asserts absent.
+1. `strictMcpConfig = Some(true) emits --strict-mcp-config` — asserts `args.contains("--strict-mcp-config")`.
+2. `strictMcpConfig default (None) does not emit --strict-mcp-config` — asserts `!args.contains("--strict-mcp-config")`.
+2a. `strictMcpConfig = Some(false) does not emit --strict-mcp-config` — asserts `!args.contains("--strict-mcp-config")` (documents the "no negation flag" behaviour).
+3. `mcpConfigPath maps to --mcp-config <path> --` — asserts the three-element slice `List("--mcp-config", path, "--")` appears (terminator isolates the variadic `--mcp-config` from whatever follows in argv).
+4. `mcpConfigPath default (None) does not emit --mcp-config` — asserts absent; also asserts the standalone `"--"` terminator is absent when the flag is unset (so we don't emit a stray terminator).
 5. `settingSources non-empty maps to --setting-sources with CSV value` — asserts `args.contains("--setting-sources")` and `args.contains("project,user")` for `List("project", "user")`.
 6. `settingSources default (Nil) does not emit --setting-sources` — asserts absent.
 7. `PermissionMode.DontAsk maps to --permission-mode dontAsk` — asserts pair appears and string is exactly `"dontAsk"`.
@@ -270,12 +242,13 @@ Add the following tests:
 
      // presence
      assert(args.contains("--strict-mcp-config"))
-     assert(args.containsSlice(List("--mcp-config", "./.mcp.json")))
+     // --mcp-config is variadic; must be followed by "--" to isolate it
+     assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
      assert(args.containsSlice(List("--setting-sources", "project")))
      assert(args.containsSlice(List("--permission-mode", "dontAsk")))
 
      // deterministic order: permission-mode precedes the MCP/settings trio,
-     // which appears as strict -> mcp-config -> setting-sources
+     // which appears as strict -> mcp-config (+ terminator) -> setting-sources
      val pmIdx = args.indexOf("--permission-mode")
      val strictIdx = args.indexOf("--strict-mcp-config")
      val mcpIdx = args.indexOf("--mcp-config")
@@ -334,7 +307,7 @@ None in this SDK. Consumers (PROC-401) will start passing the four new flags.
 ### Risk 2: Consumer (PROC-401) expects a different argv order than our chosen one
 **Likelihood:** Low
 **Impact:** Low (the CLI accepts any order; our smoke test just pins one)
-**Mitigation:** Flagged as CLARIFY above. Get confirmation before locking the order into the smoke test. If PROC-401 only inspects by flag presence, keep our order; if it expects a specific slice, match that.
+**Mitigation:** Ordering is locked by decision (see "Resolved Decisions > Argv ordering policy") and asserted in the smoke test. If PROC-401 surfaces a different expectation during validation, adjust the smoke test and this analysis in follow-up.
 
 ### Risk 3: `settingSources: List[String]` vs typed enum drift
 **Likelihood:** Low
@@ -370,6 +343,5 @@ None in this SDK. Consumers (PROC-401) will start passing the four new flags.
 **Analysis Status:** Ready for Review
 
 **Next Steps:**
-1. Resolve the four CLARIFY markers (test file naming, argv ordering, fluent helper ergonomics, `Boolean` vs `Option[Boolean]`).
-2. Run **wf-create-tasks** with issue ID `CC-46`.
-3. Run **wf-implement** for the single merged phase.
+1. Run **wf-create-tasks** with issue ID `CC-46`.
+2. Run **wf-implement** for the single merged phase.

--- a/project-management/issues/CC-46/implementation-log.md
+++ b/project-management/issues/CC-46/implementation-log.md
@@ -1,0 +1,53 @@
+# Implementation Log: Add Option-C tool-isolation knobs
+
+Issue: CC-46
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: Option-C isolation knobs (domain + CLI + tests) (2026-04-21)
+
+**Layer:** Domain + CLI translation + tests (merged per analysis — phase-size floor)
+
+**What was built:**
+- `core/src/works/iterative/claude/core/model/PermissionMode.scala` — added `DontAsk` enum case with Scaladoc.
+- `core/src/works/iterative/claude/core/model/QueryOptions.scala` — added three fields (`strictMcpConfig: Option[Boolean]`, `mcpConfigPath: Option[String]`, `settingSources: List[String]`) with Scaladoc, three fluent helpers, and exhaustive update to `QueryOptions.simple` factory. Updated `permissionMode` Scaladoc to list `DontAsk`.
+- `core/src/works/iterative/claude/core/model/SessionOptions.scala` — symmetric three fields, Scaladoc, fluent helpers.
+- `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` — added `DontAsk` branch to `permissionModeArgs` match in both `buildArgs` and `buildSessionArgs`; added `strictMcpConfigArgs`, `mcpConfigPathArgs`, `settingSourcesArgs` val blocks tail-appended in that order after `maxThinkingTokensArgs` in both builders. Empty-branch values use `List.empty` to match file convention.
+
+**Dependencies on other layers:**
+- None (phase 1 of 1). `direct` and `effectful` modules automatically pick up new fields via existing `type` / `val` re-exports — verified by `./mill direct.compile` and `./mill effectful.compile` succeeding with no source edits.
+
+**Testing:**
+- Unit tests: 19 added (9 in `CLIArgumentBuilderTest`, 10 in `SessionOptionsArgsTest` including the `requiredFlags` regression). Covers presence, absence, `Some(false)` non-emission, CSV join, terminator placement, and deterministic argv ordering.
+- Integration tests: none needed (pure `List[String]` translation, no effects).
+
+**Decisions made:**
+- `settingSources` stays `List[String]` (not a typed enum) per the issue's explicit requirement.
+- `strictMcpConfig: Option[Boolean]` mirrors existing `continueConversation` tri-state pattern; `Some(false)` and `None` both emit nothing (no `--no-strict-mcp-config` flag exists in the CLI).
+- `mcpConfigPath` emits `List("--mcp-config", path, "--")` because the CLI flag is variadic — the `"--"` terminator prevents it from consuming downstream argv tokens.
+- Argv order is locked: `permissionModeArgs` → `strictMcpConfigArgs` → `mcpConfigPathArgs` → `settingSourcesArgs`, tail-appended in both builders.
+- `PermissionMode.DontAsk` gets per-case Scaladoc; the other three cases remain undocumented per the phase context's scope.
+- Code review warnings about `Option[Boolean]` tri-state, `buildArgs`/`buildSessionArgs` duplication, missing validation on `settingSources`/`mcpConfigPath`, and other structural concerns were flagged out of scope per the analysis's resolved decisions.
+
+**Code review:**
+- Iterations: 2 (iteration 1 surfaced 2 critical testing findings; iteration 2 confirmed all resolved, 0 critical remaining).
+- Iteration 2 testing reviewer suggested re-adding `!args.contains("--")` to `mcpConfigPath` absence tests — ignored because it contradicts iteration 1's valid reasoning (`"--"` is a POSIX sentinel that could legitimately appear for other flags).
+- Review file: `review-phase-01-20260421-221853.md`
+
+**For next phases:**
+- No next phases — this is the only phase for CC-46.
+- Consumers (PROC-401 and future tickets) can now set all four isolation knobs via `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources`, and `withPermissionMode(PermissionMode.DontAsk)` on either `QueryOptions` or `SessionOptions`.
+
+**Files changed:**
+```
+M core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+M core/src/works/iterative/claude/core/model/PermissionMode.scala
+M core/src/works/iterative/claude/core/model/QueryOptions.scala
+M core/src/works/iterative/claude/core/model/SessionOptions.scala
+M core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala
+M core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+```
+
+---

--- a/project-management/issues/CC-46/phase-01-context.md
+++ b/project-management/issues/CC-46/phase-01-context.md
@@ -1,0 +1,326 @@
+# Phase 1: Option-C isolation knobs (domain + CLI + tests)
+
+## Goals
+
+Extend the SDK's configuration surface with the four CLI knobs needed for hard tool-isolation (PROC-401 / Option C): `--strict-mcp-config`, `--mcp-config <path>`, `--setting-sources <csv>`, and `--permission-mode dontAsk`. This is a purely additive, single-phase change merging the domain, CLI-translation, and test layers because they are mechanically coupled through Scala 3 enum exhaustiveness and the project's TDD rule.
+
+- Add `PermissionMode.DontAsk` enum case.
+- Add three new fields + fluent helpers on `QueryOptions` and `SessionOptions`.
+- Extend `CLIArgumentBuilder.buildArgs` and `buildSessionArgs` with one new `match` branch and three new translations each.
+- Lock presence, absence, and deterministic argv ordering of all four flags via tests.
+- Preserve byte-identical argv for callers that do not set any of the new knobs.
+
+## Scope
+
+**In-scope (merged into this single phase):**
+- Domain / model layer: `PermissionMode`, `QueryOptions`, `SessionOptions`.
+- CLI translation layer: `CLIArgumentBuilder` (both public methods).
+- Test layer: `CLIArgumentBuilderTest`, `SessionOptionsArgsTest`.
+
+**Out-of-scope:**
+- No source edits to the `direct` or `effectful` modules. They pick up the new domain additions transparently via their existing `type`/`val` re-exports in `direct/src/works/iterative/claude/direct/package.scala` and `effectful/src/works/iterative/claude/effectful/package.scala`.
+- No behaviour change for existing callers (defaults must emit zero new argv tokens).
+- No new abstractions (builder, typeclass, DSL). The existing `Option[T]` + `match` / `if` pattern is mirrored exactly.
+- No rename of `CLIArgumentBuilderTest.scala` to `QueryOptionsArgsTest.scala`; the existing file is the de-facto QueryOptions argv test.
+- No deprecation or renaming of existing `PermissionMode` cases.
+- No introduction of a typed `SettingSource` enum. `settingSources` stays `List[String]` per the issue.
+
+## Dependencies
+
+**Prior phases:** None (this is phase 1 of 1).
+
+**Upstream components required (existing, to be extended):**
+- `enum PermissionMode` with cases `Default`, `AcceptEdits`, `BypassPermissions` (`core/src/works/iterative/claude/core/model/PermissionMode.scala`).
+- `case class QueryOptions` with existing fields including `permissionMode: Option[PermissionMode] = None`; fluent helpers `withPermissionMode`, `withContinueConversation`, `withInheritEnvironment`; factory `QueryOptions.simple(prompt)` (`core/src/works/iterative/claude/core/model/QueryOptions.scala`).
+- `case class SessionOptions` with symmetric shape; `object SessionOptions` providing `val defaults: SessionOptions = SessionOptions()` (`core/src/works/iterative/claude/core/model/SessionOptions.scala`).
+- `CLIArgumentBuilder.buildArgs(QueryOptions)` and `CLIArgumentBuilder.buildSessionArgs(SessionOptions)` with their current `permissionMode` match blocks (`core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`).
+- Existing test files `CLIArgumentBuilderTest.scala` and `SessionOptionsArgsTest.scala`, extended by adding new `test("...")` blocks.
+
+**Downstream consumers:**
+- `direct` module — re-exports `type PermissionMode`, `val PermissionMode`, `type QueryOptions`, `val QueryOptions`, `type SessionOptions`, `val SessionOptions`. No source edit required; recompile propagates the new case / fields automatically.
+- `effectful` module — same re-export pattern, same outcome.
+
+## Approach
+
+Ordered implementation sequence, mirroring the analysis's "Implementation Sequence":
+
+1. **Domain layer first.** Add `PermissionMode.DontAsk`. Add three fields + three fluent helpers on each of `QueryOptions` and `SessionOptions`. Update `QueryOptions.simple` to pass the new defaults explicitly (the factory already enumerates every field by name, so keep it exhaustive). `SessionOptions.defaults` needs no change because the new fields have defaults.
+
+2. **TDD pair: CLI translation + tests.** For each new field/branch, in order `permissionMode DontAsk` → `strictMcpConfig` → `mcpConfigPath` → `settingSources`:
+   1. Add a failing test in `CLIArgumentBuilderTest` (and symmetric test in `SessionOptionsArgsTest`).
+   2. Run `./mill core.test` to confirm it fails.
+   3. Add the minimal match branch / translation in `CLIArgumentBuilder` (both `buildArgs` and `buildSessionArgs`).
+   4. Run `./mill core.test` to confirm green.
+   Then add the "absent when default" and "`Some(false)`" variants, and finally the two round-trip smoke tests.
+
+3. **Verification sweep.** Run `./mill __.compile` to confirm no non-exhaustive-match warnings (this is the positive regression signal that both builder sites were updated). Run `./mill __.test`. Run `./mill direct.compile` and `./mill effectful.compile` to confirm the re-exports propagate without source edits.
+
+## Component Specifications
+
+### 1. `PermissionMode` — add `DontAsk` case
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/PermissionMode.scala`
+
+**Change:** Add one enum case, `DontAsk`, after the existing three. Extend the file's enum Scaladoc (or add a per-case Scaladoc line) to describe `DontAsk` as "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs".
+
+**Shape after change:**
+
+```scala
+enum PermissionMode:
+  case Default
+  case AcceptEdits
+  case BypassPermissions
+  /** Enforce `allowedTools` as a hard allow-list; no prompts, no hangs. */
+  case DontAsk
+```
+
+---
+
+### 2. `QueryOptions` — add three fields and three fluent helpers
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/QueryOptions.scala`
+
+**Changes:**
+- Add three fields to the case class (with Scaladoc matching the existing field-comment style):
+  - `strictMcpConfig: Option[Boolean] = None` — maps to `--strict-mcp-config`. `Some(true)` emits the flag; `Some(false)` and `None` emit nothing (no `--no-strict-mcp-config` flag exists in the CLI today).
+  - `mcpConfigPath: Option[String] = None` — maps to `--mcp-config <path> --`. The trailing `"--"` terminator is mandatory because `--mcp-config` is variadic.
+  - `settingSources: List[String] = Nil` — maps to `--setting-sources <csv>`. Empty list emits nothing.
+- Add three fluent helpers inside the case class body, after the existing `with*` methods:
+
+```scala
+def withStrictMcpConfig(flag: Boolean): QueryOptions =
+  copy(strictMcpConfig = Some(flag))
+def withMcpConfigPath(path: String): QueryOptions =
+  copy(mcpConfigPath = Some(path))
+def withSettingSources(sources: List[String]): QueryOptions =
+  copy(settingSources = sources)
+```
+
+- Update the `QueryOptions.simple(prompt)` factory to explicitly pass the three new defaults as named arguments (`strictMcpConfig = None, mcpConfigPath = None, settingSources = Nil`), keeping the factory exhaustive per the existing convention.
+
+---
+
+### 3. `SessionOptions` — symmetric three fields and three fluent helpers
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/SessionOptions.scala`
+
+**Changes:**
+- Add three fields to the case class with identical names, types, defaults, and Scaladoc as on `QueryOptions`:
+  - `strictMcpConfig: Option[Boolean] = None`
+  - `mcpConfigPath: Option[String] = None`
+  - `settingSources: List[String] = Nil`
+- Add three fluent helpers inside the case class body:
+
+```scala
+def withStrictMcpConfig(flag: Boolean): SessionOptions =
+  copy(strictMcpConfig = Some(flag))
+def withMcpConfigPath(path: String): SessionOptions =
+  copy(mcpConfigPath = Some(path))
+def withSettingSources(sources: List[String]): SessionOptions =
+  copy(settingSources = sources)
+```
+
+- `object SessionOptions.defaults` does not need to change; its `SessionOptions()` constructor call picks up the new defaults automatically.
+
+---
+
+### 4. `CLIArgumentBuilder` — new `DontAsk` branch + three new translations, in both builders
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`
+
+**Changes apply symmetrically to both `buildArgs(QueryOptions)` and `buildSessionArgs(SessionOptions)`.**
+
+**a) `DontAsk` branch in the existing `permissionMode` match:**
+
+Add a new case to the existing `permissionModeArgs` match block so it becomes exhaustive over all four enum cases:
+
+```scala
+case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")
+```
+
+The `permissionModeArgs` value's position in the final `List(...).flatten` is unchanged.
+
+**b) `strictMcpConfigArgs`:**
+
+```scala
+val strictMcpConfigArgs = options.strictMcpConfig match
+  case Some(true) => List("--strict-mcp-config")
+  case _          => Nil
+```
+
+Emits `List("--strict-mcp-config")` only for `Some(true)`. Both `None` and `Some(false)` emit `Nil` (no negation flag exists in the CLI today).
+
+**c) `mcpConfigPathArgs`:**
+
+```scala
+val mcpConfigPathArgs = options.mcpConfigPath match
+  case Some(path) => List("--mcp-config", path, "--")
+  case None       => Nil
+```
+
+Emits the three-element list `List("--mcp-config", path, "--")` for `Some(path)`. Emits `Nil` for `None`. The trailing `"--"` is mandatory because `--mcp-config` is variadic and would otherwise consume downstream argv tokens (prompt, caller-appended flags) as additional config paths.
+
+**d) `settingSourcesArgs`:**
+
+```scala
+val settingSourcesArgs =
+  if options.settingSources.nonEmpty then
+    List("--setting-sources", options.settingSources.mkString(","))
+  else Nil
+```
+
+Emits `List("--setting-sources", "<csv>")` when the list is non-empty. Emits `Nil` otherwise.
+
+**e) Argv ordering at the tail:**
+
+In the final `List(...).flatten` of `buildArgs`, append the three new arg groups after `maxThinkingTokensArgs` in this exact order:
+
+```
+maxTurnsArgs, modelArgs, allowedToolsArgs, disallowedToolsArgs,
+systemPromptArgs, appendSystemPromptArgs, continueConversationArgs,
+resumeArgs, permissionModeArgs, maxThinkingTokensArgs,
+strictMcpConfigArgs, mcpConfigPathArgs, settingSourcesArgs
+```
+
+In `buildSessionArgs`, the same three groups are appended in the same order after `maxThinkingTokensArgs`, and the required streaming flags block (`--print`, `--input-format`, `stream-json`, `--output-format`, `stream-json`) remains first so `args.take(requiredFlags.length) == requiredFlags` continues to hold.
+
+`permissionModeArgs` does not move; only the `DontAsk` branch is added to its match.
+
+Both `buildArgs` and `buildSessionArgs` receive the same four additions in the same order.
+
+---
+
+### 5. `CLIArgumentBuilderTest` — new tests for QueryOptions-side coverage
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala`
+
+**Change:** Append nine new `test("...")` blocks covering the four new knobs plus the round-trip smoke test. See Testing Strategy below for the exact list and the verbatim smoke-test body.
+
+---
+
+### 6. `SessionOptionsArgsTest` — new tests for SessionOptions-side coverage
+
+**File:** `/home/mph/Devel/iw/claude-code-query-CC-46/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala`
+
+**Change:** Append the symmetric nine test blocks, plus one regression test asserting `args.take(requiredFlags.length) == requiredFlags` still holds when all four new flags are set. See Testing Strategy below.
+
+## Files to Modify
+
+**Domain / model layer (`core/src/.../model/`):**
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/PermissionMode.scala`
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/QueryOptions.scala`
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/model/SessionOptions.scala`
+
+**CLI translation layer (`core/src/.../cli/`):**
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`
+
+**Test layer (`core/test/src/.../cli/`):**
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala`
+- `/home/mph/Devel/iw/claude-code-query-CC-46/core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala`
+
+## Testing Strategy
+
+TDD for every new field and branch: write the failing test first, run it to confirm the failure mode (missing flag / non-exhaustive-match warning / compilation error on the unknown helper), then add the translation branch. No mocks. Pure `List[String]` comparisons.
+
+### `CLIArgumentBuilderTest.scala` — nine new tests
+
+1. `strictMcpConfig = Some(true) emits --strict-mcp-config` — assert `args.contains("--strict-mcp-config")`.
+2. `strictMcpConfig default (None) does not emit --strict-mcp-config` — assert `!args.contains("--strict-mcp-config")`.
+3. `strictMcpConfig = Some(false) does not emit --strict-mcp-config` — assert `!args.contains("--strict-mcp-config")` (documents the "no negation flag" behaviour).
+4. `mcpConfigPath maps to --mcp-config <path> --` — assert `args.containsSlice(List("--mcp-config", "./.mcp.json", "--"))`.
+5. `mcpConfigPath default (None) does not emit --mcp-config` — assert `!args.contains("--mcp-config")` and `!args.contains("--")` (no stray terminator when the flag is absent).
+6. `settingSources non-empty maps to --setting-sources with CSV value` — assert `args.contains("--setting-sources")` and `args.contains("project,user")` for `List("project", "user")`.
+7. `settingSources default (Nil) does not emit --setting-sources` — assert `!args.contains("--setting-sources")`.
+8. `PermissionMode.DontAsk maps to --permission-mode dontAsk` — assert `args.containsSlice(List("--permission-mode", "dontAsk"))`.
+9. Smoke round-trip test — verbatim from the analysis:
+
+```scala
+test("all four Option-C isolation flags round-trip in deterministic order"):
+  val options = QueryOptions
+    .simple("test prompt")
+    .withStrictMcpConfig(true)
+    .withMcpConfigPath("./.mcp.json")
+    .withSettingSources(List("project"))
+    .withPermissionMode(PermissionMode.DontAsk)
+
+  val args = CLIArgumentBuilder.buildArgs(options)
+
+  // presence
+  assert(args.contains("--strict-mcp-config"))
+  // --mcp-config is variadic; must be followed by "--" to isolate it
+  assert(args.containsSlice(List("--mcp-config", "./.mcp.json", "--")))
+  assert(args.containsSlice(List("--setting-sources", "project")))
+  assert(args.containsSlice(List("--permission-mode", "dontAsk")))
+
+  // deterministic order: permission-mode precedes the MCP/settings trio,
+  // which appears as strict -> mcp-config (+ terminator) -> setting-sources
+  val pmIdx = args.indexOf("--permission-mode")
+  val strictIdx = args.indexOf("--strict-mcp-config")
+  val mcpIdx = args.indexOf("--mcp-config")
+  val ssIdx = args.indexOf("--setting-sources")
+  assert(pmIdx < strictIdx)
+  assert(strictIdx < mcpIdx)
+  assert(mcpIdx < ssIdx)
+```
+
+### `SessionOptionsArgsTest.scala` — symmetric nine tests + required-flags regression
+
+Mirror tests 1-8 above using `SessionOptions().with*` builders and `CLIArgumentBuilder.buildSessionArgs(...)`.
+
+Add a session-flavoured round-trip test analogous to #9, constructed from:
+
+```scala
+SessionOptions()
+  .withStrictMcpConfig(true)
+  .withMcpConfigPath("./.mcp.json")
+  .withSettingSources(List("project"))
+  .withPermissionMode(PermissionMode.DontAsk)
+```
+
+with the same `containsSlice` / `indexOf` ordering asserts.
+
+Add one additional regression test:
+
+> `required session flags still appear at the start of the argument list when all four new flags are set`
+
+Build the options as above and assert `args.take(requiredFlags.length) == requiredFlags`. This locks in the tail-append invariant and protects the existing `requiredFlags` preamble.
+
+### Regression coverage
+
+- All existing tests in both files must pass unchanged.
+- The `PermissionMode` match in both `CLIArgumentBuilder` methods is exhaustive after this change; compilation without a non-exhaustive-match warning is the positive signal that both match sites were updated.
+
+## Acceptance Criteria
+
+- [ ] `PermissionMode.DontAsk` enum case exists and is exhaustively matched in both `buildArgs` and `buildSessionArgs`.
+- [ ] `QueryOptions` has new fields `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`.
+- [ ] `SessionOptions` has the same three fields with the same names, types, and defaults.
+- [ ] `QueryOptions` exposes `withStrictMcpConfig(flag: Boolean)`, `withMcpConfigPath(path: String)`, `withSettingSources(sources: List[String])`.
+- [ ] `SessionOptions` exposes the same three `with*` helpers with symmetric signatures.
+- [ ] `QueryOptions.simple` factory updated to pass the three new defaults as named arguments, keeping the factory exhaustive.
+- [ ] When `mcpConfigPath = Some(path)`, the argv contains the three-element slice `List("--mcp-config", path, "--")` (terminator included) in both builders.
+- [ ] Argv ordering is locked by tests: `permissionModeArgs` precedes the MCP/settings trio; within that trio, order is strict → mcp-config(+terminator) → setting-sources; and for `buildSessionArgs`, `requiredFlags` remains at positions 0..4.
+- [ ] `./mill __.compile` succeeds with no new warnings (specifically, no non-exhaustive `PermissionMode` match warning from either builder site).
+- [ ] `./mill __.test` is green, including the nine new `CLIArgumentBuilderTest` cases, the symmetric ten new `SessionOptionsArgsTest` cases (nine + required-flags regression), and all pre-existing tests.
+- [ ] `./mill direct.compile` and `./mill effectful.compile` are green, proving re-export propagation works without source edits in those modules.
+- [ ] Scaladoc added on the three new fields on both `QueryOptions` and `SessionOptions`, describing each CLI flag they map to in the same style as existing field comments. Scaladoc added on the new `PermissionMode.DontAsk` case describing it as "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs".
+
+## Risks
+
+**Risk 1: Non-exhaustive `PermissionMode` match somewhere other than `CLIArgumentBuilder`.**
+Likelihood: Low. Impact: Medium (compiler warning, possible CI failure if `-Xfatal-warnings` is enabled). Mitigation: before committing, search the repo for all `PermissionMode` use sites with `sg --lang scala -p 'PermissionMode.$CASE'` and `rg 'case PermissionMode\.'`. The issue-provided survey lists only `buildArgs` and `buildSessionArgs`, but re-verify during implementation.
+
+**Risk 2: Consumer (PROC-401) expects a different argv order than the one chosen here.**
+Likelihood: Low. Impact: Low (the CLI accepts any order; the smoke test only pins one). Mitigation: ordering is locked by the resolved decision (permission-mode → strict → mcp-config+terminator → setting-sources, tail-appended) and asserted in the smoke tests. If PROC-401 validation surfaces a different expectation, adjust the smoke tests and this analysis in follow-up rather than changing behaviour silently.
+
+**Risk 3: `settingSources: List[String]` is stringly typed and may drift from the CLI's accepted values.**
+Likelihood: Low. Impact: Low (the issue explicitly specifies `List[String]`). Mitigation: stick with `List[String]` per the issue. A future ticket can introduce a typed `SettingSource` enum if PROC-401 or another consumer asks for it. Note this in the journal rather than acting now (YAGNI).
+
+## Estimated Effort
+
+2.75-4.5 hours total for the merged phase:
+- Domain / model layer: 0.75-1.25 hours
+- CLI translation layer: 0.75-1.25 hours
+- Test layer: 1.25-2 hours
+
+Confidence: High. Pure additive mirror of a well-understood existing pattern; all open questions resolved in the analysis; single-module scope with no cross-module source churn.

--- a/project-management/issues/CC-46/phase-01-tasks.md
+++ b/project-management/issues/CC-46/phase-01-tasks.md
@@ -6,71 +6,72 @@
 
 ## Setup
 
-- [ ] [setup] Read `core/src/works/iterative/claude/core/model/PermissionMode.scala` to confirm the three existing cases and Scaladoc style.
-- [ ] [setup] Read `core/src/works/iterative/claude/core/model/QueryOptions.scala` and `SessionOptions.scala` to confirm existing field/helper style and `QueryOptions.simple` factory.
-- [ ] [setup] Read `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` to locate the existing `permissionMode` match and the tail `List(...).flatten` in both `buildArgs` and `buildSessionArgs`.
-- [ ] [setup] Read `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` and `SessionOptionsArgsTest.scala` to match existing test style.
-- [ ] [run] Run `./mill __.compile` and `./mill __.test` to confirm a clean baseline.
+- [x] [setup] Read `core/src/works/iterative/claude/core/model/PermissionMode.scala` to confirm the three existing cases and Scaladoc style.
+- [x] [setup] Read `core/src/works/iterative/claude/core/model/QueryOptions.scala` and `SessionOptions.scala` to confirm existing field/helper style and `QueryOptions.simple` factory.
+- [x] [setup] Read `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` to locate the existing `permissionMode` match and the tail `List(...).flatten` in both `buildArgs` and `buildSessionArgs`.
+- [x] [setup] Read `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` and `SessionOptionsArgsTest.scala` to match existing test style.
+- [x] [run] Run `./mill __.compile` and `./mill __.test` to confirm a clean baseline.
 
 ## Implementation — Domain additions (purely additive, pre-TDD)
 
-- [ ] [impl] Add `PermissionMode.DontAsk` case with Scaladoc "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs" (file: `core/src/works/iterative/claude/core/model/PermissionMode.scala`).
-- [ ] [impl] Add fields `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil` to `QueryOptions` with Scaladoc per CLI flag (file: `core/src/works/iterative/claude/core/model/QueryOptions.scala`).
-- [ ] [impl] Add fluent helpers `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources` to `QueryOptions` (same file).
-- [ ] [impl] Update `QueryOptions.simple(prompt)` factory to pass `strictMcpConfig = None, mcpConfigPath = None, settingSources = Nil` as named arguments (same file).
-- [ ] [impl] Add the same three fields with identical names/types/defaults/Scaladoc to `SessionOptions` (file: `core/src/works/iterative/claude/core/model/SessionOptions.scala`).
-- [ ] [impl] Add the same three `with*` fluent helpers to `SessionOptions` (same file).
-- [ ] [run] Run `./mill core.compile` to confirm domain additions compile cleanly. Expect a non-exhaustive-match warning at both `CLIArgumentBuilder` sites as a positive signal.
+- [x] [impl] Add `PermissionMode.DontAsk` case with Scaladoc "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs" (file: `core/src/works/iterative/claude/core/model/PermissionMode.scala`).
+- [x] [impl] Add fields `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil` to `QueryOptions` with Scaladoc per CLI flag (file: `core/src/works/iterative/claude/core/model/QueryOptions.scala`).
+- [x] [impl] Add fluent helpers `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources` to `QueryOptions` (same file).
+- [x] [impl] Update `QueryOptions.simple(prompt)` factory to pass `strictMcpConfig = None, mcpConfigPath = None, settingSources = Nil` as named arguments (same file).
+- [x] [impl] Add the same three fields with identical names/types/defaults/Scaladoc to `SessionOptions` (file: `core/src/works/iterative/claude/core/model/SessionOptions.scala`).
+- [x] [impl] Add the same three `with*` fluent helpers to `SessionOptions` (same file).
+- [x] [run] Run `./mill core.compile` to confirm domain additions compile cleanly. Expect a non-exhaustive-match warning at both `CLIArgumentBuilder` sites as a positive signal.
 
 ## Tests (failing first) — TDD per knob
 
 ### Group A: `PermissionMode.DontAsk`
 
-- [ ] [test] Write test `PermissionMode.DontAsk maps to --permission-mode dontAsk` asserting `args.containsSlice(List("--permission-mode", "dontAsk"))` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write symmetric session-side test in `SessionOptionsArgsTest.scala`.
-- [ ] [run] Run `./mill core.test` and confirm both tests fail (missing branch).
-- [ ] [impl] Add `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")` to `permissionModeArgs` in both `buildArgs` and `buildSessionArgs` (file: `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`).
-- [ ] [run] Run `./mill core.test` and confirm the two `DontAsk` tests are green.
+- [x] [test] Write test `PermissionMode.DontAsk maps to --permission-mode dontAsk` asserting `args.containsSlice(List("--permission-mode", "dontAsk"))` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write symmetric session-side test in `SessionOptionsArgsTest.scala`.
+- [x] [run] Run `./mill core.test` and confirm both tests fail (missing branch).
+- [x] [impl] Add `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")` to `permissionModeArgs` in both `buildArgs` and `buildSessionArgs` (file: `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`).
+- [x] [run] Run `./mill core.test` and confirm the two `DontAsk` tests are green.
 
 ### Group B: `strictMcpConfig`
 
-- [ ] [test] Write test `strictMcpConfig = Some(true) emits --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write test `strictMcpConfig default (None) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write test `strictMcpConfig = Some(false) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write the three symmetric session-side tests in `SessionOptionsArgsTest.scala`.
-- [ ] [run] Run `./mill core.test` and confirm the new `strictMcpConfig` tests fail.
-- [ ] [impl] Add `strictMcpConfigArgs` match block and append it after `maxThinkingTokensArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
-- [ ] [run] Run `./mill core.test` and confirm the `strictMcpConfig` tests are green.
+- [x] [test] Write test `strictMcpConfig = Some(true) emits --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write test `strictMcpConfig default (None) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write test `strictMcpConfig = Some(false) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write the three symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [x] [run] Run `./mill core.test` and confirm the new `strictMcpConfig` tests fail.
+- [x] [impl] Add `strictMcpConfigArgs` match block and append it after `maxThinkingTokensArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [x] [run] Run `./mill core.test` and confirm the `strictMcpConfig` tests are green.
 
 ### Group C: `mcpConfigPath`
 
-- [ ] [test] Write test `mcpConfigPath maps to --mcp-config <path> --` asserting `args.containsSlice(List("--mcp-config", "./.mcp.json", "--"))` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write test `mcpConfigPath default (None) does not emit --mcp-config` asserting `!args.contains("--mcp-config")` and `!args.contains("--")` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
-- [ ] [run] Run `./mill core.test` and confirm the new `mcpConfigPath` tests fail.
-- [ ] [impl] Add `mcpConfigPathArgs` match block and append it after `strictMcpConfigArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
-- [ ] [run] Run `./mill core.test` and confirm the `mcpConfigPath` tests are green.
+- [x] [test] Write test `mcpConfigPath maps to --mcp-config <path> --` asserting `args.containsSlice(List("--mcp-config", "./.mcp.json", "--"))` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write test `mcpConfigPath default (None) does not emit --mcp-config` asserting `!args.contains("--mcp-config")` and `!args.contains("--")` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [x] [run] Run `./mill core.test` and confirm the new `mcpConfigPath` tests fail.
+- [x] [impl] Add `mcpConfigPathArgs` match block and append it after `strictMcpConfigArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [x] [run] Run `./mill core.test` and confirm the `mcpConfigPath` tests are green.
 
 ### Group D: `settingSources`
 
-- [ ] [test] Write test `settingSources non-empty maps to --setting-sources with CSV value` (using `List("project", "user")` → `"project,user"`) in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write test `settingSources default (Nil) does not emit --setting-sources` in `CLIArgumentBuilderTest.scala`.
-- [ ] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
-- [ ] [run] Run `./mill core.test` and confirm the new `settingSources` tests fail.
-- [ ] [impl] Add `settingSourcesArgs` `if/else` block and append it after `mcpConfigPathArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
-- [ ] [run] Run `./mill core.test` and confirm the `settingSources` tests are green.
+- [x] [test] Write test `settingSources non-empty maps to --setting-sources with CSV value` (using `List("project", "user")` → `"project,user"`) in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write test `settingSources default (Nil) does not emit --setting-sources` in `CLIArgumentBuilderTest.scala`.
+- [x] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [x] [run] Run `./mill core.test` and confirm the new `settingSources` tests fail.
+- [x] [impl] Add `settingSourcesArgs` `if/else` block and append it after `mcpConfigPathArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [x] [run] Run `./mill core.test` and confirm the `settingSources` tests are green.
 
 ### Group E: Round-trip smoke tests + session `requiredFlags` regression
 
-- [ ] [test] Add the verbatim "all four Option-C isolation flags round-trip in deterministic order" smoke test to `CLIArgumentBuilderTest.scala` (see phase context §Testing Strategy for the exact body, including `pmIdx < strictIdx < mcpIdx < ssIdx` ordering asserts).
-- [ ] [test] Add the symmetric session-side round-trip smoke test to `SessionOptionsArgsTest.scala` using `SessionOptions().with*` builders and `buildSessionArgs`.
-- [ ] [test] Add the `required session flags still appear at the start of the argument list when all four new flags are set` regression test in `SessionOptionsArgsTest.scala`, asserting `args.take(requiredFlags.length) == requiredFlags`.
-- [ ] [run] Run `./mill core.test` and confirm all three smoke/regression tests are green.
+- [x] [test] Add the verbatim "all four Option-C isolation flags round-trip in deterministic order" smoke test to `CLIArgumentBuilderTest.scala` (see phase context §Testing Strategy for the exact body, including `pmIdx < strictIdx < mcpIdx < ssIdx` ordering asserts).
+- [x] [test] Add the symmetric session-side round-trip smoke test to `SessionOptionsArgsTest.scala` using `SessionOptions().with*` builders and `buildSessionArgs`.
+- [x] [test] Add the `required session flags still appear at the start of the argument list when all four new flags are set` regression test in `SessionOptionsArgsTest.scala`, asserting `args.take(requiredFlags.length) == requiredFlags`.
+- [x] [run] Run `./mill core.test` and confirm all three smoke/regression tests are green.
 
 ## Integration / verification sweep
 
-- [ ] [verify] Run `./mill __.compile` and confirm no non-exhaustive-match warnings (both `PermissionMode` match sites updated) and no other new warnings.
-- [ ] [verify] Run `./mill __.test` and confirm all tests green (nine new `CLIArgumentBuilderTest` cases, ten new `SessionOptionsArgsTest` cases, all pre-existing tests).
-- [ ] [verify] Run `./mill direct.compile` to confirm re-export propagation works in the `direct` module without source edits.
-- [ ] [verify] Run `./mill effectful.compile` to confirm re-export propagation works in the `effectful` module without source edits.
-- [ ] [verify] Run `sg --lang scala -p 'PermissionMode.$CASE'` (or equivalent) to confirm no non-exhaustive `PermissionMode` match exists outside `CLIArgumentBuilder` (Risk 1 mitigation).
+- [x] [verify] Run `./mill __.compile` and confirm no non-exhaustive-match warnings (both `PermissionMode` match sites updated) and no other new warnings.
+- [x] [verify] Run `./mill __.test` and confirm all tests green (nine new `CLIArgumentBuilderTest` cases, ten new `SessionOptionsArgsTest` cases, all pre-existing tests).
+- [x] [verify] Run `./mill direct.compile` to confirm re-export propagation works in the `direct` module without source edits.
+- [x] [verify] Run `./mill effectful.compile` to confirm re-export propagation works in the `effectful` module without source edits.
+- [x] [verify] Run `sg --lang scala -p 'PermissionMode.$CASE'` (or equivalent) to confirm no non-exhaustive `PermissionMode` match exists outside `CLIArgumentBuilder` (Risk 1 mitigation).
+**Phase Status:** Complete

--- a/project-management/issues/CC-46/phase-01-tasks.md
+++ b/project-management/issues/CC-46/phase-01-tasks.md
@@ -1,0 +1,76 @@
+# Phase 1 Tasks: Option-C isolation knobs (domain + CLI + tests)
+
+**Issue:** CC-46
+**Phase:** 1 of 1
+**Context:** `phase-01-context.md`
+
+## Setup
+
+- [ ] [setup] Read `core/src/works/iterative/claude/core/model/PermissionMode.scala` to confirm the three existing cases and Scaladoc style.
+- [ ] [setup] Read `core/src/works/iterative/claude/core/model/QueryOptions.scala` and `SessionOptions.scala` to confirm existing field/helper style and `QueryOptions.simple` factory.
+- [ ] [setup] Read `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` to locate the existing `permissionMode` match and the tail `List(...).flatten` in both `buildArgs` and `buildSessionArgs`.
+- [ ] [setup] Read `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` and `SessionOptionsArgsTest.scala` to match existing test style.
+- [ ] [run] Run `./mill __.compile` and `./mill __.test` to confirm a clean baseline.
+
+## Implementation — Domain additions (purely additive, pre-TDD)
+
+- [ ] [impl] Add `PermissionMode.DontAsk` case with Scaladoc "Enforce `allowedTools` as a hard allow-list; no prompts, no hangs" (file: `core/src/works/iterative/claude/core/model/PermissionMode.scala`).
+- [ ] [impl] Add fields `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil` to `QueryOptions` with Scaladoc per CLI flag (file: `core/src/works/iterative/claude/core/model/QueryOptions.scala`).
+- [ ] [impl] Add fluent helpers `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources` to `QueryOptions` (same file).
+- [ ] [impl] Update `QueryOptions.simple(prompt)` factory to pass `strictMcpConfig = None, mcpConfigPath = None, settingSources = Nil` as named arguments (same file).
+- [ ] [impl] Add the same three fields with identical names/types/defaults/Scaladoc to `SessionOptions` (file: `core/src/works/iterative/claude/core/model/SessionOptions.scala`).
+- [ ] [impl] Add the same three `with*` fluent helpers to `SessionOptions` (same file).
+- [ ] [run] Run `./mill core.compile` to confirm domain additions compile cleanly. Expect a non-exhaustive-match warning at both `CLIArgumentBuilder` sites as a positive signal.
+
+## Tests (failing first) — TDD per knob
+
+### Group A: `PermissionMode.DontAsk`
+
+- [ ] [test] Write test `PermissionMode.DontAsk maps to --permission-mode dontAsk` asserting `args.containsSlice(List("--permission-mode", "dontAsk"))` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write symmetric session-side test in `SessionOptionsArgsTest.scala`.
+- [ ] [run] Run `./mill core.test` and confirm both tests fail (missing branch).
+- [ ] [impl] Add `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")` to `permissionModeArgs` in both `buildArgs` and `buildSessionArgs` (file: `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala`).
+- [ ] [run] Run `./mill core.test` and confirm the two `DontAsk` tests are green.
+
+### Group B: `strictMcpConfig`
+
+- [ ] [test] Write test `strictMcpConfig = Some(true) emits --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write test `strictMcpConfig default (None) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write test `strictMcpConfig = Some(false) does not emit --strict-mcp-config` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write the three symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [ ] [run] Run `./mill core.test` and confirm the new `strictMcpConfig` tests fail.
+- [ ] [impl] Add `strictMcpConfigArgs` match block and append it after `maxThinkingTokensArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [ ] [run] Run `./mill core.test` and confirm the `strictMcpConfig` tests are green.
+
+### Group C: `mcpConfigPath`
+
+- [ ] [test] Write test `mcpConfigPath maps to --mcp-config <path> --` asserting `args.containsSlice(List("--mcp-config", "./.mcp.json", "--"))` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write test `mcpConfigPath default (None) does not emit --mcp-config` asserting `!args.contains("--mcp-config")` and `!args.contains("--")` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [ ] [run] Run `./mill core.test` and confirm the new `mcpConfigPath` tests fail.
+- [ ] [impl] Add `mcpConfigPathArgs` match block and append it after `strictMcpConfigArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [ ] [run] Run `./mill core.test` and confirm the `mcpConfigPath` tests are green.
+
+### Group D: `settingSources`
+
+- [ ] [test] Write test `settingSources non-empty maps to --setting-sources with CSV value` (using `List("project", "user")` → `"project,user"`) in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write test `settingSources default (Nil) does not emit --setting-sources` in `CLIArgumentBuilderTest.scala`.
+- [ ] [test] Write the two symmetric session-side tests in `SessionOptionsArgsTest.scala`.
+- [ ] [run] Run `./mill core.test` and confirm the new `settingSources` tests fail.
+- [ ] [impl] Add `settingSourcesArgs` `if/else` block and append it after `mcpConfigPathArgs` in the tail `List(...).flatten` of both `buildArgs` and `buildSessionArgs`.
+- [ ] [run] Run `./mill core.test` and confirm the `settingSources` tests are green.
+
+### Group E: Round-trip smoke tests + session `requiredFlags` regression
+
+- [ ] [test] Add the verbatim "all four Option-C isolation flags round-trip in deterministic order" smoke test to `CLIArgumentBuilderTest.scala` (see phase context §Testing Strategy for the exact body, including `pmIdx < strictIdx < mcpIdx < ssIdx` ordering asserts).
+- [ ] [test] Add the symmetric session-side round-trip smoke test to `SessionOptionsArgsTest.scala` using `SessionOptions().with*` builders and `buildSessionArgs`.
+- [ ] [test] Add the `required session flags still appear at the start of the argument list when all four new flags are set` regression test in `SessionOptionsArgsTest.scala`, asserting `args.take(requiredFlags.length) == requiredFlags`.
+- [ ] [run] Run `./mill core.test` and confirm all three smoke/regression tests are green.
+
+## Integration / verification sweep
+
+- [ ] [verify] Run `./mill __.compile` and confirm no non-exhaustive-match warnings (both `PermissionMode` match sites updated) and no other new warnings.
+- [ ] [verify] Run `./mill __.test` and confirm all tests green (nine new `CLIArgumentBuilderTest` cases, ten new `SessionOptionsArgsTest` cases, all pre-existing tests).
+- [ ] [verify] Run `./mill direct.compile` to confirm re-export propagation works in the `direct` module without source edits.
+- [ ] [verify] Run `./mill effectful.compile` to confirm re-export propagation works in the `effectful` module without source edits.
+- [ ] [verify] Run `sg --lang scala -p 'PermissionMode.$CASE'` (or equivalent) to confirm no non-exhaustive `PermissionMode` match exists outside `CLIArgumentBuilder` (Risk 1 mitigation).

--- a/project-management/issues/CC-46/release-notes.md
+++ b/project-management/issues/CC-46/release-notes.md
@@ -1,0 +1,12 @@
+# Izolace nástrojů pro spouštění Claude Code v uzavřeném režimu
+
+**Issue:** CC-46
+**Datum:** 2026-04-21
+
+Tato změna rozšiřuje Scala SDK pro Claude Code o čtyři nové volby, které umožňují spustit Claude Code v plně izolovaném režimu s pevně daným seznamem povolených nástrojů. Volající nyní může zabránit tomu, aby podprocesy spuštěné přes SDK automaticky přebíraly konfiguraci nástrojů z uživatelského nastavení, z nalezených `.mcp.json` souborů v pracovním adresáři, nebo aby při pokusu o použití nepovoleného nástroje čekaly na interaktivní potvrzení.
+
+V praxi to znamená, že aplikace, které potřebují spouštět Claude Code jako součást automatizovaných toků (například zpracování událostí nebo dávkové operace), mohou nyní vynutit, aby podproces používal pouze explicitně předaný seznam povolených nástrojů a žádnou jinou konfiguraci. Nepovolené volání nástroje už neskončí zavěšením na dotazu, ale okamžitým odmítnutím, což zásadně zvyšuje spolehlivost těchto běhů v prostředích bez uživatelské interakce.
+
+Konkrétně lze nově zapnout striktní zpracování konfigurace nástrojů (ignorování jiných zdrojů), předat cestu ke konkrétnímu konfiguračnímu souboru, omezit zdroje, ze kterých se načítají obecná nastavení (například pouze na projekt), a zvolit režim oprávnění, který vyžaduje pevný allow-list bez výzev. Tyto čtyři volby lze kombinovat nezávisle nebo dohromady — podle míry izolace, kterou daný scénář potřebuje.
+
+Pro stávající volající se nic nemění. Všechny nové volby mají výchozí chování, které odpovídá dosavadnímu stavu, a jsou aktivní pouze tehdy, když je volající explicitně nastaví. Aktualizace tedy nevyžaduje žádné úpravy existujícího kódu a představuje čistě rozšíření dostupných možností.

--- a/project-management/issues/CC-46/review-packet.md
+++ b/project-management/issues/CC-46/review-packet.md
@@ -1,0 +1,245 @@
+---
+generated_from: 011b9bc03797e963480e094fa7c26205d6774f82
+generated_at: 2026-04-21T20:36:23Z
+branch: CC-46
+issue_id: CC-46
+phase: 1
+files_analyzed:
+  - core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala
+  - core/src/works/iterative/claude/core/model/PermissionMode.scala
+  - core/src/works/iterative/claude/core/model/QueryOptions.scala
+  - core/src/works/iterative/claude/core/model/SessionOptions.scala
+  - core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala
+  - core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala
+---
+
+# Review Packet: CC-46 — Option-C Tool-Isolation Knobs
+
+## Goals
+
+Consumer `iterative-works/procedures` (PROC-401) needs to spawn event-processor subprocesses
+with a hard tool allow-list that cannot be widened by inherited `.mcp.json` files, user-level
+settings, or interactive permission prompts. Without dedicated CLI flags for those controls, an
+isolated subprocess can either silently inherit the user's MCP configuration or hang waiting on
+an interactive permission prompt for a tool not in `allowedTools`.
+
+This change extends the SDK's `QueryOptions`, `SessionOptions`, and `PermissionMode` types with
+four new "Option-C isolation" knobs:
+
+| SDK field / method | CLI flag emitted | Purpose |
+|---|---|---|
+| `strictMcpConfig = Some(true)` | `--strict-mcp-config` | Prevent merging of any `.mcp.json` other than the explicitly provided one |
+| `mcpConfigPath = Some(path)` | `--mcp-config <path> --` | Explicitly point at a specific `.mcp.json` (trailing `--` terminates the variadic flag) |
+| `settingSources = List(...)` | `--setting-sources <csv>` | Restrict settings resolution (e.g. `project` excludes user/managed) |
+| `PermissionMode.DontAsk` | `--permission-mode dontAsk` | Enforce `allowedTools` as a hard allow-list; no prompts, no hangs |
+
+Key objectives:
+- All four knobs default to emitting zero argv tokens, preserving byte-identical behaviour for
+  existing callers.
+- The `direct` and `effectful` modules pick up the additions automatically via their existing
+  `type`/`val` re-exports — no source edits required there.
+- The change is additive only: no existing `PermissionMode` cases are deprecated or renamed.
+
+## Scenarios
+
+- [ ] `PermissionMode.DontAsk` enum case exists and serialises to the CLI string `"dontAsk"` in
+      both `buildArgs` and `buildSessionArgs`.
+- [ ] `QueryOptions` exposes `strictMcpConfig: Option[Boolean] = None`,
+      `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil` with
+      matching `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources` fluent helpers.
+- [ ] `SessionOptions` exposes the same three fields and fluent helpers with symmetric signatures.
+- [ ] `QueryOptions.simple` factory is updated to enumerate the three new fields as named
+      arguments, keeping the factory exhaustive.
+- [ ] `strictMcpConfig = Some(true)` emits `--strict-mcp-config`; `Some(false)` and `None` emit
+      nothing (no `--no-strict-mcp-config` flag exists in the CLI).
+- [ ] `mcpConfigPath = Some(path)` emits the three-element slice `["--mcp-config", path, "--"]`
+      in both builders. The `"--"` terminator is mandatory because `--mcp-config` is variadic.
+- [ ] `mcpConfigPath = None` emits neither `--mcp-config` nor a stray `"--"`.
+- [ ] `settingSources` non-empty emits `--setting-sources <csv>` with values joined by commas;
+      empty list emits nothing.
+- [ ] Argv ordering is locked: `--permission-mode` precedes the isolation trio; within that trio,
+      `--strict-mcp-config` → `--mcp-config <path> --` → `--setting-sources <csv>`.
+- [ ] For `buildSessionArgs`, the required streaming preamble
+      `["--print", "--input-format", "stream-json", "--output-format", "stream-json"]` still
+      occupies positions 0–4 when all four isolation knobs are set.
+- [ ] `./mill __.compile` succeeds with no non-exhaustive `PermissionMode` match warnings.
+- [ ] `./mill __.test` is green with all 19 new tests passing alongside pre-existing tests.
+- [ ] `./mill direct.compile` and `./mill effectful.compile` succeed without source edits in
+      those modules.
+
+## Entry Points
+
+| File | Method / Class | Why Start Here |
+|---|---|---|
+| `core/src/works/iterative/claude/core/model/PermissionMode.scala` | `enum PermissionMode` | Smallest change; see the new `DontAsk` case and understand the serialisation contract |
+| `core/src/works/iterative/claude/core/model/QueryOptions.scala` | `case class QueryOptions` | New fields and fluent helpers; also see updated `permissionMode` Scaladoc and exhaustive `simple` factory |
+| `core/src/works/iterative/claude/core/model/SessionOptions.scala` | `case class SessionOptions` | Symmetric additions to `QueryOptions`; confirm field names, types, and helpers match |
+| `core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala` | `buildArgs`, `buildSessionArgs` | Core translation logic; verify new `val` blocks and their position in the final `List(...).flatten` |
+| `core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala` | tests 14–22 (new) | Presence / absence / `Some(false)` / CSV join / terminator / ordering tests for `QueryOptions` path |
+| `core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala` | tests 16–26 (new) | Symmetric coverage for `SessionOptions` path plus required-flags preamble regression |
+
+## Diagrams
+
+### Component Overview
+
+```mermaid
+graph TD
+    subgraph core["core module"]
+        PM[PermissionMode<br/>+DontAsk]
+        QO[QueryOptions<br/>+strictMcpConfig<br/>+mcpConfigPath<br/>+settingSources]
+        SO[SessionOptions<br/>+strictMcpConfig<br/>+mcpConfigPath<br/>+settingSources]
+        CAB[CLIArgumentBuilder<br/>buildArgs / buildSessionArgs]
+        PM --> QO
+        PM --> SO
+        QO --> CAB
+        SO --> CAB
+    end
+
+    subgraph direct["direct module (re-export only)"]
+        D[package.scala<br/>type / val aliases]
+    end
+
+    subgraph effectful["effectful module (re-export only)"]
+        E[package.scala<br/>type / val aliases]
+    end
+
+    core --> direct
+    core --> effectful
+    CAB -->|"List[String] argv"| CLI["Claude Code CLI subprocess"]
+```
+
+### Argv Construction Flow (buildArgs)
+
+```mermaid
+flowchart LR
+    QO["QueryOptions"] --> B["CLIArgumentBuilder.buildArgs"]
+    B --> PM["permissionModeArgs<br/>--permission-mode dontAsk"]
+    B --> MTK["maxThinkingTokensArgs<br/>(existing)"]
+    B --> SMC["strictMcpConfigArgs<br/>--strict-mcp-config"]
+    B --> MCP["mcpConfigPathArgs<br/>--mcp-config path --"]
+    B --> SS["settingSourcesArgs<br/>--setting-sources csv"]
+    PM --> F["List.flatten → argv"]
+    MTK --> F
+    SMC --> F
+    MCP --> F
+    SS --> F
+```
+
+### The `--mcp-config` Variadic Terminator
+
+```
+Without terminator:   claude ... --mcp-config ./.mcp.json  "tell me a joke"
+                                              ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
+                                              path arg      consumed as 2nd config path!
+
+With terminator:      claude ... --mcp-config ./.mcp.json  --  "tell me a joke"
+                                              ^^^^^^^^^^^^  ^^  ^^^^^^^^^^^^^^^
+                                              path arg      end  safe prompt arg
+```
+
+## Test Summary
+
+All tests are unit tests. No integration or E2E tests are needed — the change is pure argv
+construction with no effects or external process calls.
+
+### CLIArgumentBuilderTest.scala — new tests (9 added)
+
+| # | Test name | Type | Verifies |
+|---|---|---|---|
+| 1 | `PermissionMode.DontAsk maps to --permission-mode dontAsk` | Unit | Serialisation string is `"dontAsk"` (camelCase) |
+| 2 | `strictMcpConfig = Some(true) emits --strict-mcp-config` | Unit | Presence when set |
+| 3 | `strictMcpConfig default (None) does not emit --strict-mcp-config` | Unit | Absence when default |
+| 4 | `strictMcpConfig = Some(false) does not emit --strict-mcp-config` | Unit | No negation flag emitted |
+| 5 | `mcpConfigPath maps to --mcp-config <path> --` | Unit | Three-element slice including `"--"` terminator |
+| 6 | `mcpConfigPath default (None) does not emit --mcp-config` | Unit | Neither flag nor stray terminator |
+| 7 | `settingSources non-empty maps to --setting-sources with CSV value` | Unit | CSV join via `containsSlice` |
+| 8 | `settingSources default (Nil) does not emit --setting-sources` | Unit | Absence when empty |
+| 9 | `all four Option-C isolation flags round-trip in deterministic order` | Unit | All four flags present; ordering `permission-mode < strict < mcp-config < setting-sources` |
+
+### SessionOptionsArgsTest.scala — new tests (10 added)
+
+| # | Test name | Type | Verifies |
+|---|---|---|---|
+| 1 | `PermissionMode.DontAsk maps to --permission-mode dontAsk` | Unit | Same as QueryOptions counterpart |
+| 2 | `strictMcpConfig = Some(true) emits --strict-mcp-config` | Unit | Presence when set |
+| 3 | `strictMcpConfig default (None) does not emit --strict-mcp-config` | Unit | Absence when default |
+| 4 | `strictMcpConfig = Some(false) does not emit --strict-mcp-config` | Unit | No negation flag emitted |
+| 5 | `mcpConfigPath maps to --mcp-config <path> --` | Unit | Three-element slice including terminator |
+| 6 | `mcpConfigPath default (None) does not emit --mcp-config` | Unit | Absence when default |
+| 7 | `settingSources non-empty maps to --setting-sources with CSV value` | Unit | CSV join via `containsSlice` |
+| 8 | `settingSources default (Nil) does not emit --setting-sources` | Unit | Absence when empty |
+| 9 | `all four Option-C isolation flags round-trip in deterministic order` | Unit | Same ordering assertions as QueryOptions smoke test |
+| 10 | `required session flags still appear at the start of the argument list when all four new flags are set` | Unit | `args.take(5) == requiredFlags` — preamble not displaced by tail-append |
+
+**Pre-existing tests:** All pass unchanged (confirmed in implementation log; no pre-existing
+assertions were modified).
+
+## Files Changed
+
+13 files changed vs `main` (1,358 insertions, 5 deletions). Production source changes are
+confined entirely to the `core` module.
+
+### Production source (4 files)
+
+<details>
+<summary>core/src/works/iterative/claude/core/model/PermissionMode.scala (+3 lines)</summary>
+
+Added `DontAsk` enum case with per-case Scaladoc. The other three cases remain undocumented
+(pre-existing asymmetry; intentional per phase context scope).
+
+</details>
+
+<details>
+<summary>core/src/works/iterative/claude/core/model/QueryOptions.scala (+31 lines)</summary>
+
+- Three new fields: `strictMcpConfig: Option[Boolean] = None`, `mcpConfigPath: Option[String] = None`, `settingSources: List[String] = Nil`, each with Scaladoc describing the CLI flag.
+- Three fluent helpers: `withStrictMcpConfig`, `withMcpConfigPath`, `withSettingSources`.
+- `QueryOptions.simple` factory updated to pass all three as named arguments.
+- `permissionMode` field Scaladoc updated to include `DontAsk` bullet.
+
+</details>
+
+<details>
+<summary>core/src/works/iterative/claude/core/model/SessionOptions.scala (+24 lines)</summary>
+
+Symmetric additions to `QueryOptions`: same three fields, same Scaladoc, same three fluent
+helpers. `object SessionOptions.defaults` unchanged (picks up new field defaults automatically
+via the zero-argument constructor).
+
+</details>
+
+<details>
+<summary>core/src/works/iterative/claude/core/cli/CLIArgumentBuilder.scala (+40 lines)</summary>
+
+Both `buildArgs` and `buildSessionArgs` receive identical additions:
+1. `case Some(PermissionMode.DontAsk) => List("--permission-mode", "dontAsk")` in the existing `permissionModeArgs` match.
+2. `val strictMcpConfigArgs` — emits `List("--strict-mcp-config")` for `Some(true)`, `List.empty` otherwise.
+3. `val mcpConfigPathArgs` — emits `List("--mcp-config", path, "--")` for `Some(path)`, `List.empty` otherwise.
+4. `val settingSourcesArgs` — emits `List("--setting-sources", csv)` when non-empty, `List.empty` otherwise.
+
+All three new `val` blocks are tail-appended in the `List(...).flatten` after `maxThinkingTokensArgs`, in order `strict → mcp-config → setting-sources`.
+
+</details>
+
+### Test source (2 files)
+
+<details>
+<summary>core/test/src/works/iterative/claude/core/cli/CLIArgumentBuilderTest.scala (+78 lines)</summary>
+
+9 new `test("...")` blocks covering the QueryOptions-side translation. See Test Summary above.
+
+</details>
+
+<details>
+<summary>core/test/src/works/iterative/claude/core/cli/SessionOptionsArgsTest.scala (+83 lines)</summary>
+
+10 new `test("...")` blocks covering the SessionOptions-side translation and the required-flags
+preamble regression. See Test Summary above.
+
+</details>
+
+### Project management (7 files, no production impact)
+
+`project-management/issues/CC-46/` — analysis, tasks, phase context, phase tasks, implementation
+log, phase review, and review state. These document the decision trail and are not part of the
+published artifact.

--- a/project-management/issues/CC-46/review-phase-01-20260421-221853.md
+++ b/project-management/issues/CC-46/review-phase-01-20260421-221853.md
@@ -1,0 +1,199 @@
+# Code Review Results
+
+**Review Context:** Phase 1: Option-C isolation knobs (domain + CLI + tests) for CC-46 (Iteration 1/3)
+**Files Reviewed:** 6 (4 source, 2 test)
+**Skills Applied:** iterative-works:code-review-style, iterative-works:code-review-testing, iterative-works:code-review-security, iterative-works:code-review-scala3, iterative-works:code-review-composition, iterative-works:code-review-architecture
+**Timestamp:** 2026-04-21T22:18:53Z
+**Git Context:** git diff 79b8dfa644fb7930a97842bd4d0d9648a77f15db
+
+---
+
+<review skill="iterative-works:code-review-style">
+
+## Code Style & Documentation Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Missing Scaladoc on new fluent helpers** (`QueryOptions.scala:158-163`, `SessionOptions.scala:124-129`). New `withStrictMcpConfig`/`withMcpConfigPath`/`withSettingSources` lack method-level Scaladoc. Field-level docs exist but `withMcpConfigPath` does not signal the `--` terminator at the signature.
+- **Redundant `// Permission modes` comment** (`PermissionMode.scala:6`). Pre-existing; not introduced here.
+- **Test name references "Option-C"** (`CLIArgumentBuilderTest.scala:239`, `SessionOptionsArgsTest.scala:171`). "Option-C" is the issue-level label for the feature in project docs; not a free-floating implementation detail.
+
+### Suggestions
+
+- Inconsistent `DontAsk` Scaladoc (only one enum case has per-case docs).
+- `strictMcpConfig: Option[Boolean]` could be a flag-only type; but mirrors existing `continueConversation` pattern.
+- `settingSourcesArgs` uses `if/else` while siblings use `match`.
+
+</review>
+
+---
+
+<review skill="iterative-works:code-review-testing">
+
+## Testing Review
+
+### Critical Issues
+
+- **`mcpConfigPath` absence test asserts `!args.contains("--")`** (`CLIArgumentBuilderTest.scala:219-222`, `SessionOptionsArgsTest.scala:153-156`). Bare `--` is a POSIX end-of-options sentinel that could legitimately appear in other arguments. The positive `containsSlice` test already validates terminator placement. Drop the `!args.contains("--")` assertion; keep only `!args.contains("--mcp-config")`.
+- **Round-trip smoke test uses single-element `settingSources`** (`CLIArgumentBuilderTest.scala:239-266`, `SessionOptionsArgsTest.scala:171-195`). `List("project").mkString(",")` never exercises the CSV join. Focused multi-element test DOES exercise it, so this is a smoke-test-only weakness, but worth addressing.
+
+### Warnings
+
+- **Non-adjacent `--setting-sources` assertion** uses two separate `contains` calls instead of `containsSlice`. Inconsistent with how `mcpConfigPath` is tested.
+- **Redundant presence assertions in smoke tests** (duplicate the focused per-flag tests; only the ordering asserts are uniquely valuable).
+- **Duplicate pre-existing session default test** (pre-existing, not introduced here).
+- **Pre-existing `AcceptEdits` test uses two `contains` calls instead of `containsSlice`** — inconsistency the new `DontAsk` test makes visible.
+
+### Suggestions
+
+- Missing single-element `settingSources` focused test.
+- Missing combined `strictMcpConfig + mcpConfigPath` interaction test.
+- Tests extend `CatsEffectSuite` despite pure `List[String]` comparisons.
+
+</review>
+
+---
+
+<review skill="iterative-works:code-review-security">
+
+## Security Review
+
+### Critical Issues
+
+None found. Subprocess invocation is exec-style (no shell), so no injection path from `mcpConfigPath` or `settingSources` values.
+
+### Warnings
+
+- **`settingSources` elements containing commas are silently mis-parsed** (`CLIArgumentBuilder.scala:73, :154`). Configuration integrity issue; low attacker surface.
+- **Log statement exposes full argv** (`ProcessManager.scala:119`, direct module `:53`). Pre-existing behavior; not introduced here.
+
+### Suggestions
+
+- `mcpConfigPath` accepts any string with no path validation.
+- `PermissionMode.DontAsk` has elevated-trust implications not mirrored in `QueryOptions.permissionMode` field Scaladoc.
+
+</review>
+
+---
+
+<review skill="iterative-works:code-review-scala3">
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **`PermissionMode` per-case Scaladoc is inconsistent** (only `DontAsk` gets docs). Phase context explicitly asked for this Scaladoc, so intentional — but asymmetry is real.
+- **`strictMcpConfig: Option[Boolean]` is a tri-state with no use for `Some(false)`**. Mirrors existing `continueConversation` pattern (per analysis); out of scope per review context.
+
+### Suggestions
+
+- `QueryOptions.simple` factory redundant with named-args constructor (pre-existing style choice).
+- Wildcard `case _` on `strictMcpConfig` match loses exhaustiveness.
+- `permissionMode` match uses `List.empty` while new blocks use `Nil` — inconsistent.
+
+</review>
+
+---
+
+<review skill="iterative-works:code-review-composition">
+
+## Composition Patterns Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Duplication between `buildArgs` and `buildSessionArgs`**. Analysis explicitly marked this as by design and out of scope for this phase.
+- **`strictMcpConfig: Option[Boolean]` tri-state** (same point as scala3 reviewer).
+
+### Suggestions
+
+- `continueConversationArgs` uses `List.empty` while new blocks use `Nil` — inconsistent.
+
+</review>
+
+---
+
+<review skill="iterative-works:code-review-architecture">
+
+## Architecture Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+- **Duplication between `buildArgs` and `buildSessionArgs`** (same as composition reviewer; by design per analysis).
+- **`QueryOptions.permissionMode` Scaladoc does not mention `DontAsk`** (`QueryOptions.scala:62-68`). Stale field doc — real bug. Should list `DontAsk` bullet.
+
+### Suggestions
+
+- `mcpConfigPath: Option[String]` could be a typed `Path`. Consistent with existing `pathToClaudeCodeExecutable: Option[String]`; not a scope item.
+- `strictMcpConfig` flag modeling (same as scala3/composition).
+
+</review>
+
+---
+
+## Summary
+
+**Critical issues:** 2 (both from testing reviewer)
+**Warnings:** ~14 (several pre-existing, several explicitly out of scope per analysis)
+**Suggestions:** ~11
+
+**Actionable for iteration 2 (items to fix):**
+
+1. **[testing, critical]** Drop `!args.contains("--")` in both `mcpConfigPath` absence tests. Keep only `!args.contains("--mcp-config")`.
+2. **[testing, critical]** Change round-trip smoke test `settingSources` from `List("project")` to `List("project", "local")` so the CSV join is exercised end-to-end.
+3. **[architecture, warning]** Update `QueryOptions.permissionMode` Scaladoc to include a `DontAsk` bullet.
+4. **[testing, warning]** Use `containsSlice(List("--setting-sources", "project,user"))` in the non-empty `settingSources` tests (both files).
+5. **[style/scala3/composition, warning]** Replace `Nil` with `List.empty` in the three new arg blocks (both builders) to match the surrounding file convention.
+
+**Out of scope or not actionable:**
+- `Option[Boolean]` tri-state — analysis explicitly preserves existing pattern.
+- Duplication between builders — explicitly by design per analysis.
+- Missing Scaladoc on fluent helpers — matches existing style in the files.
+- Pre-existing issues (`// Permission modes` comment, `AcceptEdits` weak assertions, log statement exposing argv, duplicate session default test) — not introduced by this change.
+- Test name "Option-C" — project-level feature label, not an implementation detail.
+
+---
+
+## Iteration 2 (after fixes)
+
+**Timestamp:** 2026-04-21T22:30:00Z
+**Baseline:** 79b8dfa (same as iteration 1 — uncommitted fixes layered on top)
+
+### Iteration 2 summary
+
+**Critical issues:** 0 across all six reviewers. The testing reviewer explicitly confirmed all three iteration 1 critical findings are resolved:
+1. `!args.contains("--")` removed from `mcpConfigPath` absence tests.
+2. Round-trip smoke test now uses `List("project", "local")`, exercising the CSV join.
+3. Non-empty `settingSources` tests use `containsSlice` for adjacency.
+
+**Warnings (all pre-existing or out of scope):**
+- `DontAsk` Scaladoc inconsistency across enum cases (intentional per phase context; phase context explicitly asked for per-case Scaladoc on `DontAsk`).
+- `// Permission modes` comment redundancy (pre-existing).
+- `AcceptEdits` test uses `contains` instead of `containsSlice` (pre-existing; iteration 1 made the inconsistency visible but the pre-existing test was not touched per "smallest reasonable changes" rule).
+- `settingSources` comma injection / `mcpConfigPath` path validation — out of scope per analysis (no validation framework for option-type fields exists; adding it would extend scope).
+- `Option[Boolean]` tri-state — out of scope per analysis (mirrors `continueConversation`).
+- `buildArgs`/`buildSessionArgs` duplication — explicitly by design per analysis.
+- `mcpConfigPath` `--` terminator inside builder — intentional per analysis (flag is variadic).
+
+**Testing reviewer contradiction with iteration 1:** Iteration 2 suggests re-adding `!args.contains("--")` to the `mcpConfigPath` absence tests. This contradicts iteration 1's critical finding that the same assertion was fragile coupling. Iteration 1's reasoning — bare `"--"` is a POSIX sentinel that could legitimately appear for any other flag — is stronger. Keeping the iteration 1 fix as-is.
+
+**Suggestions:** Multiple (split round-trip test, single-source focused tests, `SettingSource` enum, `QueryOptions.simple` simplification, extract shared arg helpers, etc.) — all deferred to future iterations.
+
+### Verdict
+
+Proceed to phase commit. All critical issues resolved. Remaining warnings are pre-existing or explicitly out of scope per the analysis.

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -19,16 +19,28 @@
     {
       "label": "Phase 1 Tasks",
       "path": "project-management/issues/CC-46/phase-01-tasks.md"
+    },
+    {
+      "label": "Review Packet",
+      "path": "project-management/issues/CC-46/review-packet.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/CC-46/implementation-log.md"
+    },
+    {
+      "label": "Release Notes",
+      "path": "project-management/issues/CC-46/release-notes.md"
     }
   ],
-  "last_updated": "2026-04-21T20:32:21.593171902Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-21T20:39:42.746727725Z",
+  "status": "all_complete",
   "display": {
-    "text": "Phase 01: Awaiting Review",
-    "type": "warning",
+    "text": "Ready for Final Review",
+    "type": "success",
     "subtext": "Option-C isolation knobs (domain + CLI + tests)"
   },
-  "message": "Phase 01 implementation started",
+  "message": "All phases complete - final PR created",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -56,6 +68,11 @@
       "id": "view-pr",
       "label": "View Pull Request",
       "skill": "external-link"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "67a1642",
@@ -75,5 +92,5 @@
       "type": "warning"
     }
   ],
-  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/47"
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/48"
 }

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -15,17 +15,21 @@
     {
       "label": "Phase 1 Context",
       "path": "project-management/issues/CC-46/phase-01-context.md"
+    },
+    {
+      "label": "Phase 1 Tasks",
+      "path": "project-management/issues/CC-46/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-21T20:05:45.443507367Z",
-  "status": "context_ready",
+  "last_updated": "2026-04-21T20:10:30.408808087Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Phase 1: Context Ready",
-    "type": "info",
+    "text": "Phase 1: Tasks Ready",
+    "type": "success",
     "subtext": "Option-C isolation knobs (domain + CLI + tests)"
   },
-  "message": "Phase 1 context ready for review",
-  "activity": "working",
+  "message": "Phase 1 tasks ready",
+  "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
     {
@@ -41,6 +45,11 @@
     {
       "id": "implement",
       "label": "Start Implementation",
+      "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
       "skill": "wf-implement"
     }
   ],

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -1,0 +1,34 @@
+{
+  "version": 2,
+  "issue_id": "CC-46",
+  "artifacts": [
+    {
+      "label": "Analysis",
+      "path": "project-management/issues/CC-46/analysis.md",
+      "category": "input"
+    }
+  ],
+  "last_updated": "2026-04-21T15:21:40.375597155Z",
+  "status": "analysis_ready",
+  "display": {
+    "text": "Analysis Ready",
+    "type": "success",
+    "subtext": "Architecture analysis complete"
+  },
+  "message": "Analysis complete - ready for task generation",
+  "activity": "waiting",
+  "workflow_type": "waterfall",
+  "available_actions": [
+    {
+      "id": "create-tasks",
+      "label": "Generate Tasks",
+      "skill": "wf-create-tasks"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
+    }
+  ],
+  "git_sha": "67a1642"
+}

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -6,16 +6,21 @@
       "label": "Analysis",
       "path": "project-management/issues/CC-46/analysis.md",
       "category": "input"
+    },
+    {
+      "label": "Tasks",
+      "path": "project-management/issues/CC-46/tasks.md",
+      "category": "output"
     }
   ],
-  "last_updated": "2026-04-21T15:21:40.375597155Z",
-  "status": "analysis_ready",
+  "last_updated": "2026-04-21T19:51:13.713174565Z",
+  "status": "tasks_ready",
   "display": {
-    "text": "Analysis Ready",
+    "text": "Tasks Ready",
     "type": "success",
-    "subtext": "Architecture analysis complete"
+    "subtext": "1 phase identified"
   },
-  "message": "Analysis complete - ready for task generation",
+  "message": "Task breakdown complete. Ready to begin implementation.",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -28,7 +33,13 @@
       "id": "implement",
       "label": "Start Implementation",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
     }
   ],
-  "git_sha": "67a1642"
+  "git_sha": "67a1642",
+  "needs_attention": true
 }

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -21,14 +21,14 @@
       "path": "project-management/issues/CC-46/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-21T20:10:30.408808087Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-21T20:32:21.593171902Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 1: Tasks Ready",
-    "type": "success",
+    "text": "Phase 01: Awaiting Review",
+    "type": "warning",
     "subtext": "Option-C isolation knobs (domain + CLI + tests)"
   },
-  "message": "Phase 1 tasks ready",
+  "message": "Phase 01 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -51,6 +51,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "67a1642",
@@ -59,5 +64,16 @@
     "1": {
       "context_sha": "context_sha=144c711743dcb8741865050b7539a3553f385a23"
     }
-  }
+  },
+  "badges": [
+    {
+      "label": "In Progress",
+      "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
+    }
+  ],
+  "pr_url": "https://github.com/iterative-works/claude-code-query/pull/47"
 }

--- a/project-management/issues/CC-46/review-state.json
+++ b/project-management/issues/CC-46/review-state.json
@@ -11,17 +11,21 @@
       "label": "Tasks",
       "path": "project-management/issues/CC-46/tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Context",
+      "path": "project-management/issues/CC-46/phase-01-context.md"
     }
   ],
-  "last_updated": "2026-04-21T19:51:13.713174565Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-21T20:05:45.443507367Z",
+  "status": "context_ready",
   "display": {
-    "text": "Tasks Ready",
-    "type": "success",
-    "subtext": "1 phase identified"
+    "text": "Phase 1: Context Ready",
+    "type": "info",
+    "subtext": "Option-C isolation knobs (domain + CLI + tests)"
   },
-  "message": "Task breakdown complete. Ready to begin implementation.",
-  "activity": "waiting",
+  "message": "Phase 1 context ready for review",
+  "activity": "working",
   "workflow_type": "waterfall",
   "available_actions": [
     {
@@ -41,5 +45,10 @@
     }
   ],
   "git_sha": "67a1642",
-  "needs_attention": true
+  "needs_attention": true,
+  "phase_checkpoints": {
+    "1": {
+      "context_sha": "context_sha=144c711743dcb8741865050b7539a3553f385a23"
+    }
+  }
 }

--- a/project-management/issues/CC-46/tasks.md
+++ b/project-management/issues/CC-46/tasks.md
@@ -1,0 +1,23 @@
+# Implementation Tasks: Add Option-C tool-isolation knobs (strict MCP config, mcp-config path, setting sources, DontAsk permission mode)
+
+**Issue:** CC-46
+**Created:** 2026-04-21
+**Status:** 0/1 phases complete (0%)
+
+## Phase Index
+
+- [ ] Phase 1: Option-C isolation knobs (domain + CLI + tests) (Est: 2.75-4.5h) → `phase-01-context.md`
+
+## Progress Tracker
+
+**Completed:** 0/1 phases
+**Estimated Total:** 2.75-4.5 hours
+**Time Spent:** 0 hours
+
+## Notes
+
+- Phase context files generated just-in-time during implementation
+- Use wf-implement to start next phase automatically
+- Estimates are rough and will be refined during implementation
+- Phases follow layer dependency order (domain → infrastructure → application → presentation); a single phase may merge multiple layers when each alone is below the phase-size floor
+- CC-46 is a cohesive single-phase change: the three layers (domain model, CLI translation, tests) are mechanically coupled via Scala 3 enum exhaustiveness, and the low-end (2.75h) is below the 3h phase-size floor, so merging is mandatory per the sizing policy

--- a/project-management/issues/CC-46/tasks.md
+++ b/project-management/issues/CC-46/tasks.md
@@ -2,15 +2,15 @@
 
 **Issue:** CC-46
 **Created:** 2026-04-21
-**Status:** 0/1 phases complete (0%)
+**Status:** 1/1 phases complete (100%)
 
 ## Phase Index
 
-- [ ] Phase 1: Option-C isolation knobs (domain + CLI + tests) (Est: 2.75-4.5h) → `phase-01-context.md`
+- [x] Phase 1: Option-C isolation knobs (domain + CLI + tests) (Est: 2.75-4.5h) → `phase-01-context.md`
 
 ## Progress Tracker
 
-**Completed:** 0/1 phases
+**Completed:** 1/1 phases
 **Estimated Total:** 2.75-4.5 hours
 **Time Spent:** 0 hours
 


### PR DESCRIPTION
## Summary

Adds four CLI isolation knobs to the SDK so consumers (notably PROC-401) can spawn Claude Code subprocesses with a hard, non-inheritable tool allow-list:

- `QueryOptions.strictMcpConfig` / `SessionOptions.strictMcpConfig` → `--strict-mcp-config`
- `QueryOptions.mcpConfigPath` / `SessionOptions.mcpConfigPath` → `--mcp-config <path> --`
- `QueryOptions.settingSources` / `SessionOptions.settingSources` → `--setting-sources <csv>`
- `PermissionMode.DontAsk` → `--permission-mode dontAsk`

Each knob is purely additive: defaults preserve existing behaviour (no flag emitted). `direct` and `effectful` pick up the new fields automatically via `type`/`val` re-exports — no source edits required there.

Linked issue: #46

## Changes

- `core/.../model/PermissionMode.scala` — new `DontAsk` enum case with Scaladoc.
- `core/.../model/QueryOptions.scala` / `SessionOptions.scala` — three new fields, Scaladoc, fluent `with*` helpers.
- `core/.../cli/CLIArgumentBuilder.scala` — new branch + three translation blocks in both `buildArgs` and `buildSessionArgs`; argv order locked (`permissionMode → strictMcpConfig → mcpConfigPath → settingSources`).
- `core/test/.../cli/CLIArgumentBuilderTest.scala` & `SessionOptionsArgsTest.scala` — 19 new unit tests (presence, absence, `Some(false)` non-emission, CSV join, `--` terminator, deterministic ordering).

## Testing

- [x] `./mill __.test` — all tests pass (19 new unit tests for this feature)
- [x] `./mill core.compile` / `./mill direct.compile` / `./mill effectful.compile` — clean, no warnings
- [x] Phase 01 passed code review after 2 iterations (0 critical remaining)

## Review Artifacts

- Review packet: `project-management/issues/CC-46/review-packet.md`
- Implementation log: `project-management/issues/CC-46/implementation-log.md`
- Phase 01 code review: `project-management/issues/CC-46/review-phase-01-20260421-221853.md`

## Release Notes (CZ)

Viz `project-management/issues/CC-46/release-notes.md` — rozšiřuje SDK o čtyři volby pro plně izolovaný běh Claude Code s pevným allow-listem nástrojů. Výchozí chování se nemění; stávající volající nemusí nic upravovat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)